### PR TITLE
Fix for == methods in NewType and Pos throwing NullReferenceExceptions

### DIFF
--- a/LanguageExt.Core/NewType.cs
+++ b/LanguageExt.Core/NewType.cs
@@ -57,10 +57,8 @@ namespace LanguageExt
             Value.Equals(other.Value);
 
         [Pure]
-        public override bool Equals(object obj) =>
-            !ReferenceEquals(obj, null) &&
-            obj is NewType<T> &&
-            Equals((NewType<T>)obj);
+        public override bool Equals(object obj) => 
+            Equals(obj as NewType<T>);
 
         [Pure]
         public override int GetHashCode() =>
@@ -68,11 +66,13 @@ namespace LanguageExt
 
         [Pure]
         public static bool operator ==(NewType<T> lhs, NewType<T> rhs) =>
-            lhs.Equals(rhs);
+            (ReferenceEquals(lhs, null) && ReferenceEquals(rhs, null))
+            ||
+            lhs?.Equals(rhs) == true;
 
         [Pure]
-        public static bool operator !=(NewType<T> lhs, NewType<T> rhs) =>
-            !lhs.Equals(rhs);
+        public static bool operator !=(NewType<T> lhs, NewType<T> rhs) => 
+            !(lhs == rhs);
 
         [Pure]
         public static bool operator >(NewType<T> lhs, NewType<T> rhs) =>

--- a/LanguageExt.Parsec/Pos.cs
+++ b/LanguageExt.Parsec/Pos.cs
@@ -43,10 +43,12 @@ namespace LanguageExt.Parsec
                     : Column.CompareTo(other.Column);
 
         public static bool operator ==(Pos lhs, Pos rhs) =>
-            lhs.Equals(rhs);
+            (ReferenceEquals(lhs, null) && ReferenceEquals(rhs, null))
+            ||
+            lhs?.Equals(rhs) == true;
 
-        public static bool operator !=(Pos lhs, Pos rhs) =>
-            !lhs.Equals(rhs);
+        public static bool operator !=(Pos lhs, Pos rhs) => 
+            !(lhs == rhs);
 
         public static bool operator < (Pos lhs, Pos rhs) =>
             lhs.CompareTo(rhs) < 0;

--- a/LanguageExt.Tests/NewTypeTests.cs
+++ b/LanguageExt.Tests/NewTypeTests.cs
@@ -36,6 +36,19 @@ namespace LanguageExtTests
             Assert.False(m1 == m3);
             //var r3 = m1 == h1;    // won't compile
         }
+        [Fact]
+        public void EqTestWithNull()
+        {
+            var m1 = new Metres(1);
+            var m2 = default(Metres);
+
+            Assert.False(m1 == m2);
+            Assert.False(m1 == null);
+            Assert.False(null == m1);
+
+            Assert.True(null == m2);
+            Assert.True(m2 == null);
+        }
 
         [Fact]
         public void OrdTest1()


### PR DESCRIPTION
The types NewType<> and Pos both throw exceptions if the == operator is used and the left-hand side is null. E.g.

```csharp

public class Name: NewType<string> { public Name(string value) : base (value){} }

var x = (Name) null;

if ( x == null ) // Throws NullReferenceException
{ }

```