### PR TITLE
Option.AsEnumerable returns Seq<T>

### DIFF
--- a/LanguageExt.Core/DataTypes/Option/Option.Extensions.Async.cs
+++ b/LanguageExt.Core/DataTypes/Option/Option.Extensions.Async.cs
@@ -114,7 +114,7 @@ public static partial class OptionAsyncExtensions
     /// </summary>
     /// <returns>An enumerable of zero or one items</returns>
     [Pure]
-    public static Task<Seq<A>> AsEnumerableAsync<A>(this Option<A> self) =>
+    public static Task<IEnumerable<A>> AsEnumerableAsync<A>(this Option<A> self) =>
         asEnumerableAsync<MOptionAsync<A>, OptionAsync<A>, A>(self.ToAsync());
 
     /// <summary>

--- a/LanguageExt.Core/DataTypes/Option/Option.cs
+++ b/LanguageExt.Core/DataTypes/Option/Option.cs
@@ -402,7 +402,7 @@ namespace LanguageExt
         /// </summary>
         /// <returns>An enumerable of zero or one items</returns>
         [Pure]
-        public Seq<A> AsEnumerable() =>
+        public IEnumerable<A> AsEnumerable() =>
             asEnumerable<MOption<A>, Option<A>, A>(this);
 
         [Pure]

--- a/LanguageExt.Core/DataTypes/Option/Task.Option.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Option/Task.Option.Extensions.cs
@@ -120,7 +120,7 @@ public static class TaskOptionAsyncExtensions
     /// </summary>
     /// <returns>An enumerable of zero or one items</returns>
     [Pure]
-    public static Task<Seq<A>> AsEnumerableAsync<A>(this Task<Option<A>> self) =>
+    public static Task<IEnumerable<A>> AsEnumerableAsync<A>(this Task<Option<A>> self) =>
         asEnumerableAsync<MOptionAsync<A>, OptionAsync<A>, A>(self.ToAsync());
 
     /// <summary>

--- a/LanguageExt.Core/DataTypes/OptionAsync/OptionAsync.cs
+++ b/LanguageExt.Core/DataTypes/OptionAsync/OptionAsync.cs
@@ -269,7 +269,7 @@ namespace LanguageExt
         /// </summary>
         /// <returns>An enumerable of zero or one items</returns>
         [Pure]
-        public Task<Seq<A>> AsEnumerable() =>
+        public Task<IEnumerable<A>> AsEnumerable() =>
             asEnumerableAsync<MOptionAsync<A>, OptionAsync<A>, A>(this);
 
         /// <summary>

--- a/LanguageExt.Core/DataTypes/OptionUnsafe/OptionUnsafe.cs
+++ b/LanguageExt.Core/DataTypes/OptionUnsafe/OptionUnsafe.cs
@@ -407,7 +407,7 @@ namespace LanguageExt
         /// </summary>
         /// <returns>An enumerable of zero or one items</returns>
         [Pure]
-        public Seq<A> AsEnumerable() =>
+        public IEnumerable<A> AsEnumerable() =>
             asEnumerable<MOptionUnsafe<A>, OptionUnsafe<A>, A>(this);
 
         [Pure]

--- a/LanguageExt.Core/TypeClasses/Optional/Optional.Prelude.cs
+++ b/LanguageExt.Core/TypeClasses/Optional/Optional.Prelude.cs
@@ -154,7 +154,7 @@ namespace LanguageExt
         /// <param name="ma">Option</param>
         /// <returns>An enumerable of zero or one items</returns>
         [Pure]
-        public static Seq<A> asEnumerable<OPT, OA, A>(OA ma)
+        public static IEnumerable<A> asEnumerable<OPT, OA, A>(OA ma)
             where OPT : struct, Optional<OA, A> =>
             Seq(toArray<OPT, OA, A>(ma));
 

--- a/LanguageExt.Core/TypeClasses/OptionalAsync/OptionalAsync.Prelude.cs
+++ b/LanguageExt.Core/TypeClasses/OptionalAsync/OptionalAsync.Prelude.cs
@@ -338,9 +338,9 @@ namespace LanguageExt
         /// <param name="ma">Option</param>
         /// <returns>An enumerable of zero or one items</returns>
         [Pure]
-        public static Task<Seq<A>> asEnumerableAsync<OPT, OA, A>(OA ma)
+        public static Task<IEnumerable<A>> asEnumerableAsync<OPT, OA, A>(OA ma)
             where OPT : struct, OptionalAsync<OA, A> =>
-            toArrayAsync<OPT, OA, A>(ma).Map(Prelude.Seq);
+            toArrayAsync<OPT, OA, A>(ma).Map(ar => ar.AsEnumerable());
 
         /// <summary>
         /// Convert the structure to an Either

--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Xunit;
 using LanguageExt;
