### PR TITLE
JsonSerializerSettings for Deserialize

### DIFF
--- a/LanguageExt.Process/ActorSys/Deserialise.cs
+++ b/LanguageExt.Process/ActorSys/Deserialise.cs
@@ -25,7 +25,8 @@ namespace LanguageExt
             var func = typeof(JsonConvert).GetTypeInfo()
                                    .GetDeclaredMethods("DeserializeObject")
                                    .Filter(m => m.IsGenericMethod)
-                                   .Filter(m => m.GetParameters().Length == 1)
+                                   .Filter(m => m.GetParameters().Length == 2)
+                                   .Filter(m => m.GetParameters().ElementAt(1).ParameterType.Equals(typeof(JsonSerializerSettings)))
                                    .Head()
                                    .MakeGenericMethod(type);
 
@@ -36,6 +37,6 @@ namespace LanguageExt
         }
 
         public static object Object(string value, Type type) =>
-            DeserialiseFunc(type).Invoke(null, new[] { value });
+            DeserialiseFunc(type).Invoke(null, new object[] { value, ActorSystemConfig.Default.JsonSerializerSettings });
     }
 }

--- a/LanguageExt.Process/ActorSys/Deserialise.cs
+++ b/LanguageExt.Process/ActorSys/Deserialise.cs
@@ -3,6 +3,7 @@ using System;
 using System.Reflection;
 using LanguageExt.Trans;
 using static LanguageExt.Prelude;
+using System.Linq;
 
 namespace LanguageExt
 {


### PR DESCRIPTION
This change makes the deserialization use the ActorSystemConfig.Default.JsonSerializerSettings.  Those settings are used when serializing already.  See issue #142 for more info.