### PR TITLE
HashSet constructor IEnumerable / fixing distinct check

### DIFF
--- a/LanguageExt.Core/DataTypes/HashSet/HashSet.cs
+++ b/LanguageExt.Core/DataTypes/HashSet/HashSet.cs
@@ -32,12 +32,22 @@ namespace LanguageExt
             new HashSet<U>(value);
 
         /// <summary>
-        /// Ctor that takes an initial (distinct) set of items
+        /// Ctor from an enumerable 
         /// </summary>
         /// <param name="items"></param>
-        internal HashSet(IEnumerable<A> items, bool checkUniqueness = false)
+        internal HashSet(IEnumerable<A> items)
         {
-            value = new HashSetInternal<OrdDefault<A>, A>(items, checkUniqueness);
+            value = new HashSetInternal<OrdDefault<A>, A>(items, true);
+        }
+
+        /// <summary>
+        /// Ctor that takes an initial set of items
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="tryAdd">true = ignore duplicates, false = check for distinct items</param>
+        internal HashSet(IEnumerable<A> items, bool tryAdd)
+        {
+            value = new HashSetInternal<OrdDefault<A>, A>(items, tryAdd);
         }
 
         /// <summary>
@@ -508,7 +518,7 @@ namespace LanguageExt
                     }
                 }
             }
-            return new HashSet<B>(Yield(), true);
+            return new HashSet<B>(Yield(), false);
         }
 
         [Pure]
@@ -526,7 +536,7 @@ namespace LanguageExt
                     }
                 }
             }
-            return new HashSet<C>(Yield(), true);
+            return new HashSet<C>(Yield(), false);
         }
     }
 }

--- a/LanguageExt.Core/DataTypes/Set/Set.cs
+++ b/LanguageExt.Core/DataTypes/Set/Set.cs
@@ -55,9 +55,10 @@ namespace LanguageExt
         /// Ctor that takes an initial (distinct) set of items
         /// </summary>
         /// <param name="items"></param>
-        internal Set(IEnumerable<A> items, bool checkUniqueness)
+        /// <param name="tryAdd">true = ignore duplicates, false = check for distinct items</param>
+        internal Set(IEnumerable<A> items, bool tryAdd)
         {
-            value = new SetInternal<OrdDefault<A>, A>(items, checkUniqueness);
+            value = new SetInternal<OrdDefault<A>, A>(items, tryAdd);
         }
 
         static Set<A> Wrap(SetInternal<OrdDefault<A>, A> set) =>
@@ -489,7 +490,7 @@ namespace LanguageExt
                     }
                 }
             }
-            return new Set<B>(Yield(), true);
+            return new Set<B>(Yield(), false);
         }
 
         [Pure]
@@ -507,7 +508,7 @@ namespace LanguageExt
                     }
                 }
             }
-            return new Set<C>(Yield(), true);
+            return new Set<C>(Yield(), false);
         }
 
         [Pure]


### PR DESCRIPTION
Hi,

1. I think there is a bug in internal constructor for Set/HashSet with `checkUniqueness`. You pass this to `tryAdd`. I think tryAdd will ignore duplicates, so probably a negation missing. This commit contains a fix. 
Seems you use this constructor only for Bind when creating new sets. I changed the name of checkUniqueness to tryAdd and negated the values there. IMHO this makes it more clear because everything is now "tryAdd". But perhaps you don't like this way... then you probably have to add "!" in constructor code before calling Internal constructor like `new SetInternal<OrdDefault<A>, A>(items, !checkForUniqueness)` to just fix the bug.

2. I splitted HashSet constructor function the same way it is splitted for Set. I didn't really verify this but I guess the errors I get when deserializing json are due to a "missing" constructor with only `IEnumerable<T>` as arg. (It's working for Set.)
At least this makes Set and HashSet same style.


Side note: I switched my code from Set to HashSet because I noticed some "strange" behaviour when comparing my sets. The cause was that I have Sets of a `Record<T>` with `[OptOutOfEq]` and custom `Equals` -- but Set equality comparison (and especially `Contains`) uses Ord. This is not a bug in LanguageExt, but reminded me that Set can only be used with types that have valid Ordering. I just need Equality for my use case so that's all I want to implement.