@@ -114,6 +115,62 @@ namespace LanguageExt.Tests
             Assert.True(res == 10);
 
             taskOpt = optTask.Sequence();
+        }
+
+        [Fact]
+        public void ToArrayTest()
+        {
+            var x = Option<int>.None.ToAsync();
+            var arr1 = x.ToArray();
+            Assert.Equal(0, arr1.Result.Count);
+            Assert.True(arr1 is Task<Arr<int>>);
+
+            var y = SomeAsync(_ => 10);
+            var arr2 = y.ToArray();
+            Assert.Equal(1, arr2.Result.Count);
+            Assert.Equal(10, arr2.Result[0]);
+        }
+
+        [Fact]
+        public void ToListTest()
+        {
+            var x = Option<int>.None.ToAsync();
+            var lst1 = x.ToList();
+            Assert.Equal(0, lst1.Result.Count);
+            Assert.True(lst1 is Task<Lst<int>>);
+
+            var y = SomeAsync(_ => 10);
+            var lst2 = y.ToList();
+            Assert.Equal(1, lst2.Result.Count);
+            Assert.Equal(10, lst2.Result[0]);
+        }
+
+        [Fact]
+        public void ToSeqTest()
+        {
+            var x = Option<int>.None.ToAsync();
+            var seq1 = x.ToSeq();
+            Assert.Equal(0, seq1.Result.Count);
+            Assert.True(seq1 is Task<Seq<int>>);
+
+            var y = SomeAsync(_ => 10);
+            var seq2 = y.ToSeq();
+            Assert.Equal(1, seq2.Result.Count);
+            Assert.Equal(10, seq2.Result.First());
+        }
+
+        [Fact]
+        public void AsEnumerableTest()
+        {
+            var x = Option<int>.None.ToAsync();
+            var enmrbl1 = x.AsEnumerable();
+            Assert.False(enmrbl1.Result.Any());
+            Assert.True(enmrbl1 is Task<IEnumerable<int>>);
+
+            var y = SomeAsync(_ => 10);
+            var enmrbl2 = y.AsEnumerable();
+            Assert.True(enmrbl2.Result.Any());
+            Assert.Equal(10, enmrbl2.Result.First());
         }
     }
 }

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -1,6 +1,7 @@
 ﻿using Xunit;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
@@ -192,6 +193,66 @@ namespace LanguageExtTests
             int way = 0;
             var dummy = x.BiIter(_ => way = 1, () => way = 2);
             Assert.Equal(2, way);
+        }
+
+        [Fact]
+        public void ToArrayTest()
+        {
+            var x = Option<int>.None;
+            var arr1 = x.ToArray();
+            Assert.Equal(0, arr1.Count);
+#pragma warning disable CS0183 // 'is' expression's given expression is always of the provided type
+            Assert.True(arr1 is Arr<int>);
+#pragma warning restore CS0183 // 'is' expression's given expression is always of the provided type
+
+            var y = Option<int>.Some(10);
+            var arr2 = y.ToArray();
+            Assert.Equal(1, arr2.Count);
+            Assert.Equal(10, arr2[0]);
+        }
+
+        [Fact]
+        public void ToListTest()
+        {
+            var x = Option<int>.None;
+            var lst1 = x.ToList();
+            Assert.Equal(0, lst1.Count);
+#pragma warning disable CS0183 // 'is' expression's given expression is always of the provided type
+            Assert.True(lst1 is Lst<int>);
+#pragma warning restore CS0183 // 'is' expression's given expression is always of the provided type
+
+            var y = Option<int>.Some(10);
+            var lst2 = y.ToList();
+            Assert.Equal(1, lst2.Count);
+            Assert.Equal(10, lst2[0]);
+        }
+
+        [Fact]
+        public void ToSeqTest()
+        {
+            var x = Option<int>.None;
+            var seq1 = x.ToSeq();
+            Assert.Equal(0, seq1.Count);
+            Assert.True(seq1 is Seq<int>);
+
+            var y = Option<int>.Some(10);
+            var seq2 = y.ToSeq();
+            Assert.Equal(1, seq2.Count);
+            Assert.Equal(10, seq2.First());
+        }
+
+        [Fact]
+        public void AsEnumerableTest()
+        {
+            var x = Option<int>.None;
+            var enmrbl1 = x.AsEnumerable();
+            Assert.False(enmrbl1.Any());
+            Assert.True(enmrbl1 is IEnumerable<int>);
+
+            var y = Option<int>.Some(10);
+            var enmrbl2 = y.AsEnumerable();
+            Assert.True(enmrbl2.Any());
+            Assert.Equal(10, enmrbl2.First());
         }
 
         private Option<string> GetStringNone()


### PR DESCRIPTION
Hello,

I have noticed that Option.AsEnumeragle() returns Seq<T> type. (so OptionUnsafe, OptionAysnc are)
I'm not sure this is by design or not.

This PR includes that the fix of type declaration and unit tests related to fix.