### PR TITLE
Use gitversion for versioning

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: ContinuousDeployment
+next-version: 2.1.24
+branches: {}
+ignore:
+  sha: []

--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -12,7 +12,6 @@
     <DefineConstants>COREFX13</DefineConstants>
   </PropertyGroup>-->
   <PropertyGroup>
-    <PackageVersion>2.1.22</PackageVersion>
     <PackageId>LanguageExt.Core</PackageId>
     <Title>LanguageExt.Core</Title>
     <Authors>Paul Louth</Authors>

--- a/LanguageExt.FSharp/LanguageExt.FSharp.csproj
+++ b/LanguageExt.FSharp/LanguageExt.FSharp.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
-    <PackageVersion>2.1.22</PackageVersion>
     <PackageId>LanguageExt.FSharp</PackageId>
     <Title>LanguageExt.FSharp</Title>
     <Authors>Paul Louth</Authors>
@@ -20,8 +19,6 @@
     <PackageLicenseUrl>https://github.com/louthy/language-ext/blob/master/LICENSE.md</PackageLicenseUrl>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <OutputType>library</OutputType>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/LanguageExt.Parsec/LanguageExt.Parsec.csproj
+++ b/LanguageExt.Parsec/LanguageExt.Parsec.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
-    <PackageVersion>2.1.22</PackageVersion>
     <PackageId>LanguageExt.Parsec</PackageId>
     <Title>LanguageExt.Parsec</Title>
     <Authors>Paul Louth</Authors>
@@ -20,8 +19,6 @@
     <PackageLicenseUrl>https://github.com/louthy/language-ext/blob/master/LICENSE.md</PackageLicenseUrl>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <OutputType>library</OutputType>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />

--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
-    <FileVersion>2.0.0.0</FileVersion>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="LanguageExt.Tests.nuget.props" />

--- a/pack.bat
+++ b/pack.bat
@@ -1,4 +1,1 @@
-dotnet restore
-dotnet pack LanguageExt.Core -c Release -o ../../artifacts/bin
-dotnet pack LanguageExt.FSharp -c Release -o ../../artifacts/bin
-dotnet pack LanguageExt.Parsec -c Release -o ../../artifacts/bin
+powershell .\pack.ps1

--- a/pack.ps1
+++ b/pack.ps1
@@ -1,0 +1,6 @@
+$version=gitversion /output json /showvariable FullSemVer
+write-host "VERSION is $version"
+dotnet restore
+dotnet pack LanguageExt.Core -c Release /p:Version=$version /p:PackageVersion=$version -o ../../artifacts/bin
+dotnet pack LanguageExt.FSharp -c Release /p:Version=$version /p:PackageVersion=$version -o ../../artifacts/bin
+dotnet pack LanguageExt.Parsec -c Release /p:Version=$version /p:PackageVersion=$version -o ../../artifacts/bin


### PR DESCRIPTION
Instead of patching the csproj file I use [GitVersion](http://gitversion.readthedocs.io/en/latest/) and pass the version number directly to the ``dotnet pack`` command. This makes creating pre-release packages easier for contributers. For example now when I build for the current branch I get SemVer 2.0 compatible names and on every commit the version is incremented.

```
C:\Users\phelan\workspace\language-ext [easy-versioning +2 ~5 -0 | +0 ~2 -0 !]> ls ..\artifacts\bin\

    Directory: C:\Users\phelan\workspace\artifacts\bin

Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----       10/19/2017  10:58 AM        3193099 LanguageExt.Core.2.1.24-easy-versioning.17.nupkg
-a----       10/19/2017  10:58 AM          10214 LanguageExt.FSharp.2.1.24-easy-versioning.17.nupkg
-a----       10/19/2017  10:58 AM         133303 LanguageExt.Parsec.2.1.24-easy-versioning.17.nupkg
```
Updating the next real version is as simple as editing the GitVersion.yml file
```
C:\Users\phelan\workspace\language-ext [easy-versioning +2 ~5 -0 ~]> cat .\GitVersion.yml
mode: ContinuousDeployment
next-version: 2.1.24
branches: {}
ignore:
  sha: []
```