### PR TITLE
window.location.origin is (sometimes) undefined

### DIFF
--- a/LanguageExt.ProcessJS/process.js
+++ b/LanguageExt.ProcessJS/process.js
@@ -5,6 +5,13 @@
 
 var unit = "(unit)";
 
+// set the origin if it isn't supported by the browser
+if (!window.location.origin) {
+    window.location.origin = window.location.protocol + "//"
+        + window.location.hostname
+        + (window.location.port ? ':' + window.location.port : '');
+}
+
 var failwith = function (err) {
     console.error(err);
     throw err;


### PR DESCRIPTION
`window.location.origin` isn't supported by all browsers

See: 
https://developer.mozilla.org/en-US/docs/Web/API/HTMLHyperlinkElementUtils/origin
https://connect.microsoft.com/IE/feedback/details/1763802/location-origin-is-undefined-in-ie-11-on-windows-10-but-works-on-windows-7