### PR TITLE
Error handling exceptions in OptionAsync Match

### DIFF
--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -115,5 +115,29 @@ namespace LanguageExt.Tests
 
             taskOpt = optTask.Sequence();
         }
+
+        [Fact]
+        public async void HandlesException ()
+        {
+            Option<int> i = 1;
+            
+            await Assert.ThrowsAsync<MyException>(async () => await i.ToAsync().Match (
+                    async n =>
+                    {
+                        await DoWork();
+                        throw new MyException (n.ToString());
+                    },
+                    () => { }));
+        }
+        
+        
+
+    }
+
+    public class MyException : Exception 
+    {
+        public MyException (string message):base(message)
+        {
+        }
     }
 }


### PR DESCRIPTION
Hi,

it seems like there is a problem with Exceptions in a Match, when its thrown inside an async Action.
The unit test attached reproduces the problem.

Running in an application this problem also kills the problem, as it causes an unhandled Exception on the ThreadPool.

Regards Georg