### PR TITLE
Adds async constructors to TryOptionAsync and TryAsync

### DIFF
--- a/LanguageExt.Core/DataTypes/TryAsync/TryAsync.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/TryAsync/TryAsync.Prelude.cs
@@ -17,9 +17,21 @@ namespace LanguageExt
         /// <param name="f">Function to run asynchronously</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]
-        public static TryAsync<A> TryAsync<A>(Func<A> f) => 
+        public static TryAsync<A> TryAsync<A>(Func<A> f) =>
             TryAsyncExtensions.Memo<A>(() =>
+            
                 Task.Run(() => new Result<A>(f())));
+
+        /// <summary>
+        /// TryAsync constructor function
+        /// </summary>
+        /// <typeparam name="A">Bound value type</typeparam>
+        /// <param name="f">Asynchronous function to run asynchronously</param>
+        /// <returns>A lifted operation that returns a value of A</returns>
+        [Pure]
+        public static TryAsync<A> TryAsyncAsync<A>(Func<Task<A>> f) =>
+            TryAsyncExtensions.Memo<A>(() =>
+                f().Map(r => new Result<A>(r)));
 
         /// <summary>
         /// TryAsync identity constructor function

--- a/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
@@ -36,7 +36,7 @@ namespace LanguageExt
         /// TryOptionAsync constructor function
         /// </summary>
         /// <typeparam name="A">Bound value type</typeparam>
-        /// <param name="f">Asynchronous function to run</param>
+        /// <param name="f">Asynchronous function to run asynchronously</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]
         public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<A>> f) =>
@@ -47,7 +47,7 @@ namespace LanguageExt
         /// TryOptionAsync constructor function
         /// </summary>
         /// <typeparam name="A">Bound value type</typeparam>
-        /// <param name="f">Function to run asynchronously</param>
+        /// <param name="f">Asynchronously function to run asynchronously</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]
         public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<Option<A>>> f) =>

--- a/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
@@ -36,6 +36,28 @@ namespace LanguageExt
         /// TryOptionAsync constructor function
         /// </summary>
         /// <typeparam name="A">Bound value type</typeparam>
+        /// <param name="f">Asynchronous function to run</param>
+        /// <returns>A lifted operation that returns a value of A</returns>
+        [Pure]
+        public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<A>> f) =>
+            TryOptionAsyncExtensions.Memo<A>(() =>
+                f().Map(r => new OptionalResult<A>(r)));
+
+        /// <summary>
+        /// TryOptionAsync constructor function
+        /// </summary>
+        /// <typeparam name="A">Bound value type</typeparam>
+        /// <param name="f">Function to run asynchronously</param>
+        /// <returns>A lifted operation that returns a value of A</returns>
+        [Pure]
+        public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<Option<A>>> f) =>
+            TryOptionAsyncExtensions.Memo<A>(() =>
+                f().Map(r => new OptionalResult<A>(r)));
+
+        /// <summary>
+        /// TryOptionAsync constructor function
+        /// </summary>
+        /// <typeparam name="A">Bound value type</typeparam>
         /// <param name="v">Bound value to return</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]

--- a/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Prelude.cs
@@ -39,7 +39,7 @@ namespace LanguageExt
         /// <param name="f">Asynchronous function to run asynchronously</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]
-        public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<A>> f) =>
+        public static TryOptionAsync<A> TryOptionAsyncAsync<A>(Func<Task<A>> f) =>
             TryOptionAsyncExtensions.Memo<A>(() =>
                 f().Map(r => new OptionalResult<A>(r)));
 
@@ -50,7 +50,7 @@ namespace LanguageExt
         /// <param name="f">Asynchronously function to run asynchronously</param>
         /// <returns>A lifted operation that returns a value of A</returns>
         [Pure]
-        public static TryOptionAsync<A> TryOptionAsync<A>(Func<Task<Option<A>>> f) =>
+        public static TryOptionAsync<A> TryOptionAsyncAsync<A>(Func<Task<Option<A>>> f) =>
             TryOptionAsyncExtensions.Memo<A>(() =>
                 f().Map(r => new OptionalResult<A>(r)));
 

--- a/LanguageExt.Tests/TryAsyncTEsts.cs
+++ b/LanguageExt.Tests/TryAsyncTEsts.cs
@@ -211,6 +211,7 @@ namespace LanguageExt.Tests
 
             Assert.True(ab == "hello", $"Actually got {ab}");
         }
+
         [Fact]
         public async void BindingWithTryOptionFail3()
         {
@@ -238,6 +239,31 @@ namespace LanguageExt.Tests
                     Fail: ex => ex.Message));
 
             Assert.True(ab == "NONE", $"Actually got {ab}");
+        }
+
+        [Fact]
+        public async void AsyncBindingWithTryOptionSuccess()
+        {
+            var ma = TryAsyncAsync(async () =>
+            {
+                await Task.Delay(1000);
+                return 100;
+            });
+
+            var mb = TryOptionAsyncAsync(async () =>
+            {
+                await Task.Delay(1000);
+                return 100;
+            });
+
+            var res = AsyncHelper.CompletesImmediately(() =>
+                MTryAsync<int>.Inst.Bind<MTryAsync<int>, TryAsync<int>, int>(ma, a =>
+                    MTryOptionAsync<int>.Inst.Bind<MTryAsync<int>, TryAsync<int>, int>(mb, b =>
+                        TryAsync(a + b))));
+
+            var ab = await AsyncHelper.TakesRoughly(2000, () => res.IfFail(0));
+
+            Assert.True(ab == 200);
         }
 
         [Fact]


### PR DESCRIPTION
If you have a function that returns a `Task<>` and try and use the existing constructor functions you'll end up with that `Task<>` wrapped inside the `OptionResult<>` or `Result<>`. This PR adds constructors to allow the result to be correctly wrapped.

Unfortunately, I've had to choose a different name to disambiguate because C#'s type inference cannot tell which constructor should be used. Honestly, I wanted to ditch the `Task.Run(() => {})` constructors because people could explicitly write that if they want it to run on the thread pool---however, that'd be a breaking change so I avoided that.
(If you have better approach for this, please let me know.)