### PR TITLE
List.foldBackUntil and Seq.foldBackUntil are using foldWhile internally

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Module.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Module.cs
@@ -559,7 +559,7 @@ namespace LanguageExt
         /// <returns>Aggregate value</returns>
         [Pure]
         public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+            foldUntil(rev(list), state, folder, pred);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -578,7 +578,7 @@ namespace LanguageExt
         /// <returns>Aggregate value</returns>
         [Pure]
         public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+            foldUntil(rev(list), state, folder, pred);
 
         /// <summary>
         /// Applies a function to each element of the collection (from last element to first), threading 

--- a/LanguageExt.Core/DataTypes/Seq/Seq.Module.cs
+++ b/LanguageExt.Core/DataTypes/Seq/Seq.Module.cs
@@ -442,7 +442,7 @@ namespace LanguageExt
         /// <returns>Aggregate value</returns>
         [Pure]
         public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+            foldUntil(rev(list), state, folder, pred);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the sequence (from last element to first), 
@@ -461,7 +461,7 @@ namespace LanguageExt
         /// <returns>Aggregate value</returns>
         [Pure]
         public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+            foldUntil(rev(list), state, folder, pred);
 
         /// <summary>
         /// Applies a function to each element of the sequence (from last element to first), threading 

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -425,5 +425,69 @@ namespace LanguageExtTests
             l = l.Remove(o1);
             Assert.Equal(0, l.Count);
         }
+
+        [Fact]
+        public void FoldTest()
+        {
+            var input = List(1, 2, 3, 4, 5);
+            var output1 = fold(input, "", (s, x) => s + x.ToString());
+            Assert.Equal("12345", output1);
+        }
+
+        [Fact]
+        public void FoldBackTest()
+        {
+            var input = List(1, 2, 3, 4, 5);
+            var output1 = foldBack(input, "", (s, x) => s + x.ToString());
+            Assert.Equal("54321", output1);
+        }
+
+        [Fact]
+        public void FoldWhileTest()
+        {
+            var input = List(10, 20, 30, 40, 50);
+
+            var output1 = foldWhile(input, "", (s, x) => s + x.ToString(), x => x < 40);
+            Assert.Equal("102030", output1);
+
+            var output2 = foldWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 6);
+            Assert.Equal("102030", output2);
+        }
+
+        [Fact]
+        public void FoldBackWhileTest()
+        {
+            var input = List(10, 20, 30, 40, 50);
+
+            var output1 = foldBackWhile(input, "", (s, x) => s + x.ToString(), x => x >= 40);
+            Assert.Equal("5040", output1);
+
+            var output2 = foldBackWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 4);
+            Assert.Equal("5040", output2);
+        }
+
+        [Fact]
+        public void FoldUntilTest()
+        {
+            var input = List(10, 20, 30, 40, 50);
+
+            var output1 = foldUntil(input, "", (s, x) => s + x.ToString(), x => x >= 40);
+            Assert.Equal("102030", output1);
+
+            var output2 = foldUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 6);
+            Assert.Equal("102030", output2);
+        }
+
+        [Fact]
+        public void FoldBackUntilTest()
+        {
+            var input = List(10, 20, 30, 40, 50);
+
+            var output1 = foldBackUntil(input, "", (s, x) => s + x.ToString(), x => x < 40);
+            Assert.Equal("5040", output1);
+
+            var output2 = foldBackUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 4);
+            Assert.Equal("5040", output2);
+        }
     }
 }

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 using static LanguageExt.Prelude;
+using static LanguageExt.Seq;
 
 namespace LanguageExt.Tests
 {
@@ -68,6 +69,70 @@ namespace LanguageExt.Tests
             var b = seq.Skip(5).Take(5).Sum();
             Assert.True(b == 35);
 
+        }
+
+        [Fact]
+        public void FoldTest()
+        {
+            var input = Seq(1, 2, 3, 4, 5);
+            var output1 = fold(input, "", (s, x) => s + x.ToString());
+            Assert.Equal("12345", output1);
+        }
+
+        [Fact]
+        public void FoldBackTest()
+        {
+            var input = Seq(1, 2, 3, 4, 5);
+            var output1 = foldBack(input, "", (s, x) => s + x.ToString());
+            Assert.Equal("54321", output1);
+        }
+
+        [Fact]
+        public void FoldWhileTest()
+        {
+            var input = Seq(10, 20, 30, 40, 50);
+
+            var output1 = foldWhile(input, "", (s, x) => s + x.ToString(), x => x < 40);
+            Assert.Equal("102030", output1);
+
+            var output2 = foldWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 6);
+            Assert.Equal("102030", output2);
+        }
+
+        [Fact]
+        public void FoldBackWhileTest()
+        {
+            var input = Seq(10, 20, 30, 40, 50);
+
+            var output1 = foldBackWhile(input, "", (s, x) => s + x.ToString(), x => x >= 40);
+            Assert.Equal("5040", output1);
+
+            var output2 = foldBackWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 4);
+            Assert.Equal("5040", output2);
+        }
+
+        [Fact]
+        public void FoldUntilTest()
+        {
+            var input = Seq(10, 20, 30, 40, 50);
+
+            var output1 = foldUntil(input, "", (s, x) => s + x.ToString(), x => x >= 40);
+            Assert.Equal("102030", output1);
+
+            var output2 = foldUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 6);
+            Assert.Equal("102030", output2);
+        }
+
+        [Fact]
+        public void FoldBackUntilTest()
+        {
+            var input = Seq(10, 20, 30, 40, 50);
+
+            var output1 = foldBackUntil(input, "", (s, x) => s + x.ToString(), x => x < 40);
+            Assert.Equal("5040", output1);
+
+            var output2 = foldBackUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 4);
+            Assert.Equal("5040", output2);
         }
     }
 }


### PR DESCRIPTION
Hello,

I have found that List.foldBackUntil() and Seq.foldBackUntil() are using foldWhile() internally.
And I have added some tests about this modification and around.

So, if this PR is acceptable level, please consider to merge this.

Regards.