### PR TITLE
Made OptionNone.Default readonly

### DIFF
--- a/LanguageExt.Core/Option.cs
+++ b/LanguageExt.Core/Option.cs
@@ -582,7 +582,7 @@ namespace LanguageExt
 
     public struct OptionNone
     {
-        public static OptionNone Default = new OptionNone();
+        public static readonly OptionNone Default = new OptionNone();
     }
 }
 


### PR DESCRIPTION
Is there a reason why it is not readonly?