### PR TITLE
Generic Union type with match.  

### DIFF
--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Prelude_Nullable.cs" />
     <Compile Include="DVV.cs" />
     <Compile Include="Prelude_Tasks.cs" />
+    <Compile Include="Prelude_Union.cs" />
     <Compile Include="Task.cs" />
     <Compile Include="Compose.cs" />
     <Compile Include="EitherState.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="TupleExt.cs" />
     <Compile Include="TypeConverters.cs" />
     <Compile Include="TypeDesc.cs" />
+    <Compile Include="Union.cs" />
     <Compile Include="Unit.cs" />
     <Compile Include="UnitsOfMeasure\Accel.cs" />
     <Compile Include="UnitsOfMeasure\TimeSq.cs" />

--- a/LanguageExt.Core/Prelude_Union.cs
+++ b/LanguageExt.Core/Prelude_Union.cs
@@ -4,24 +4,34 @@
 
 	public static partial class Prelude
 	{
-		public static IUnion<B> Bind<A, B>(this IUnion<A> a, Func<A, IUnion<B>> func) =>
-			a.Optional()
-				.Match(
-					(aVal) => func(aVal),
-					() => new Union<B>());
+		public static Union<T1> Bind<A, T1>(this A a, Func<A, Union<T1>> func) => func(a);
 
-		public static Option<B> Select<A, B>(this IUnion<A> a, Func<A, B> select) =>
-			a.Bind(aval => new Union<B>(select(aval))).opt;
+		public static Union<T1, T2> Bind<A, T1, T2>(this A a, Func<A, Union<T1, T2>> func) => func(a);
 
-		public static IUnion<TSource> Where<TSource>(this IUnion<TSource> source, Func<TSource, bool> predicate) =>
-			source.Optional().Match(
-					(s) => predicate(s) ? source : new Union<TSource>(),
-					() => new Union<TSource>());
+		public static Union<T1, T2, T3> Bind<A, T1, T2, T3>(this A a, Func<A, Union<T1, T2, T3>> func) => func(a);
 
-		public static Option<T> Optional<T>(this IUnion<T> source) =>
-			source == null
-				? new Option<T>()
-				: source.opt;
+		public static Union<T1, T2, T3, T4> Bind<A, T1, T2, T3, T4>(this A a, Func<A, Union<T1, T2, T3, T4>> func) => func(a);
+
+		public static Union<T1, T2, T3, T4, T5> Bind<A, T1, T2, T3, T4, T5>(this A a, Func<A, Union<T1, T2, T3, T4, T5>> func) => func(a);
+
+		public static Union<T1, T2, T3, T4, T5, T6> Bind<A, T1, T2, T3, T4, T5, T6>(this A a, Func<A, Union<T1, T2, T3, T4, T5, T6>> func) => func(a);
+
+		public static Union<T1, T2, T3, T4, T5, T6, T7> Bind<A, T1, T2, T3, T4, T5, T6, T7>(this A a, Func<A, Union<T1, T2, T3, T4, T5, T6, T7>> func) => func(a);
+
+		public static Union<T1, T2, T3, T4, T5, T6, T7, T8> Bind<A, T1, T2, T3, T4, T5, T6, T7, T8>(this A a, Func<A, Union<T1, T2, T3, T4, T5, T6, T7, T8>> func) => func(a);
+
+		public static Union<B> Select<A, B>(this Union<A> source, Func<Union<A>, B> predicate) =>
+			source.Bind(aval => new Union<B>(predicate(aval)));
+
+		//public static IUnion<TSource> Where<TSource>(this IUnion<TSource> source, Func<TSource, bool> predicate) =>
+		//	source.Match(
+		//			(s) => predicate(s) ? source : new Union<TSource>(),
+		//			() => new Union<TSource>());
+
+		//public static Option<T> Optional<T>(this Union source) =>
+		//	source == null
+		//		? new Option<T>()
+		//		: source.opt;
 
 		public static TReturn Match<T1, TReturn>(this Union<T1> union, Func<T1, TReturn> f1)
 		{
@@ -255,70 +265,67 @@
 			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
 		}
 
-		public static R Match<T, R>(this IUnion<T> union, Func<T, R> Some, Func<R> None) =>
-			 union.Optional().Match(Some, None);
-
 		public static Tuple<Option<T1>> ToTuple<T1>(this Union<T1> union) =>
-			System.Tuple.Create(((IUnion<T1>)union).Optional());
+			((IUnion<T1>)union).InternalValue() ?? System.Tuple.Create(Option<T1>.None);
 
 		public static Tuple<Option<T1>, Option<T2>> ToTuple<T1, T2>(this Union<T1, T2> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional());
+			((IUnion<T1, T2>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>> ToTuple<T1, T2, T3>(this Union<T1, T2, T3> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional());
+			((IUnion<T1, T2, T3>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>> ToTuple<T1, T2, T3, T4>(this Union<T1, T2, T3, T4> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional(),
-				((IUnion<T4>)union).Optional());
+			((IUnion<T1, T2, T3, T4>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None,
+				Option<T4>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>> ToTuple<T1, T2, T3, T4, T5>(this Union<T1, T2, T3, T4, T5> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional(),
-				((IUnion<T4>)union).Optional(),
-				((IUnion<T5>)union).Optional());
+			((IUnion<T1, T2, T3, T4, T5>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None,
+				Option<T4>.None,
+				Option<T5>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>
 			ToTuple<T1, T2, T3, T4, T5, T6>(this Union<T1, T2, T3, T4, T5, T6> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional(),
-				((IUnion<T4>)union).Optional(),
-				((IUnion<T5>)union).Optional(),
-				((IUnion<T6>)union).Optional());
+			((IUnion<T1, T2, T3, T4, T5, T6>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None,
+				Option<T4>.None,
+				Option<T5>.None,
+				Option<T6>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>
 			ToTuple<T1, T2, T3, T4, T5, T6, T7>(this Union<T1, T2, T3, T4, T5, T6, T7> union) =>
-			Tuple(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional(),
-				((IUnion<T4>)union).Optional(),
-				((IUnion<T5>)union).Optional(),
-				((IUnion<T6>)union).Optional(),
-				((IUnion<T7>)union).Optional());
+			((IUnion<T1, T2, T3, T4, T5, T6, T7>)union).InternalValue() ?? Tuple(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None,
+				Option<T4>.None,
+				Option<T5>.None,
+				Option<T6>.None,
+				Option<T7>.None);
 
 		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Tuple<Option<T8>>>
 			ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this Union<T1, T2, T3, T4, T5, T6, T7, T8> union) =>
-			  System.Tuple.Create(
-				((IUnion<T1>)union).Optional(),
-				((IUnion<T2>)union).Optional(),
-				((IUnion<T3>)union).Optional(),
-				((IUnion<T4>)union).Optional(),
-				((IUnion<T5>)union).Optional(),
-				((IUnion<T6>)union).Optional(),
-				((IUnion<T7>)union).Optional(),
-				((IUnion<T8>)union).Optional());
+			  ((IUnion<T1, T2, T3, T4, T5, T6, T7, T8>)union).InternalValue() ?? System.Tuple.Create(
+				Option<T1>.None,
+				Option<T2>.None,
+				Option<T3>.None,
+				Option<T4>.None,
+				Option<T5>.None,
+				Option<T6>.None,
+				Option<T7>.None,
+				Option<T8>.None);
 
 		public static Union<T, Err> ToErrorUnion<T, Err>(this Func<T> factory)
 			where Err : SystemException

--- a/LanguageExt.Core/Prelude_Union.cs
+++ b/LanguageExt.Core/Prelude_Union.cs
@@ -1,0 +1,366 @@
+﻿namespace LanguageExt
+{
+	using System;
+
+	public static partial class Prelude
+	{
+		public static IUnion<B> Bind<A, B>(this IUnion<A> a, Func<A, IUnion<B>> func) =>
+			a.Optional()
+				.Match(
+					(aVal) => func(aVal),
+					() => new Union<B>());
+
+		public static Option<B> Select<A, B>(this IUnion<A> a, Func<A, B> select) =>
+			a.Bind(aval => new Union<B>(select(aval))).opt;
+
+		public static IUnion<TSource> Where<TSource>(this IUnion<TSource> source, Func<TSource, bool> predicate) =>
+			source.Optional().Match(
+					(s) => predicate(s) ? source : new Union<TSource>(),
+					() => new Union<TSource>());
+
+		public static Option<T> Optional<T>(this IUnion<T> source) =>
+			source == null
+				? new Option<T>()
+				: source.opt;
+
+		public static TReturn Match<T1, TReturn>(this Union<T1> union, Func<T1, TReturn> f1)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, TReturn>(this Union<T1, T2> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, TReturn>(this Union<T1, T2, T3> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, T4, TReturn>(this Union<T1, T2, T3, T4> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3, Func<T4, TReturn> f4)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+			unionTuple.Item4.IfSome(tm => retVal = f4(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, T4, T5, TReturn>(this Union<T1, T2, T3, T4, T5> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3, Func<T4, TReturn> f4, Func<T5, TReturn> f5)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+			unionTuple.Item4.IfSome(tm => retVal = f4(tm));
+			unionTuple.Item5.IfSome(tm => retVal = f5(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, T4, T5, T6, TReturn>(this Union<T1, T2, T3, T4, T5, T6> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3, Func<T4, TReturn> f4, Func<T5, TReturn> f5, Func<T6, TReturn> f6)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+			unionTuple.Item4.IfSome(tm => retVal = f4(tm));
+			unionTuple.Item5.IfSome(tm => retVal = f5(tm));
+			unionTuple.Item6.IfSome(tm => retVal = f6(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, T4, T5, T6, T7, TReturn>(this Union<T1, T2, T3, T4, T5, T6, T7> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3, Func<T4, TReturn> f4, Func<T5, TReturn> f5, Func<T6, TReturn> f6, Func<T7, TReturn> f7)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+			unionTuple.Item4.IfSome(tm => retVal = f4(tm));
+			unionTuple.Item5.IfSome(tm => retVal = f5(tm));
+			unionTuple.Item6.IfSome(tm => retVal = f6(tm));
+			unionTuple.Item7.IfSome(tm => retVal = f7(tm));
+
+			return retVal;
+		}
+
+		public static TReturn Match<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(this Union<T1, T2, T3, T4, T5, T6, T7, T8> union, Func<T1, TReturn> f1, Func<T2, TReturn> f2, Func<T3, TReturn> f3, Func<T4, TReturn> f4, Func<T5, TReturn> f5, Func<T6, TReturn> f6, Func<T7, TReturn> f7, Func<T8, TReturn> f8)
+		{
+			var unionTuple = union.ToTuple();
+			TReturn retVal = default(TReturn);
+
+			unionTuple.Item1.IfSome(tm => retVal = f1(tm));
+			unionTuple.Item2.IfSome(tm => retVal = f2(tm));
+			unionTuple.Item3.IfSome(tm => retVal = f3(tm));
+			unionTuple.Item4.IfSome(tm => retVal = f4(tm));
+			unionTuple.Item5.IfSome(tm => retVal = f5(tm));
+			unionTuple.Item6.IfSome(tm => retVal = f6(tm));
+			unionTuple.Item7.IfSome(tm => retVal = f7(tm));
+			unionTuple.Rest.Item1.IfSome(tm => retVal = f8(tm));
+
+			return retVal;
+		}
+
+		public static Func<Func<T1, TReturn>, TReturn> Match<T1, TReturn>(this Union<T1> union)
+		{
+			var curried = curry((Func<Union<T1>, Func<T1, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, TReturn>> Match<T1, T2, TReturn>(this Union<T1, T2> union)
+		{
+			var curried = curry((Func<Union<T1, T2>, Func<T1, TReturn>, Func<T2, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, TReturn>>> Match<T1, T2, T3, TReturn>(this Union<T1, T2, T3> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, Func<Func<T4, TReturn>, TReturn>>>> Match<T1, T2, T3, T4, TReturn>(this Union<T1, T2, T3, T4> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3, T4>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, Func<T4, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, Func<Func<T4, TReturn>, Func<Func<T5, TReturn>, TReturn>>>>> Match<T1, T2, T3, T4, T5, TReturn>(this Union<T1, T2, T3, T4, T5> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3, T4, T5>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, Func<T4, TReturn>, Func<T5, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, Func<Func<T4, TReturn>, Func<Func<T5, TReturn>, Func<Func<T6, TReturn>, TReturn>>>>>> Match<T1, T2, T3, T4, T5, T6, TReturn>(this Union<T1, T2, T3, T4, T5, T6> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3, T4, T5, T6>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, Func<T4, TReturn>, Func<T5, TReturn>, Func<T6, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, Func<Func<T4, TReturn>, Func<Func<T5, TReturn>, Func<Func<T6, TReturn>, Func<Func<T7, TReturn>, TReturn>>>>>>> Match<T1, T2, T3, T4, T5, T6, T7, TReturn>(this Union<T1, T2, T3, T4, T5, T6, T7> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3, T4, T5, T6, T7>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, Func<T4, TReturn>, Func<T5, TReturn>, Func<T6, TReturn>, Func<T7, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Func<Func<T1, TReturn>, Func<Func<T2, TReturn>, Func<Func<T3, TReturn>, Func<Func<T4, TReturn>, Func<Func<T5, TReturn>, Func<Func<T6, TReturn>, Func<Func<T7, TReturn>, Func<Func<T8, TReturn>, TReturn>>>>>>>> Match<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(this Union<T1, T2, T3, T4, T5, T6, T7, T8> union)
+		{
+			var curried = curry((Func<Union<T1, T2, T3, T4, T5, T6, T7, T8>, Func<T1, TReturn>, Func<T2, TReturn>, Func<T3, TReturn>, Func<T4, TReturn>, Func<T5, TReturn>, Func<T6, TReturn>, Func<T7, TReturn>, Func<T8, TReturn>, TReturn>)Match);
+			return curried(union);
+		}
+
+		public static Action<Action<T1>> Match<T1>(this Union<T1> union)
+		{
+			var unionTuple = union.ToTuple();
+			return act((Action<T1> a) => unionTuple.Item1.IfSome(a));
+		}
+
+		public static Func<Action<T1>, Action<Action<T2>>> Match<T1, T2>(this Union<T1, T2> union)
+		{
+			var unionTuple = union.ToTuple();
+			var bAct = act((Action<T2> b) => unionTuple.Item2.IfSome(b));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Action<Action<T3>>>> Match<T1, T2, T3>(this Union<T1, T2, T3> union)
+		{
+			var unionTuple = union.ToTuple();
+			var cAct = act((Action<T3> c) => unionTuple.Item3.IfSome(c));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Func<Action<T3>, Action<Action<T4>>>>> Match<T1, T2, T3, T4>(this Union<T1, T2, T3, T4> union)
+		{
+			var unionTuple = union.ToTuple();
+			var dAct = act((Action<T4> d) => unionTuple.Item4.IfSome(d));
+			var cAct = fun((Action<T3> c) => unionTuple.Item3.IfSome(c).Return(dAct));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Func<Action<T3>, Func<Action<T4>, Action<Action<T5>>>>>> Match<T1, T2, T3, T4, T5>(this Union<T1, T2, T3, T4, T5> union)
+		{
+			var unionTuple = union.ToTuple();
+			var eAct = act((Action<T5> e) => unionTuple.Item5.IfSome(e));
+			var dAct = fun((Action<T4> d) => unionTuple.Item4.IfSome(d).Return(eAct));
+			var cAct = fun((Action<T3> c) => unionTuple.Item3.IfSome(c).Return(dAct));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Func<Action<T3>, Func<Action<T4>, Func<Action<T5>, Action<Action<T6>>>>>>> Match<T1, T2, T3, T4, T5, T6>(this Union<T1, T2, T3, T4, T5, T6> union)
+		{
+			var unionTuple = union.ToTuple();
+			var fAct = act((Action<T6> f) => unionTuple.Item6.IfSome(f));
+			var eAct = fun((Action<T5> e) => unionTuple.Item5.IfSome(e).Return(fAct));
+			var dAct = fun((Action<T4> d) => unionTuple.Item4.IfSome(d).Return(eAct));
+			var cAct = fun((Action<T3> c) => unionTuple.Item3.IfSome(c).Return(dAct));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Func<Action<T3>, Func<Action<T4>, Func<Action<T5>, Func<Action<T6>, Action<Action<T7>>>>>>>> Match<T1, T2, T3, T4, T5, T6, T7>(this Union<T1, T2, T3, T4, T5, T6, T7> union)
+		{
+			var unionTuple = union.ToTuple();
+			var gAct = act((Action<T7> g) => unionTuple.Item7.IfSome(g));
+			var fAct = fun((Action<T6> f) => unionTuple.Item6.IfSome(f).Return(gAct));
+			var eAct = fun((Action<T5> e) => unionTuple.Item5.IfSome(e).Return(fAct));
+			var dAct = fun((Action<T4> d) => unionTuple.Item4.IfSome(d).Return(eAct));
+			var cAct = fun((Action<T3> c) => unionTuple.Item3.IfSome(c).Return(dAct));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static Func<Action<T1>, Func<Action<T2>, Func<Action<T3>, Func<Action<T4>, Func<Action<T5>, Func<Action<T6>, Func<Action<T7>, Action<Action<T8>>>>>>>>> Match<T1, T2, T3, T4, T5, T6, T7, T8>(this Union<T1, T2, T3, T4, T5, T6, T7, T8> union)
+		{
+			var unionTuple = union.ToTuple();
+			var hAct = act((Action<T8> h) => unionTuple.Rest.Item1.IfSome(h));
+			var gAct = fun((Action<T7> g) => unionTuple.Item7.IfSome(g).Return(hAct));
+			var fAct = fun((Action<T6> f) => unionTuple.Item6.IfSome(f).Return(gAct));
+			var eAct = fun((Action<T5> e) => unionTuple.Item5.IfSome(e).Return(fAct));
+			var dAct = fun((Action<T4> d) => unionTuple.Item4.IfSome(d).Return(eAct));
+			var cAct = fun((Action<T3> c) => unionTuple.Item3.IfSome(c).Return(dAct));
+			var bAct = fun((Action<T2> b) => unionTuple.Item2.IfSome(b).Return(cAct));
+			return fun((Action<T1> a) => unionTuple.Item1.IfSome(a).Return(bAct));
+		}
+
+		public static R Match<T, R>(this IUnion<T> union, Func<T, R> Some, Func<R> None) =>
+			 union.Optional().Match(Some, None);
+
+		public static Tuple<Option<T1>> ToTuple<T1>(this Union<T1> union) =>
+			System.Tuple.Create(((IUnion<T1>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>> ToTuple<T1, T2>(this Union<T1, T2> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>> ToTuple<T1, T2, T3>(this Union<T1, T2, T3> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>> ToTuple<T1, T2, T3, T4>(this Union<T1, T2, T3, T4> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional(),
+				((IUnion<T4>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>> ToTuple<T1, T2, T3, T4, T5>(this Union<T1, T2, T3, T4, T5> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional(),
+				((IUnion<T4>)union).Optional(),
+				((IUnion<T5>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>
+			ToTuple<T1, T2, T3, T4, T5, T6>(this Union<T1, T2, T3, T4, T5, T6> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional(),
+				((IUnion<T4>)union).Optional(),
+				((IUnion<T5>)union).Optional(),
+				((IUnion<T6>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>
+			ToTuple<T1, T2, T3, T4, T5, T6, T7>(this Union<T1, T2, T3, T4, T5, T6, T7> union) =>
+			Tuple(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional(),
+				((IUnion<T4>)union).Optional(),
+				((IUnion<T5>)union).Optional(),
+				((IUnion<T6>)union).Optional(),
+				((IUnion<T7>)union).Optional());
+
+		public static Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Tuple<Option<T8>>>
+			ToTuple<T1, T2, T3, T4, T5, T6, T7, T8>(this Union<T1, T2, T3, T4, T5, T6, T7, T8> union) =>
+			  System.Tuple.Create(
+				((IUnion<T1>)union).Optional(),
+				((IUnion<T2>)union).Optional(),
+				((IUnion<T3>)union).Optional(),
+				((IUnion<T4>)union).Optional(),
+				((IUnion<T5>)union).Optional(),
+				((IUnion<T6>)union).Optional(),
+				((IUnion<T7>)union).Optional(),
+				((IUnion<T8>)union).Optional());
+
+		public static Union<T, Err> ToErrorUnion<T, Err>(this Func<T> factory)
+			where Err : SystemException
+		{
+			try
+			{
+				return new Union<T, Err>(factory());
+			}
+			catch (Err ex)
+			{
+				return new Union<T, Err>(ex);
+			}
+		}
+
+		public static Union<T, Err1, Err2> ToErrorUnion<T, Err1, Err2>(this Func<T> factory)
+		where Err1 : SystemException
+		where Err2 : SystemException
+		{
+			try
+			{
+				return new Union<T, Err1, Err2>(factory());
+			}
+			catch (Err1 ex)
+			{
+				return new Union<T, Err1, Err2>(ex);
+			}
+			catch (Err2 ex)
+			{
+				return new Union<T, Err1, Err2>(ex);
+			}
+		}
+
+		public static Union<T, SystemException> ToErrorUnion<T>(this Func<T> factory)
+		{
+			try
+			{
+				return new Union<T, SystemException>(factory());
+			}
+			catch (SystemException ex)
+			{
+				return new Union<T, SystemException>(ex);
+			}
+		}
+	}
+}

--- a/LanguageExt.Core/Union.cs
+++ b/LanguageExt.Core/Union.cs
@@ -1,30 +1,64 @@
 ﻿using System;
+using static LanguageExt.Prelude;
 
 namespace LanguageExt
 {
-	public interface IUnion { }
-
-	public interface IUnion<T>
+	public interface IUnion
 	{
-		Option<T> opt { get; }
+	}
+
+	public interface IUnion<T1>
+	{
+		Tuple<Option<T1>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3, T4> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3, T4, T5> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3, T4, T5, T6> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3, T4, T5, T6, T7> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>> InternalValue();
+	}
+
+	public interface IUnion<T1, T2, T3, T4, T5, T6, T7, T8> : IUnion
+	{
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Tuple<Option<T8>>> InternalValue();
 	}
 
 	public class Union<T1> : IUnion, IUnion<T1>
 	{
-		private readonly Option<T1> internalValue;
-
-		public Union()
-		{
-		}
+		private readonly Tuple<Option<T1>> internalValue;
 
 		public Union(T1 value)
 		{
-			this.internalValue = value;
+			this.internalValue = System.Tuple.Create(Some(value));
 		}
 
-		Option<T1> IUnion<T1>.opt
+		Tuple<Option<T1>> IUnion<T1>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None);
 		}
 
 		public static implicit operator Union<T1>(T1 item)
@@ -33,25 +67,23 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2> : Union<T1>, IUnion, IUnion<T2>
+	public class Union<T1, T2> : IUnion, IUnion<T1, T2>
 	{
-		private readonly Option<T2> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 a) : base(a)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>>(value, Option<T2>.None);
 		}
 
 		public Union(T2 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>>(Option<T1>.None, value);
 		}
 
-		Option<T2> IUnion<T2>.opt
+		Tuple<Option<T1>, Option<T2>> IUnion<T1, T2>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None);
 		}
 
 		public static implicit operator Union<T1, T2>(T1 item)
@@ -65,29 +97,28 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3> : Union<T1, T2>, IUnion, IUnion<T3>
+	public class Union<T1, T2, T3> : IUnion, IUnion<T1, T2, T3>
 	{
-		private readonly Option<T3> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>>(value, Option<T2>.None, Option<T3>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>>(Option<T1>.None, value, Option<T3>.None);
 		}
 
 		public Union(T3 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>>(Option<T1>.None, Option<T2>.None, value);
 		}
 
-		Option<T3> IUnion<T3>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>> IUnion<T1, T2, T3>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3>(T1 item)
@@ -106,33 +137,33 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3, T4> : Union<T1, T2, T3>, IUnion, IUnion<T4>
+	public class Union<T1, T2, T3, T4> : IUnion, IUnion<T1, T2, T3, T4>
 	{
-		private readonly Option<T4> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>>(value, Option<T2>.None, Option<T3>.None, Option<T4>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>>(Option<T1>.None, value, Option<T3>.None, Option<T4>.None);
 		}
 
-		public Union(T3 value) : base(value)
+		public Union(T3 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>>(Option<T1>.None, Option<T2>.None, value, Option<T4>.None);
 		}
 
 		public Union(T4 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, value);
 		}
 
-		Option<T4> IUnion<T4>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>> IUnion<T1, T2, T3, T4>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3, T4>(T1 item)
@@ -156,37 +187,38 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3, T4, T5> : Union<T1, T2, T3, T4>, IUnion, IUnion<T5>
+	public class Union<T1, T2, T3, T4, T5> : IUnion, IUnion<T1, T2, T3, T4, T5>
 	{
-		private readonly Option<T5> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>>(value, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>>(Option<T1>.None, value, Option<T3>.None, Option<T4>.None, Option<T5>.None);
 		}
 
-		public Union(T3 value) : base(value)
+		public Union(T3 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>>(Option<T1>.None, Option<T2>.None, value, Option<T4>.None, Option<T5>.None);
 		}
 
-		public Union(T4 value) : base(value)
+		public Union(T4 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, value, Option<T5>.None);
 		}
 
 		public Union(T5 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, value);
 		}
 
-		Option<T5> IUnion<T5>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>> IUnion<T1, T2, T3, T4, T5>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3, T4, T5>(T1 item)
@@ -215,41 +247,43 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3, T4, T5, T6> : Union<T1, T2, T3, T4, T5>, IUnion, IUnion<T6>
+	public class Union<T1, T2, T3, T4, T5, T6> : IUnion, IUnion<T1, T2, T3, T4, T5, T6>
 	{
-		private readonly Option<T6> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(value, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(Option<T1>.None, value, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None);
 		}
 
-		public Union(T3 value) : base(value)
+		public Union(T3 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(Option<T1>.None, Option<T2>.None, value, Option<T4>.None, Option<T5>.None, Option<T6>.None);
 		}
 
-		public Union(T4 value) : base(value)
+		public Union(T4 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, value, Option<T5>.None, Option<T6>.None);
 		}
 
-		public Union(T5 value) : base(value)
+		public Union(T5 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, value, Option<T6>.None);
 		}
 
 		public Union(T6 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, value);
 		}
 
-		Option<T6> IUnion<T6>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>> IUnion<T1, T2, T3, T4, T5, T6>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T1 item)
@@ -283,45 +317,48 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3, T4, T5, T6, T7> : Union<T1, T2, T3, T4, T5, T6>, IUnion, IUnion<T7>
+	public class Union<T1, T2, T3, T4, T5, T6, T7> : IUnion, IUnion<T1, T2, T3, T4, T5, T6, T7>
 	{
-		private readonly Option<T7> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(value, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, value, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None);
 		}
 
-		public Union(T3 value) : base(value)
+		public Union(T3 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, Option<T2>.None, value, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None);
 		}
 
-		public Union(T4 value) : base(value)
+		public Union(T4 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, value, Option<T5>.None, Option<T6>.None, Option<T7>.None);
 		}
 
-		public Union(T5 value) : base(value)
+		public Union(T5 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, value, Option<T6>.None, Option<T7>.None);
 		}
 
-		public Union(T6 value) : base(value)
+		public Union(T6 value)
 		{
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, value, Option<T7>.None);
 		}
 
 		public Union(T7 value)
 		{
-			this.internalValue = value;
+			this.internalValue = Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, value);
 		}
 
-		Option<T7> IUnion<T7>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>> IUnion<T1, T2, T3, T4, T5, T6, T7>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T1 item)
@@ -360,49 +397,53 @@ namespace LanguageExt
 		}
 	}
 
-	public class Union<T1, T2, T3, T4, T5, T6, T7, T8> : Union<T1, T2, T3, T4, T5, T6, T7>, IUnion, IUnion<T8>
+	public class Union<T1, T2, T3, T4, T5, T6, T7, T8> : IUnion, IUnion<T1, T2, T3, T4, T5, T6, T7, T8>
 	{
-		private readonly Option<T8> internalValue;
+		private readonly Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Tuple<Option<T8>>> internalValue;
 
-		protected Union()
-		{ }
-
-		public Union(T1 value) : base(value)
+		public Union(T1 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(value, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T2 value) : base(value)
+		public Union(T2 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, value, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T3 value) : base(value)
+		public Union(T3 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, value, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T4 value) : base(value)
+		public Union(T4 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, value, Option<T5>.None, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T5 value) : base(value)
+		public Union(T5 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, value, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T6 value) : base(value)
+		public Union(T6 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, value, Option<T7>.None, Option<T8>.None);
 		}
 
-		public Union(T7 value) : base(value)
+		public Union(T7 value)
 		{
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, value, Option<T8>.None);
 		}
 
 		public Union(T8 value)
 		{
-			this.internalValue = value;
+			this.internalValue = System.Tuple.Create<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Option<T8>>(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None, value);
 		}
 
-		Option<T8> IUnion<T8>.opt
+		Tuple<Option<T1>, Option<T2>, Option<T3>, Option<T4>, Option<T5>, Option<T6>, Option<T7>, Tuple<Option<T8>>> IUnion<T1, T2, T3, T4, T5, T6, T7, T8>.InternalValue()
 		{
-			get { return internalValue; }
+			return internalValue ?? System.Tuple.Create(Option<T1>.None, Option<T2>.None, Option<T3>.None, Option<T4>.None, Option<T5>.None, Option<T6>.None, Option<T7>.None, Option<T8>.None);
 		}
 
 		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item)

--- a/LanguageExt.Core/Union.cs
+++ b/LanguageExt.Core/Union.cs
@@ -1,0 +1,448 @@
+﻿using System;
+
+namespace LanguageExt
+{
+	public interface IUnion { }
+
+	public interface IUnion<T>
+	{
+		Option<T> opt { get; }
+	}
+
+	public class Union<T1> : IUnion, IUnion<T1>
+	{
+		private readonly Option<T1> internalValue;
+
+		public Union()
+		{
+		}
+
+		public Union(T1 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T1> IUnion<T1>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1>(T1 item)
+		{
+			return new Union<T1>(item);
+		}
+	}
+
+	public class Union<T1, T2> : Union<T1>, IUnion, IUnion<T2>
+	{
+		private readonly Option<T2> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 a) : base(a)
+		{
+		}
+
+		public Union(T2 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T2> IUnion<T2>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2>(T1 item)
+		{
+			return new Union<T1, T2>(item);
+		}
+
+		public static implicit operator Union<T1, T2>(T2 item)
+		{
+			return new Union<T1, T2>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3> : Union<T1, T2>, IUnion, IUnion<T3>
+	{
+		private readonly Option<T3> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T3> IUnion<T3>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3>(T1 item)
+		{
+			return new Union<T1, T2, T3>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3>(T2 item)
+		{
+			return new Union<T1, T2, T3>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3>(T3 item)
+		{
+			return new Union<T1, T2, T3>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3, T4> : Union<T1, T2, T3>, IUnion, IUnion<T4>
+	{
+		private readonly Option<T4> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value) : base(value)
+		{
+		}
+
+		public Union(T4 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T4> IUnion<T4>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4>(T1 item)
+		{
+			return new Union<T1, T2, T3, T4>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4>(T2 item)
+		{
+			return new Union<T1, T2, T3, T4>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4>(T3 item)
+		{
+			return new Union<T1, T2, T3, T4>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4>(T4 item)
+		{
+			return new Union<T1, T2, T3, T4>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3, T4, T5> : Union<T1, T2, T3, T4>, IUnion, IUnion<T5>
+	{
+		private readonly Option<T5> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value) : base(value)
+		{
+		}
+
+		public Union(T4 value) : base(value)
+		{
+		}
+
+		public Union(T5 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T5> IUnion<T5>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5>(T1 item)
+		{
+			return new Union<T1, T2, T3, T4, T5>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5>(T2 item)
+		{
+			return new Union<T1, T2, T3, T4, T5>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5>(T3 item)
+		{
+			return new Union<T1, T2, T3, T4, T5>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5>(T4 item)
+		{
+			return new Union<T1, T2, T3, T4, T5>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5>(T5 item)
+		{
+			return new Union<T1, T2, T3, T4, T5>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3, T4, T5, T6> : Union<T1, T2, T3, T4, T5>, IUnion, IUnion<T6>
+	{
+		private readonly Option<T6> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value) : base(value)
+		{
+		}
+
+		public Union(T4 value) : base(value)
+		{
+		}
+
+		public Union(T5 value) : base(value)
+		{
+		}
+
+		public Union(T6 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T6> IUnion<T6>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T1 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T2 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T3 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T4 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T5 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6>(T6 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3, T4, T5, T6, T7> : Union<T1, T2, T3, T4, T5, T6>, IUnion, IUnion<T7>
+	{
+		private readonly Option<T7> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value) : base(value)
+		{
+		}
+
+		public Union(T4 value) : base(value)
+		{
+		}
+
+		public Union(T5 value) : base(value)
+		{
+		}
+
+		public Union(T6 value) : base(value)
+		{
+		}
+
+		public Union(T7 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T7> IUnion<T7>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T1 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T2 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T3 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T4 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T5 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T6 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(T7 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7>(item);
+		}
+	}
+
+	public class Union<T1, T2, T3, T4, T5, T6, T7, T8> : Union<T1, T2, T3, T4, T5, T6, T7>, IUnion, IUnion<T8>
+	{
+		private readonly Option<T8> internalValue;
+
+		protected Union()
+		{ }
+
+		public Union(T1 value) : base(value)
+		{
+		}
+
+		public Union(T2 value) : base(value)
+		{
+		}
+
+		public Union(T3 value) : base(value)
+		{
+		}
+
+		public Union(T4 value) : base(value)
+		{
+		}
+
+		public Union(T5 value) : base(value)
+		{
+		}
+
+		public Union(T6 value) : base(value)
+		{
+		}
+
+		public Union(T7 value) : base(value)
+		{
+		}
+
+		public Union(T8 value)
+		{
+			this.internalValue = value;
+		}
+
+		Option<T8> IUnion<T8>.opt
+		{
+			get { return internalValue; }
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T1 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T2 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T3 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T4 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T5 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T6 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T7 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+
+		public static implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(T8 item)
+		{
+			return new Union<T1, T2, T3, T4, T5, T6, T7, T8>(item);
+		}
+	}
+}

--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="TryOutTests.cs" />
     <Compile Include="TupleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnionTests.cs" />
     <Compile Include="UnitsOfMeasureTests.cs" />
     <Compile Include="UnsafeTests.cs" />
     <Compile Include="MonadTests.cs" />

--- a/LanguageExt.Tests/UnionTests.cs
+++ b/LanguageExt.Tests/UnionTests.cs
@@ -1,0 +1,132 @@
+﻿using LanguageExt;
+using System;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExtTests
+{
+	public class UnionTests
+	{
+		[Fact]
+		public void UnionTest1()
+		{
+			Union<string, int> x = "Test";
+
+			object value = null;
+
+			x.Match()
+				(a => value = a)
+				(b => value = b);
+
+			Assert.IsType<string>(value);
+		}
+
+		[Fact]
+		public void UnionTest2()
+		{
+			Union<string, int> x = 100;
+
+			object value = null;
+
+			x.Match()
+				(v => value = v)
+				(v => value = v);
+
+			Assert.IsType<int>(value);
+		}
+
+		[Fact]
+		public void UnionTest3()
+		{
+			Union<string, int> x = "Test";
+
+			string value = x.Match<string, int, string>()
+				(a => a)
+				(b => b.ToString());
+
+			Assert.Equal("Test", value);
+		}
+
+		[Fact]
+		public void UnionTest4()
+		{
+			var x = new Union<string, int>(100);
+
+			string value = x.Match<string, int, string>()
+				(a => a)
+				(b => b.ToString());
+
+			Assert.Equal("100", value);
+		}
+
+		[Fact]
+		public void UnionTest5()
+		{
+			var x = new Union<string, int>(100);
+
+			string value = x.Match<string, int, string>()
+				(a => a)
+				(b => b == 100 ? "Keeping It 100." : "Tea?");
+
+			Assert.Equal("Keeping It 100.", value);
+		}
+
+		[Fact]
+		public void UnionTest6()
+		{
+			string value = AOrB(true)
+				.Match<string, int, string>()
+				(a => a)
+				(b => b == 100 ? "Keeping It 100." : "Tea?");
+
+			Assert.Equal("Keeping It 100.", value);
+		}
+
+		[Fact]
+		public void UnionTest7()
+		{
+			string value = AOrB(false)
+				.Match<string, int, string>()
+				(a => a)
+				(b => b == 100 ? "Keeping It 100." : "Tea?");
+
+			Assert.Equal("test", value);
+		}
+
+		[Fact]
+		public void UnionTest8()
+		{
+			var x = Prelude.ToErrorUnion<int, UnauthorizedAccessException>(() => AOrError(false));
+			string value = x
+				.Match<int, UnauthorizedAccessException, string>()
+				(a => a.ToString())
+				(b => "test");
+
+			Assert.Equal("test", value);
+		}
+
+		private Union<string, int> AOrB(bool isA)
+		{
+			if (isA)
+			{
+				return 100;
+			}
+			else
+			{
+				return "test";
+			}
+		}
+
+		private int AOrError(bool isA)
+		{
+			if (isA)
+			{
+				return 100;
+			}
+			else
+			{
+				throw new System.UnauthorizedAccessException();
+			}
+		}
+	}
+}

--- a/LanguageExt.Tests/UnionTests.cs
+++ b/LanguageExt.Tests/UnionTests.cs
@@ -128,5 +128,152 @@ namespace LanguageExtTests
 				throw new System.UnauthorizedAccessException();
 			}
 		}
+
+		[Fact]
+		public void UnionTest3_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3> x = new ItemType3();
+
+			Assert.Equal("value3", x.Match<ItemType1, ItemType2, ItemType3, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		[Fact]
+		public void UnionTest4_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3, ItemType4> x = new ItemType4();
+
+			Assert.Equal("value4", x.Match<ItemType1, ItemType2, ItemType3, ItemType4, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		[Fact]
+		public void UnionTest5_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5> x = new ItemType5();
+
+			Assert.Equal("value5", x.Match<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		[Fact]
+		public void UnionTest6_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6> x = new ItemType6();
+
+			Assert.Equal("value6", x.Match<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		[Fact]
+		public void UnionTest7_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6, ItemType7> x = new ItemType7();
+
+			Assert.Equal("value7", x.Match<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6, ItemType7, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		[Fact]
+		public void UnionTest8_1()
+		{
+			Union<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6, ItemType7, ItemType8> x = new ItemType8();
+
+			Assert.Equal("value8", x.Match<ItemType1, ItemType2, ItemType3, ItemType4, ItemType5, ItemType6, ItemType7, ItemType8, string>()
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value)
+				(item => item.Value));
+		}
+
+		public class TestTypeBase
+		{
+			public string Value { get; }
+
+			public TestTypeBase(string value)
+			{
+				this.Value = value;
+			}
+		}
+
+		public class ItemType1 : TestTypeBase
+		{
+			public ItemType1() : base("value1")
+			{
+			}
+		}
+
+		public class ItemType2 : TestTypeBase
+		{
+			public ItemType2() : base("value2")
+			{
+			}
+		}
+
+		public class ItemType3 : TestTypeBase
+		{
+			public ItemType3() : base("value3")
+			{
+			}
+		}
+
+		public class ItemType4 : TestTypeBase
+		{
+			public ItemType4() : base("value4")
+			{
+			}
+		}
+
+		public class ItemType5 : TestTypeBase
+		{
+			public ItemType5() : base("value5")
+			{
+			}
+		}
+
+		public class ItemType6 : TestTypeBase
+		{
+			public ItemType6() : base("value6")
+			{
+			}
+		}
+
+		public class ItemType7 : TestTypeBase
+		{
+			public ItemType7() : base("value7")
+			{
+			}
+		}
+
+		public class ItemType8 : TestTypeBase
+		{
+			public ItemType8() : base("value8")
+			{
+			}
+		}
 	}
 }


### PR DESCRIPTION
Union Type with functional Match syntax mentioned in issue #153.

Discriminated Unions of up to eight types can be created.  Unions support implicit casting to the union type to simplify return statements.  the match syntax sticks as closely to the F# syntax as I could manage in C# and includes both a curried syntax and a multi parameter syntax.   