### PR TITLE
Documentation fixes for List/IEnumerable ForAll methods

### DIFF
--- a/LanguageExt.Core/List.cs
+++ b/LanguageExt.Core/List.cs
@@ -746,7 +746,7 @@ namespace LanguageExt
         }
 
         /// <summary>
-        /// Returns true if all items in the enumerable match a predicate (Any in LINQ)
+        /// Returns true if all items in the enumerable match a predicate (All in LINQ)
         /// </summary>
         /// <typeparam name="T">Enumerable item type</typeparam>
         /// <param name="list">Enumerable to test</param>
@@ -1792,7 +1792,7 @@ namespace LanguageExt
             LanguageExt.List.iter(list, action);
 
         /// <summary>
-        /// Returns true if all items in the enumerable match a predicate (Any in LINQ)
+        /// Returns true if all items in the enumerable match a predicate (All in LINQ)
         /// </summary>
         /// <typeparam name="T">Enumerable item type</typeparam>
         /// <param name="list">Enumerable to test</param>


### PR DESCRIPTION
The docs incorrectly mentions "Any in LINQ" for ForAll methods