### PR TITLE
Bug in biIter for Option / OptionUnsafe (fix attached)

### DIFF
--- a/LanguageExt.Core/ClassInstances/Monad/MOption.cs
+++ b/LanguageExt.Core/ClassInstances/Monad/MOption.cs
@@ -125,7 +125,7 @@ namespace LanguageExt.ClassInstances
             if (state.IsNull()) throw new ArgumentNullException(nameof(state));
             if (fa == null) throw new ArgumentNullException(nameof(fa));
             if (fb == null) throw new ArgumentNullException(nameof(fb));
-            return Check.NullReturn(ma.IsNone
+            return Check.NullReturn(ma.IsSome
                 ? fa(state, ma.Value)
                 : fb(state, unit));
         }
@@ -136,7 +136,7 @@ namespace LanguageExt.ClassInstances
             if (state.IsNull()) throw new ArgumentNullException(nameof(state));
             if (fa == null) throw new ArgumentNullException(nameof(fa));
             if (fb == null) throw new ArgumentNullException(nameof(fb));
-            return Check.NullReturn(ma.IsNone
+            return Check.NullReturn(ma.IsSome
                 ? fa(state, ma.Value)
                 : fb(state, unit));
         }

--- a/LanguageExt.Core/ClassInstances/Monad/MOptionUnsafe.cs
+++ b/LanguageExt.Core/ClassInstances/Monad/MOptionUnsafe.cs
@@ -122,7 +122,7 @@ namespace LanguageExt.ClassInstances
             if (state.IsNull()) throw new ArgumentNullException(nameof(state));
             if (fa == null) throw new ArgumentNullException(nameof(fa));
             if (fb == null) throw new ArgumentNullException(nameof(fb));
-            return ma.IsNone
+            return ma.IsSome
                 ? fa(state, ma.Value)
                 : fb(state, unit);
         }
@@ -133,7 +133,7 @@ namespace LanguageExt.ClassInstances
             if (state.IsNull()) throw new ArgumentNullException(nameof(state));
             if (fa == null) throw new ArgumentNullException(nameof(fa));
             if (fb == null) throw new ArgumentNullException(nameof(fb));
-            return ma.IsNone
+            return ma.IsSome
                 ? fa(state, ma.Value)
                 : fb(state, unit);
         }

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -176,6 +176,24 @@ namespace LanguageExtTests
                 );
         }
 
+        [Fact]
+        public void BiIterSomeTest()
+        {
+            var x = Some(3);
+            int way = 0;
+            var dummy = x.BiIter(_ => way = 1, () => way = 2);
+            Assert.Equal(1, way);
+        }
+
+        [Fact]
+        public void BiIterNoneTest()
+        {
+            var x = Option<int>.None;
+            int way = 0;
+            var dummy = x.BiIter(_ => way = 1, () => way = 2);
+            Assert.Equal(2, way);
+        }
+
         private Option<string> GetStringNone()
         {
             // This should fail


### PR DESCRIPTION
The attached fix results in correct behaviour for  Option(Unsafe).BiIter(...)

call fa when some
call fb when none

A small test is included.