### PR TITLE
Lst.remove.fails

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Internal.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Internal.cs
@@ -219,8 +219,11 @@ namespace LanguageExt
         /// Remove an item from the list
         /// </summary>
         [Pure]
-        public LstInternal<A> Remove(A value) => 
-            Remove(value, Comparer<A>.Default);
+        public LstInternal<A> Remove(A value)
+        {
+            var i = IndexOf( value );
+            return i >= 0 ? RemoveAt( i )  : this;
+        }
 
         /// <summary>
         /// Remove an item from the list

--- a/LanguageExt.Core/DataTypes/List/Lst.Internal.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Internal.cs
@@ -219,9 +219,9 @@ namespace LanguageExt
         /// Remove an item from the list
         /// </summary>
         [Pure]
-        public LstInternal<A> Remove(A value)
+        public LstInternal<A> Remove(A value, IEqualityComparer<A> equalityComparer = null)
         {
-            var i = IndexOf( value );
+            var i = IndexOf( value, equalityComparer: equalityComparer );
             return i >= 0 ? RemoveAt( i )  : this;
         }
 

--- a/LanguageExt.Core/DataTypes/List/Lst.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.cs
@@ -175,11 +175,7 @@ namespace LanguageExt
         /// Remove an item from the list
         /// </summary>
         [Pure]
-        public Lst<A> Remove(A value)
-        {
-            var i = Value.IndexOf( value );
-            return i >= 0 ? Wrap( Value.RemoveAt( i ) ) : this;
-        }
+        public Lst<A> Remove(A value) => Wrap( Value.Remove( value ) );
 
         /// <summary>
         /// Remove an item from the list

--- a/LanguageExt.Core/DataTypes/List/Lst.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.cs
@@ -175,7 +175,8 @@ namespace LanguageExt
         /// Remove an item from the list
         /// </summary>
         [Pure]
-        public Lst<A> Remove(A value) => Wrap( Value.Remove( value ) );
+        public Lst<A> Remove(A value, IEqualityComparer<A> equalityComparer = null) => 
+            Wrap( Value.Remove( value, equalityComparer ) );
 
         /// <summary>
         /// Remove an item from the list

--- a/LanguageExt.Core/DataTypes/List/Lst.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.cs
@@ -175,8 +175,11 @@ namespace LanguageExt
         /// Remove an item from the list
         /// </summary>
         [Pure]
-        public Lst<A> Remove(A value) =>
-            Wrap(Value.Remove(value));
+        public Lst<A> Remove(A value)
+        {
+            var i = Value.IndexOf( value );
+            return i >= 0 ? Wrap( Value.RemoveAt( i ) ) : this;
+        }
 
         /// <summary>
         /// Remove an item from the list

--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -67,6 +67,11 @@
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Reflection.TypeExtensions">
+      <HintPath>..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\microsoft.netcore.app\2.0.0\ref\netcoreapp2.0\System.Reflection.TypeExtensions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="HKT\HKT.Extensions.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -383,5 +383,36 @@ namespace LanguageExtTests
                 }
             }
         }
+
+
+        [Fact]
+        public void ListShouldRemoveByReference()
+        {
+            var o0 = new Object();
+            var o1 = new Object();
+            var o2 = new Object();
+            var l = List(o0, o1);
+            l = l.Remove(o2);
+            Assert.Equal( 2, l.Count );
+            l = l.Remove(o0);
+            Assert.Equal( 1, l.Count );
+            l = l.Remove(o1);
+            Assert.Equal( 0, l.Count );
+        }
+
+        [Fact]
+        public void ListShouldRemoveByReferenceForReverseLists()
+        {
+            var o0 = new Object();
+            var o1 = new Object();
+            var o2 = new Object();
+            var l = List(o0, o1).Reverse();
+            l = l.Remove(o2);
+            Assert.Equal( 2, l.Count );
+            l = l.Remove(o0);
+            Assert.Equal( 1, l.Count );
+            l = l.Remove(o1);
+            Assert.Equal( 0, l.Count );
+        }
     }
 }


### PR DESCRIPTION
Fixes #284 

However I think there seems to be a more general problem with Lst that I can't figure out how to fix.

Why does

       /// <summary>
        /// Remove an item from the list
        /// </summary>
        [Pure]
        public Lst<A> Remove(A value, IComparer<A> equalityComparer) =>
            Wrap(Value.Remove(value, equalityComparer));

use an **IComparer** rather than an IEqualityComparer. I assume the ordering for a list is insertion order and there is no automatic ordering.

In some other parts of the code you do use an IEqualityComparer. For example

```
  public int LastIndexOf(A item, int index = 0, int count = -1, IEqualityComparer<A> equalityComparer = null)
    {
      return this.Count - this.Reverse().IndexOf(item, index, count, equalityComparer) - 1;
    }
```

Drilling down into the code I find the requirement for IComparable is at ListModule::Find

```
    public static int Find<T>(ListItem<T> node, T key, int index, int count, IComparer<T> comparer)
    {
      comparer = comparer ?? (IComparer<T>) Comparer<T>.Default;
      if (node.IsEmpty || node.Count <= 0)
        return ~index;
      int count1 = node.Left.Count;
      if (index + count <= count1)
        return ListModule.Find<T>(node.Left, key, index, count, comparer);
      if (index > count1)
      {
        int num1 = ListModule.Find<T>(node.Right, key, index - count1 - 1, count, comparer);
        int num2 = count1 + 1;
        if (num1 >= 0)
          return num1 + num2;
        return num1 - num2;
      }
      int num3 = comparer.Compare(key, node.Key);
      if (num3 == 0)
        return count1;
      if (num3 > 0)
      {
        int count2 = count - (count1 - index) - 1;
        int num1 = count2 < 0 ? -1 : ListModule.Find<T>(node.Right, key, 0, count2, comparer);
        int num2 = count1 + 1;
        if (num1 >= 0)
          return num1 + num2;
        return num1 - num2;
      }
      if (index == count1)
        return ~index;
      return ListModule.Find<T>(node.Left, key, index, count, comparer);
    }
```

but the code is a bit complex for me as I don't quite get the data structure. Is it a linked list or some kind of tree? The output of the compare is definitely using the three state of IComparable output so I can't figure out how I would replace with IEqualityComparable. 

