### PR TITLE
Fixed Option<T>.IfNoneUnsafe samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ So you can use `matchUnsafe` and `ifNoneUnsafe`:
                             Some: v => v,
                             None: () => null );
 
-    string x = ifNoneUnsafe( optional, null );
+    string x = ifNoneUnsafe( optional, (string)null );
     string x = ifNoneUnsafe( optional, () => GetNull() );
 ```
 And fluent versions:
@@ -322,7 +322,7 @@ And fluent versions:
                    Some: v => v,
                    None: () => null 
                    );
-    string x = optional.IfNoneUnsafe(null);
+    string x = optional.IfNoneUnsafe((string)null);
     string x = optional.IfNoneUnsafe(() => GetNull());
 ```
 That is consistent throughout the library.  Anything that could return `null` has the `Unsafe` suffix.  That means that in those unavoidable circumstances where you need a `null`, it gives you and any other programmers working with your code the clearest possible sign that they should treat the result with care.


### PR DESCRIPTION
These lines won't compile:
```C#
    string x = ifNoneUnsafe( optional, null );
    string x = optional.IfNoneUnsafe(null);
```

> The call is ambiguous between the following methods or properties: 'LanguageExt.Option<string>.IfNoneUnsafe(System.Func<string>)' and 'LanguageExt.Option<string>.IfNoneUnsafe(string)'

Ofc it should specify a cast (just like in the examples a bit above).