### PR TITLE
Bug fix for Lst<T>::operator !=

### DIFF
--- a/LanguageExt.Core/Lst.cs
+++ b/LanguageExt.Core/Lst.cs
@@ -449,15 +449,12 @@ namespace LanguageExt
 
         [Pure]
         public static bool operator ==(Lst<T> lhs, Lst<T> rhs) =>
-              ReferenceEquals(lhs, null)  && ReferenceEquals(rhs, null) ? true
-            : ReferenceEquals(lhs, null) || ReferenceEquals(rhs, null)  ? false
-            : lhs.Equals(rhs);
+              ReferenceEquals(lhs, null)  && ReferenceEquals(rhs, null) || 
+              !ReferenceEquals(lhs, null) && !ReferenceEquals(rhs, null) && lhs.Equals(rhs);
 
         [Pure]
         public static bool operator !=(Lst<T> lhs, Lst<T> rhs) =>
-              ReferenceEquals(lhs, null) && ReferenceEquals(rhs, null) ? true
-            : ReferenceEquals(lhs, null) || ReferenceEquals(rhs, null) ? false
-            : !lhs.Equals(rhs);
+              !(lhs == rhs);
     }
 
 #if !COREFX

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -249,18 +249,16 @@ namespace LanguageExtTests
                 Tuple(List(1, 2, 3), (Lst<int>)null)
             );
 
-            goodOnes.Iter(t => t.Map((fst, snd) =>
+            goodOnes.Iter(t => t.Iter((fst, snd) =>
             {
                 Assert.True(fst == snd, $"'{fst}' == '{snd}'");
                 Assert.False(fst != snd, $"'{fst}' != '{snd}'");
-                return Unit.Default;
             }));
 
-            badOnes.Iter(t => t.Map((fst, snd) =>
+            badOnes.Iter(t => t.Iter((fst, snd) =>
             {
                 Assert.True(fst != snd, $"'{fst}' != '{snd}'");
                 Assert.False(fst == snd, $"'{fst}' == '{snd}'");
-                return Unit.Default;
             }));
         }
     }

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -234,5 +234,34 @@ namespace LanguageExtTests
             Assert.True(rev.LastIndexOf(1) == 4, "Should have been 4, actually is: " + rev.LastIndexOf(1));
             Assert.True(rev.LastIndexOf(2) == 2, "Should have been 2, actually is: " + rev.LastIndexOf(5));
         }
+
+        [Fact]
+        public void OpEqualTest()
+        {
+            var goodOnes = List(
+                Tuple(List(1, 2, 3), List(1, 2, 3)),
+                Tuple(Lst<int>.Empty, Lst<int>.Empty),
+                Tuple((Lst<int>)null, (Lst<int>)null)
+            );
+            var badOnes = List(
+                Tuple(List(1, 2, 3), List(1, 2, 4)),
+                Tuple(List(1, 2, 3), Lst<int>.Empty),
+                Tuple(List(1, 2, 3), (Lst<int>)null)
+            );
+
+            goodOnes.Iter(t => t.Map((fst, snd) =>
+            {
+                Assert.True(fst == snd, $"'{fst}' == '{snd}'");
+                Assert.False(fst != snd, $"'{fst}' != '{snd}'");
+                return Unit.Default;
+            }));
+
+            badOnes.Iter(t => t.Map((fst, snd) =>
+            {
+                Assert.True(fst != snd, $"'{fst}' != '{snd}'");
+                Assert.False(fst == snd, $"'{fst}' == '{snd}'");
+                return Unit.Default;
+            }));
+        }
     }
 }


### PR DESCRIPTION
Small fix for the case of nulls. 

The invariant 

> (lst1 == lst2) always gives opposite of (lst1 != lst2)

was not true, not it is true