### PR TITLE
Static properties cause  Record<T>::Equals to fail

### DIFF
--- a/LanguageExt.Core/Utility/Reflect.cs
+++ b/LanguageExt.Core/Utility/Reflect.cs
@@ -30,7 +30,7 @@ namespace LanguageExt
 #if !COREFX13
                                     .OrderBy(p => p.MetadataToken)
 #endif
-                                    .Where(p => p.CanRead && p.GetMethod.IsPublic && !p.GetAccessors(true)[0].IsStatic)
+                                    .Where(p => p.CanRead && p.GetMethod.IsPublic && !IsStatic(p))
                                     .Where(p => !toSet(p.CustomAttributes.Map(a => a.AttributeType.Name)).Intersect(excludeAttrsSet).Any())
                                     .ToArray();
 
@@ -46,6 +46,18 @@ namespace LanguageExt
 
             return Enumerable.Concat(publicFields, backingFields);
         }
+
+        /// <summary>
+        /// Returns true if the property is static by inspecting
+        /// the static property of the accessors. Note that if
+        /// there are no accessors then the property is assumed
+        /// to be **non static**. Not sure that this case is
+        /// even possible in CLR.
+        /// </summary>
+        /// <param name="p"></param>
+        /// <returns></returns>
+        public static bool IsStatic
+            (PropertyInfo p) => p.GetAccessors( true ).HeadOrNone().Map( x => x.IsStatic ).IfNone( false );
 
         public static Option<MethodInfo> GetPublicStaticMethod(Type type, string name, Type argA) =>
             type.GetTypeInfo()

--- a/LanguageExt.Core/Utility/Reflect.cs
+++ b/LanguageExt.Core/Utility/Reflect.cs
@@ -30,7 +30,7 @@ namespace LanguageExt
 #if !COREFX13
                                     .OrderBy(p => p.MetadataToken)
 #endif
-                                    .Where(p => p.CanRead && p.GetMethod.IsPublic)
+                                    .Where(p => p.CanRead && p.GetMethod.IsPublic && !p.GetAccessors(true)[0].IsStatic)
                                     .Where(p => !toSet(p.CustomAttributes.Map(a => a.AttributeType.Name)).Intersect(excludeAttrsSet).Any())
                                     .ToArray();
 

--- a/LanguageExt.Tests/EqualityTests.cs
+++ b/LanguageExt.Tests/EqualityTests.cs
@@ -194,4 +194,50 @@ namespace LanguageExtTests
                 default(MonadA).Fold(my, false, (s2, y) =>
                     default(EqA).Equals(x, y))(unit))(unit);
     }
+
+
+    public class EqualityTestsWithStaticProperties
+    {
+        public class Foo : Record<Foo>
+        {
+            public static Foo Default { get; } 
+
+            static Foo()
+            {
+                Default = new Foo( 10,20,List(1,2) );
+            }
+
+            public Foo(int age, int s, Lst<int> numbers)
+            {
+                Age = age;
+                String = s;
+                Numbers = numbers;
+            }
+            public int Age { get; }
+            public int String { get; }
+            public Lst<int> Numbers { get; }
+        }
+
+        [Fact]
+        public void EqualRecordsShouldBeEqual()
+        {
+
+            var a = new Foo( 10, 20, List( 0, 1, 2 ) );
+            var b = new Foo( 10, 20, List( 0, 1, 2 ) );
+
+            Assert.Equal( b, a );
+
+        }
+
+        [Fact]
+        public void NonEqualRecordsShouldBeNotEqual()
+        {
+
+            var a = new Foo( 10, 20, List( 0, 1, 2 ) );
+            var b = new Foo( 10, 20, List( 0, -1, 2 ) );
+
+            Assert.NotEqual( b, a );
+
+        }
+    }
 }


### PR DESCRIPTION
Fixes #281 