### PR TITLE
Avoid ambiguous calling when S and T are same type

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
@@ -386,11 +386,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldWhile(list, state, folder, pred);
+    public static S FoldWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldWhile(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection, threading an accumulator 
@@ -404,11 +404,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldWhile(list, state, folder, pred);
+    public static S FoldWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldWhile(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first)
@@ -423,11 +423,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldBackWhile(list, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldBackWhile(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -442,11 +442,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldBackWhile(list, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldBackWhile(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection whilst the predicate function 
@@ -460,11 +460,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldUntil<S, T>(list, state, folder, pred);
+    public static S FoldUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldUntil<S, T>(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection, threading an accumulator 
@@ -478,11 +478,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldUntil(list, state, folder, pred);
+    public static S FoldUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldUntil(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first)
@@ -497,11 +497,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldBackUntil(list, state, folder, pred);
+    public static S FoldBackUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldBackUntil(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -516,11 +516,11 @@ public static class ListExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldBackUntil(list, state, folder, pred);
+    public static S FoldBackUntil<S, T>(this IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldBackUntil(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function to each element of the collection (from last element to first), threading 

--- a/LanguageExt.Core/DataTypes/List/Lst.Module.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Module.cs
@@ -404,14 +404,14 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred)
+        public static S foldWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem)
         {
             foreach (var item in list)
             {
-                if (!pred(item))
+                if (!preditem(item))
                 {
                     return state;
                 }
@@ -432,14 +432,14 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred)
+        public static S foldWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate)
         {
             foreach (var item in list)
             {
-                if (!pred(state))
+                if (!predstate(state))
                 {
                     return state;
                 }
@@ -461,11 +461,11 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+        public static S foldBackWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            foldWhile(rev(list), state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -480,11 +480,11 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+        public static S foldBackWhile<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            foldWhile(rev(list), state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection whilst the predicate function 
@@ -498,14 +498,14 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred)
+        public static S foldUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem)
         {
             foreach (var item in list)
             {
-                if (pred(item))
+                if (preditem(item))
                 {
                     return state;
                 }
@@ -526,14 +526,14 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred)
+        public static S foldUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate)
         {
             foreach (var item in list)
             {
-                if (pred(state))
+                if (predstate(state))
                 {
                     return state;
                 }
@@ -555,11 +555,11 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldUntil(rev(list), state, folder, pred);
+        public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            foldUntil(rev(list), state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -574,11 +574,11 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldUntil(rev(list), state, folder, pred);
+        public static S foldBackUntil<S, T>(IEnumerable<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            foldUntil(rev(list), state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function to each element of the collection (from last element to first), threading 

--- a/LanguageExt.Core/DataTypes/Seq/Seq.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Seq/Seq.Extensions.cs
@@ -154,11 +154,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.Seq.foldWhile(list, state, folder, pred);
+    public static S FoldWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.Seq.foldWhile(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence, threading an accumulator 
@@ -172,11 +172,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.Seq.foldWhile(list, state, folder, pred);
+    public static S FoldWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.Seq.foldWhile(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence (from last element to first)
@@ -191,11 +191,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.Seq.foldBackWhile(list, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.Seq.foldBackWhile(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence (from last element to first), 
@@ -210,11 +210,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.Seq.foldBackWhile(list, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.Seq.foldBackWhile(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence whilst the predicate function 
@@ -228,11 +228,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.Seq.foldUntil(list, state, folder, pred);
+    public static S FoldUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.Seq.foldUntil(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence, threading an accumulator 
@@ -246,11 +246,11 @@ public static class SeqExtensions
     /// <param name="list">Enumerable to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.Seq.foldUntil(list, state, folder, pred);
+    public static S FoldUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.Seq.foldUntil(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence (from last element to first)
@@ -265,11 +265,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.Seq.foldBackUntil(list, state, folder, pred);
+    public static S FoldBackUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.Seq.foldBackUntil(list, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the sequence (from last element to first), 
@@ -284,11 +284,11 @@ public static class SeqExtensions
     /// <param name="list">sequence to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.Seq.foldBackUntil(list, state, folder, pred);
+    public static S FoldBackUntil<S, T>(this Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.Seq.foldBackUntil(list, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function to each element of the sequence (from last element to first), threading 

--- a/LanguageExt.Core/DataTypes/Seq/Seq.Module.cs
+++ b/LanguageExt.Core/DataTypes/Seq/Seq.Module.cs
@@ -287,14 +287,14 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred)
+        public static S foldWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem)
         {
             foreach (var item in list)
             {
-                if (!pred(item))
+                if (!preditem(item))
                 {
                     return state;
                 }
@@ -315,14 +315,14 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred)
+        public static S foldWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate)
         {
             foreach (var item in list)
             {
-                if (!pred(state))
+                if (!predstate(state))
                 {
                     return state;
                 }
@@ -344,11 +344,11 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+        public static S foldBackWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            foldWhile(rev(list), state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the sequence (from last element to first), 
@@ -363,11 +363,11 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldWhile(rev(list), state, folder, pred);
+        public static S foldBackWhile<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            foldWhile(rev(list), state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the sequence whilst the predicate function 
@@ -381,14 +381,14 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred)
+        public static S foldUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem)
         {
             foreach (var item in list)
             {
-                if (pred(item))
+                if (preditem(item))
                 {
                     return state;
                 }
@@ -409,14 +409,14 @@ namespace LanguageExt
         /// <param name="list">Enumerable to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred)
+        public static S foldUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate)
         {
             foreach (var item in list)
             {
-                if (pred(state))
+                if (predstate(state))
                 {
                     return state;
                 }
@@ -438,11 +438,11 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            foldUntil(rev(list), state, folder, pred);
+        public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            foldUntil(rev(list), state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the sequence (from last element to first), 
@@ -457,11 +457,11 @@ namespace LanguageExt
         /// <param name="list">sequence to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            foldUntil(rev(list), state, folder, pred);
+        public static S foldBackUntil<S, T>(Seq<T> list, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            foldUntil(rev(list), state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function to each element of the sequence (from last element to first), threading 

--- a/LanguageExt.Core/DataTypes/Stack/Stack.Module.cs
+++ b/LanguageExt.Core/DataTypes/Stack/Stack.Module.cs
@@ -254,11 +254,11 @@ namespace LanguageExt
         /// <param name="stack">Stack to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            List.foldWhile(stack, state, folder, pred);
+        public static S foldWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            List.foldWhile(stack, state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection, threading an accumulator 
@@ -272,11 +272,11 @@ namespace LanguageExt
         /// <param name="stack">Stack to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            List.foldWhile(stack, state, folder, pred);
+        public static S foldWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            List.foldWhile(stack, state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection (from last element to first)
@@ -291,11 +291,11 @@ namespace LanguageExt
         /// <param name="stack">Stack to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="preditem">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-            List.foldBackWhile(stack, state, folder, pred);
+        public static S foldBackWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+            List.foldBackWhile(stack, state, folder, preditem: preditem);
 
         /// <summary>
         /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -310,11 +310,11 @@ namespace LanguageExt
         /// <param name="stack">Stack to fold</param>
         /// <param name="state">Initial state</param>
         /// <param name="folder">Fold function</param>
-        /// <param name="pred">Predicate function</param>
+        /// <param name="predstate">Predicate function</param>
         /// <returns>Aggregate value</returns>
         [Pure]
-        public static S foldBackWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-            List.foldBackWhile(stack, state, folder, pred);
+        public static S foldBackWhile<S, T>(Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+            List.foldBackWhile(stack, state, folder, predstate: predstate);
 
         /// <summary>
         /// Applies a function to each element of the collection (from last element to first), threading 
@@ -652,11 +652,11 @@ public static class StackExtensions
     /// <param name="stack">Stack to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldWhile(stack, state, folder, pred);
+    public static S FoldWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldWhile(stack, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection, threading an accumulator 
@@ -670,11 +670,11 @@ public static class StackExtensions
     /// <param name="stack">Stack to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldWhile(stack, state, folder, pred);
+    public static S FoldWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldWhile(stack, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first)
@@ -689,11 +689,11 @@ public static class StackExtensions
     /// <param name="stack">Stack to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="preditem">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> pred) =>
-        LanguageExt.List.foldBackWhile(stack, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<T, bool> preditem) =>
+        LanguageExt.List.foldBackWhile(stack, state, folder, preditem: preditem);
 
     /// <summary>
     /// Applies a function 'folder' to each element of the collection (from last element to first), 
@@ -708,11 +708,11 @@ public static class StackExtensions
     /// <param name="stack">Stack to fold</param>
     /// <param name="state">Initial state</param>
     /// <param name="folder">Fold function</param>
-    /// <param name="pred">Predicate function</param>
+    /// <param name="predstate">Predicate function</param>
     /// <returns>Aggregate value</returns>
     [Pure]
-    public static S FoldBackWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> pred) =>
-        LanguageExt.List.foldBackWhile(stack, state, folder, pred);
+    public static S FoldBackWhile<S, T>(this Stck<T> stack, S state, Func<S, T, S> folder, Func<S, bool> predstate) =>
+        LanguageExt.List.foldBackWhile(stack, state, folder, predstate: predstate);
 
     /// <summary>
     /// Applies a function to each element of the collection, threading an accumulator argument 

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -452,6 +452,12 @@ namespace LanguageExtTests
 
             var output2 = foldWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 6);
             Assert.Equal("102030", output2);
+
+            var output3 = foldWhile(input, 0, (s, x) => s + x, preditem: x => x < 40);
+            Assert.Equal(60, output3);
+
+            var output4 = foldWhile(input, 0, (s, x) => s + x, predstate: s => s < 60);
+            Assert.Equal(60, output4);
         }
 
         [Fact]
@@ -464,6 +470,12 @@ namespace LanguageExtTests
 
             var output2 = foldBackWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 4);
             Assert.Equal("5040", output2);
+
+            var output3 = foldBackWhile(input, 0, (s, x) => s + x, preditem: x => x >= 40);
+            Assert.Equal(90, output3);
+
+            var output4 = foldBackWhile(input, 0, (s, x) => s + x, predstate: s => s < 90);
+            Assert.Equal(90, output4);
         }
 
         [Fact]
@@ -476,6 +488,12 @@ namespace LanguageExtTests
 
             var output2 = foldUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 6);
             Assert.Equal("102030", output2);
+
+            var output3 = foldUntil(input, 0, (s, x) => s + x, preditem: x => x >= 40);
+            Assert.Equal(60, output3);
+
+            var output4 = foldUntil(input, 0, (s, x) => s + x, predstate: s => s >= 60);
+            Assert.Equal(60, output4);
         }
 
         [Fact]
@@ -488,6 +506,12 @@ namespace LanguageExtTests
 
             var output2 = foldBackUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 4);
             Assert.Equal("5040", output2);
+
+            var output3 = foldBackUntil(input, 0, (s, x) => s + x, preditem: x => x < 40);
+            Assert.Equal(90, output3);
+
+            var output4 = foldBackUntil(input, 0, (s, x) => s + x, predstate: s => s >= 90);
+            Assert.Equal(90, output4);
         }
     }
 }

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -97,6 +97,12 @@ namespace LanguageExt.Tests
 
             var output2 = foldWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 6);
             Assert.Equal("102030", output2);
+
+            var output3 = foldWhile(input, 0, (s, x) => s + x, preditem: x => x < 40);
+            Assert.Equal(60, output3);
+
+            var output4 = foldWhile(input, 0, (s, x) => s + x, predstate: s => s < 60);
+            Assert.Equal(60, output4);
         }
 
         [Fact]
@@ -109,6 +115,12 @@ namespace LanguageExt.Tests
 
             var output2 = foldBackWhile(input, "", (s, x) => s + x.ToString(), (string s) => s.Length < 4);
             Assert.Equal("5040", output2);
+
+            var output3 = foldBackWhile(input, 0, (s, x) => s + x, preditem: x => x >= 40);
+            Assert.Equal(90, output3);
+
+            var output4 = foldBackWhile(input, 0, (s, x) => s + x, predstate: s => s < 90);
+            Assert.Equal(90, output4);
         }
 
         [Fact]
@@ -121,6 +133,12 @@ namespace LanguageExt.Tests
 
             var output2 = foldUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 6);
             Assert.Equal("102030", output2);
+
+            var output3 = foldUntil(input, 0, (s, x) => s + x, preditem: x => x >= 40);
+            Assert.Equal(60, output3);
+
+            var output4 = foldUntil(input, 0, (s, x) => s + x, predstate: s => s >= 60);
+            Assert.Equal(60, output4);
         }
 
         [Fact]
@@ -133,6 +151,12 @@ namespace LanguageExt.Tests
 
             var output2 = foldBackUntil(input, "", (s, x) => s + x.ToString(), (string s) => s.Length >= 4);
             Assert.Equal("5040", output2);
+
+            var output3 = foldBackUntil(input, 0, (s, x) => s + x, preditem: x => x < 40);
+            Assert.Equal(90, output3);
+
+            var output4 = foldBackUntil(input, 0, (s, x) => s + x, predstate: s => s >= 90);
+            Assert.Equal(90, output4);
         }
     }
 }


### PR DESCRIPTION
Fix of #304 .

Hello,

This PR is in order to avoid ambiguous method calling and add related unit tests.
List(or Seq).foldX(foldWhile, foldBackWhile, foldUntil, foldBackUntil) causes compile time error when type S and T are same types.
A compilation time error will happen when you build following code.

```
var input = Seq(10, 20, 30, 40, 50);
var output = foldBackWhile(input, 0, (s, x) => s + x, x => x >= 40);
//The call is ambiguous between the following methods or properties:
//'Seq.foldBackWhile<S, T>(Seq<T>, S, Func<S, T, S>, Func<T, bool>)' and
//'Seq.foldBackWhile<S, T>(Seq<T>, S, Func<S, T, S>, Func<S, bool>)'
```