### PR TITLE
Added missing ToAsync implementation

### DIFF
--- a/LanguageExt.Core/DataTypes/Try/Task.Try.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Try/Task.Try.Extensions.cs
@@ -26,6 +26,25 @@ public static class TaskTryExtensions
         };
 
     /// <summary>
+    /// Convert a Task to a TryAsync<Unit>
+    /// </summary>
+    [Pure]
+    public static TryAsync<Unit> ToAsync(this Try<Task> self) =>
+        async () =>
+        {
+            try
+            {
+                var task = self.Try();
+                await task.Value;
+                return new Result<Unit>(Unit.Default);
+            }
+            catch (Exception e)
+            {
+                return new Result<Unit>(e);
+            }
+        };
+
+    /// <summary>
     /// Convert a Task<Try<A>> to a TryAsync<A>
     /// </summary>
     [Pure]
@@ -35,7 +54,6 @@ public static class TaskTryExtensions
             try
             {
                 var task = self.Try();
-                if (task.IsFaulted) return new Result<A>(task.Exception);
                 return await task.Value;
             }
             catch (Exception e)

--- a/LanguageExt.Tests/Regression/Issue283.cs
+++ b/LanguageExt.Tests/Regression/Issue283.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using LanguageExt;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Regression
+{
+    public class Issue283
+    {
+        [Fact]
+        public async Task AsyncFunctionShouldReturnFail()
+        {
+            var result = await Try(async () =>
+            {
+                var never = await Task.FromException<string>(new TestException());
+                return never.ToUpperInvariant();
+            }).ToAsync().Match(
+                Succ: _ => Option<Exception>.None,
+                Fail: ex => Some(ex)
+            );
+
+            Assert.True(result.IsSome);
+            result.Some(e => Assert.IsType<TestException>(e));
+        }
+
+        [Fact]
+        public async Task AsyncActionShouldReturnFail()
+        {
+            string never;
+            var result = await Try(async () =>
+            {
+                var s = await Task.FromException<string>(new TestException());
+                never = s.ToUpperInvariant();
+            }).ToAsync().Match(
+                Succ: _ => Option<Exception>.None,
+                Fail: ex => Some(ex)
+            );
+
+            Assert.True(result.IsSome);
+            result.Some(e => Assert.IsType<TestException>(e));
+        }
+
+        [Fact]
+        public async Task SyncFunctionShouldReturnFail()
+        {
+            var result = await Try(() => Task.FromException<string>(new Exception())).ToAsync().Match(
+                Succ: _ =>
+                    Option<Exception>.None,
+                Fail: ex =>
+                    Some(ex)
+            );
+
+            Assert.True(result.IsSome);
+            result.Some(e => Assert.IsType<TestException>(e));
+        }
+
+        [Fact]
+        public async Task SyncActionShouldReturnFail()
+        {
+            var result = await Try(() => Task.FromException(new Exception())).ToAsync().Match(
+                Succ: _ =>
+                    Option<Exception>.None,
+                Fail: ex =>
+                    Some(ex)
+            );
+
+            Assert.True(result.IsSome);
+            result.Some(e => Assert.IsType<TestException>(e));
+        }
+
+
+        public class TestException : Exception
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hi, 

First of all, thanks for this amazing library.

This pull request solvs some problems I've encountered related to issue #283.

Changes:
1. Added missing implementation of ToAsync that handles untyped Tasks,
2. Removed unnecessary check of Task status - awaiting on task.Value will result in exception being thrown if underlying task is faulted or cancelled, so there's no need to manually check if task has faulted,
3. Added tests for ToAsync to verify the changes