### PR TITLE
Fix equality for Arr<A>

### DIFF
--- a/LanguageExt.Core/DataTypes/Arr/Arr.cs
+++ b/LanguageExt.Core/DataTypes/Arr/Arr.cs
@@ -449,6 +449,22 @@ namespace LanguageExt
         public override bool Equals(object obj) =>
             obj is Arr<A> && Equals((Arr<A>)obj);
 
+        [Pure]
+        public bool Equals(Arr<A> obj) =>
+            SafeEquals(Value, obj.Value);
+
+
+        private static bool SafeEquals(A[] strA, A[] strB)
+        {
+            var length = strA.Length;
+            if (length != strB.Length)
+                return false;
+            for (var i = 0; i < length; i++)
+                if (!strA[i].Equals( strB[i] ))
+                    return false;
+            return true;
+        }
+
         /// <summary>
         /// Get the hash code
         /// Lazily (and once only) calculates the hash from the elements in the array

--- a/LanguageExt.Tests/ArrayTests.cs
+++ b/LanguageExt.Tests/ArrayTests.cs
@@ -113,5 +113,26 @@ namespace LanguageExtTests
                 Assert.False(fst == snd, $"'{fst}' == '{snd}'");
             }));
         }
+
+
+        [Fact]
+        public void ArrShouldNotStackOverflowOnEquals()
+        {
+            Arr<Arr<double>> arr = default(Arr<Arr<double>>);
+
+            Assert.True( arr.Equals( arr ) );
+        }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.False( Array( 1, 2, 3 ).Equals( Array<int>()));
+            Assert.False( Array<int>( ).Equals( Array<int>(1,2,3)));
+            Assert.True( Array<int>( ).Equals( Array<int>()));
+            Assert.True( Array<int>(1 ).Equals( Array<int>(1)));
+            Assert.True( Array<int>(1,2 ).Equals( Array<int>(1,2)));
+            Assert.False( Array<int>(1,2 ).Equals( Array<int>(1,2,3)));
+            Assert.False( Array<int>(1,2,3 ).Equals( Array<int>(1,2)));
+        }
     }
 }

--- a/LanguageExt.Tests/HashMapTests.cs
+++ b/LanguageExt.Tests/HashMapTests.cs
@@ -200,5 +200,19 @@ namespace LanguageExtTests
                 Assert.True(m.Count == max);
             }
         }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.True( HashMap<int,int>().Equals(HashMap<int,int>())  );
+            Assert.False( HashMap<int,int>((1,2)).Equals(HashMap<int,int>())  );
+            Assert.False( HashMap<int,int>().Equals(HashMap<int,int>((1,2)))  );
+            Assert.True( HashMap<int,int>((1,2)).Equals(HashMap<int,int>((1,2)))  );
+            Assert.False( HashMap<int,int>((1,2),(3,4)).Equals(HashMap<int,int>((1,2)))  );
+            Assert.False( HashMap<int,int>((1,2)).Equals(HashMap<int,int>((1,2),(3,4)))  );
+            Assert.True( HashMap<int,int>((1,2),(3,4)).Equals(HashMap<int,int>((1,2),(3,4)))  );
+            Assert.True( HashMap<int,int>((3,4),(1,2)).Equals(HashMap<int,int>((1,2),(3,4)))  );
+            Assert.True( HashMap<int,int>((3,4),(1,2)).Equals(HashMap<int,int>((3,4),(1,2)))  );
+        }
     }
 }

--- a/LanguageExt.Tests/HashSetTests.cs
+++ b/LanguageExt.Tests/HashSetTests.cs
@@ -157,5 +157,17 @@ namespace LanguageExtTests
             Assert.True(m.Count == 0);
             Assert.True(m.Find("e").IsNone);
         }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.False( HashSet( 1, 2, 3 ).Equals( HashSet<int>()));
+            Assert.False( HashSet<int>( ).Equals( HashSet<int>(1,2,3)));
+            Assert.True( HashSet<int>( ).Equals( HashSet<int>()));
+            Assert.True( HashSet<int>(1 ).Equals( HashSet<int>(1)));
+            Assert.True( HashSet<int>(1,2 ).Equals( HashSet<int>(1,2)));
+            Assert.False( HashSet<int>(1,2 ).Equals( HashSet<int>(1,2,3)));
+            Assert.False( HashSet<int>(1,2,3 ).Equals( HashSet<int>(1,2)));
+        }
     }
 }

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -383,5 +383,17 @@ namespace LanguageExtTests
                 }
             }
         }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.False( List( 1, 2, 3 ).Equals( List<int>()));
+            Assert.False( List<int>( ).Equals( List<int>(1,2,3)));
+            Assert.True( List<int>( ).Equals( List<int>()));
+            Assert.True( List<int>(1 ).Equals( List<int>(1)));
+            Assert.True( List<int>(1,2 ).Equals( List<int>(1,2)));
+            Assert.False( List<int>(1,2 ).Equals( List<int>(1,2,3)));
+            Assert.False( List<int>(1,2,3 ).Equals( List<int>(1,2)));
+        }
     }
 }

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -306,5 +306,19 @@ namespace LanguageExtTests
 
             Assert.True(z == Map((2, 2)));
         }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.True( Map<int,int>().Equals(Map<int,int>())  );
+            Assert.False( Map<int,int>((1,2)).Equals(Map<int,int>())  );
+            Assert.False( Map<int,int>().Equals(Map<int,int>((1,2)))  );
+            Assert.True( Map<int,int>((1,2)).Equals(Map<int,int>((1,2)))  );
+            Assert.False( Map<int,int>((1,2),(3,4)).Equals(Map<int,int>((1,2)))  );
+            Assert.False( Map<int,int>((1,2)).Equals(Map<int,int>((1,2),(3,4)))  );
+            Assert.True( Map<int,int>((1,2),(3,4)).Equals(Map<int,int>((1,2),(3,4)))  );
+            Assert.True( Map<int,int>((3,4),(1,2)).Equals(Map<int,int>((1,2),(3,4)))  );
+            Assert.True( Map<int,int>((3,4),(1,2)).Equals(Map<int,int>((3,4),(1,2)))  );
+        }
     }
 }

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -40,5 +40,17 @@ namespace LanguageExt.Tests
             Assert.True(set.Contains("three"));
             Assert.True(set.Contains("thREE"));
         }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            Assert.False( Set( 1, 2, 3 ).Equals( Set<int>()));
+            Assert.False( Set<int>( ).Equals( Set<int>(1,2,3)));
+            Assert.True( Set<int>( ).Equals( Set<int>()));
+            Assert.True( Set<int>(1 ).Equals( Set<int>(1)));
+            Assert.True( Set<int>(1,2 ).Equals( Set<int>(1,2)));
+            Assert.False( Set<int>(1,2 ).Equals( Set<int>(1,2,3)));
+            Assert.False( Set<int>(1,2,3 ).Equals( Set<int>(1,2)));
+        }
     }
 }


### PR DESCRIPTION
Fixes #286 

There probably should be more testing on equality for all the types. This just fixes ``Arr<T>``