### PR TITLE
Added parseEnum

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -162,5 +162,15 @@ namespace LanguageExt
                 ? Some(result)
                 : None;
         }
+
+        [Pure]
+        public static Option<IEnum> parseEnum<IEnum>(string value)
+            where IEnum: struct
+        {
+            IEnum result;
+            return Enum.TryParse(value, out result)
+                ? Some(result)
+                : None;
+        }
     }
 }


### PR DESCRIPTION
This is my attempt at parseEnum function. There is a constraint on Enum that is must be a non-nullable value type. I added the struct constraint so that would not be an issue. The downside being that you have to use it like so, passing in the enum type
`enum breakfast { Eggs, Bacon, Toast };` `var test = parseEnum<breakfast>("Toast");` 

