### PR TITLE
Lst and Set now IDivisible

### DIFF
--- a/LanguageExt.Core/Exceptions.cs
+++ b/LanguageExt.Core/Exceptions.cs
@@ -221,4 +221,36 @@ namespace LanguageExt
         {
         }
     }
+
+    public class NotAppendableException : Exception
+    {
+        public NotAppendableException(Type t)
+            :base ("Type '"+t.Name+"' not appendable: It's neither a CLR numeric-type, a string nor dervied from IAppendable")
+        {
+        }
+    }
+
+    public class NotSubtractableException : Exception
+    {
+        public NotSubtractableException(Type t)
+            : base("Type '" + t.Name + "' not subtractable: It's neither a CLR numeric-type, nor dervied from ISubtractable")
+        {
+        }
+    }
+
+    public class NotProductableException : Exception
+    {
+        public NotProductableException(Type t)
+            : base("Type '" + t.Name + "' not productable: It's neither a CLR numeric-type, nor dervied from IProductable")
+        {
+        }
+    }
+
+    public class NotDivisibleException : Exception
+    {
+        public NotDivisibleException(Type t)
+            : base("Type '" + t.Name + "' not divisible: It's neither a CLR numeric-type, nor dervied from IDivisible")
+        {
+        }
+    }
 }

--- a/LanguageExt.Core/Lst.cs
+++ b/LanguageExt.Core/Lst.cs
@@ -19,7 +19,8 @@ namespace LanguageExt
         IReadOnlyCollection<T>, 
         IAppendable<Lst<T>>, 
         ISubtractable<Lst<T>>,
-        IProductable<Lst<T>>
+        IProductable<Lst<T>>,
+        IDivisible<Lst<T>>
     {
         /// <summary>
         /// Empty list
@@ -342,6 +343,14 @@ namespace LanguageExt
             (from x in this.AsEnumerable()
              from y in rhs.AsEnumerable()
              select TypeDesc.Product(x, y, TypeDesc<T>.Default)).Freeze();
+
+        public static Lst<T> operator /(Lst<T> lhs, Lst<T> rhs) =>
+            lhs.Divide(rhs);
+
+        public Lst<T> Divide(Lst<T> rhs) =>
+            (from y in rhs.AsEnumerable()
+             from x in this.AsEnumerable()
+             select TypeDesc.Divide(x, y, TypeDesc<T>.Default)).Freeze();
     }
 
     [Serializable]

--- a/LanguageExt.Core/SetT.cs
+++ b/LanguageExt.Core/SetT.cs
@@ -22,6 +22,7 @@ namespace LanguageExt
         IAppendable<Set<T>>,
         ISubtractable<Set<T>>,
         IProductable<Set<T>>,
+        IDivisible<Set<T>>,
         IEquatable<Set<T>>
     {
         public static readonly Set<T> Empty = new Set<T>();
@@ -396,6 +397,14 @@ namespace LanguageExt
 
         public bool Equals(Set<T> other) =>
             SetEquals(other);
+
+        public static Set<T> operator /(Set<T> lhs, Set<T> rhs) =>
+            lhs.Divide(rhs);
+
+        public Set<T> Divide(Set<T> rhs) =>
+            new Set<T>((from y in rhs.AsEnumerable()
+                        from x in this.AsEnumerable()
+                        select TypeDesc.Divide(x, y, TypeDesc<T>.Default)).Distinct());
     }
 
     internal class SetItem<K>

--- a/LanguageExt.Core/TypeDesc.cs
+++ b/LanguageExt.Core/TypeDesc.cs
@@ -98,7 +98,7 @@ namespace LanguageExt
             {
                 return (lhs as IAppendable<T>).Append(rhs);
             }
-            return lhs;
+            throw new NotAppendableException(typeof(T));
         }
 
         public static T Subtract<T>(T lhs, T rhs, TypeDesc desc)
@@ -111,7 +111,7 @@ namespace LanguageExt
             {
                 return (lhs as ISubtractable<T>).Subtract(rhs);
             }
-            return lhs;
+            throw new NotSubtractableException(typeof(T));
         }
 
         public static T Product<T>(T lhs, T rhs, TypeDesc desc)
@@ -124,7 +124,7 @@ namespace LanguageExt
             {
                 return (lhs as IProductable<T>).Product(rhs);
             }
-            return lhs;
+            throw new NotProductableException(typeof(T));
         }
 
         public static T Divide<T>(T lhs, T rhs, TypeDesc desc)
@@ -137,7 +137,7 @@ namespace LanguageExt
             {
                 return (lhs as IDivisible<T>).Divide(rhs);
             }
-            return lhs;
+            throw new NotDivisibleException(typeof(T));
         }
 
         private static object AppendNumeric(object lhs, object rhs, TypeDesc desc)

--- a/LanguageExt.Tests/Divisible.cs
+++ b/LanguageExt.Tests/Divisible.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using static LanguageExt.Prelude;
+using LanguageExt;
+
+namespace LanguageExtTests
+{
+    public class Divisible
+    {
+        [Fact]
+        public void OptionalNumericDivide()
+        {
+            var x = Some(20);
+            var y = Some(10);
+            var z = x / y;
+
+            Assert.True(z == 2);
+        }
+
+        [Fact]
+        public void OptionalListDivide()
+        {
+            var x = Some(List(15, 30, 60));
+            var y = Some(List(3, 5));
+            var z = x / y;
+
+            match(z,
+                Some: list =>
+                {
+                    Assert.True(list.Count == 6);
+                    Assert.True(list[0] == 5);
+                    Assert.True(list[1] == 10);
+                    Assert.True(list[2] == 20);
+                    Assert.True(list[3] == 3);
+                    Assert.True(list[4] == 6);
+                    Assert.True(list[5] == 12);
+                },
+                None: () => Assert.True(false)
+            );
+        }
+
+        [Fact]
+        public void OptionalSetDivide()
+        {
+            var x = Some(Set(15, 30, 60));
+            var y = Some(Set(3, 5));
+            var z = x / y;
+
+            match(z,
+                Some: set =>
+                {
+                    Assert.True(set.Count == 6);
+                    Assert.True(set.Contains(5));
+                    Assert.True(set.Contains(10));
+                    Assert.True(set.Contains(20));
+                    Assert.True(set.Contains(3));
+                    Assert.True(set.Contains(6));
+                    Assert.True(set.Contains(12));
+                },
+                None: () => Assert.True(false)
+            );
+        }
+    }
+}

--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -90,6 +90,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Divisible.cs" />
     <Compile Include="Productable.cs" />
     <Compile Include="Subtractable.cs" />
     <Compile Include="Appendable.cs" />


### PR DESCRIPTION
Added exceptions for runtime append/divide/subtract/product calls that can't be honoured.