### PR TITLE
improve null checking

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -363,20 +363,22 @@ namespace LanguageExt
 
         static class Check<T>
         {
-            static readonly bool IsValueType;
+            static readonly bool IsReferenceType;
             static readonly bool IsNullable;
+            static readonly EqualityComparer<T> DefaultEqualityComparer;
 
             static Check()
             {
                 IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
-                IsValueType = typeof(T).GetTypeInfo().IsValueType;
+                IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;
+                DefaultEqualityComparer = EqualityComparer<T>.Default;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static bool IsNull(T value) =>
                 IsNullable
                     ? value.Equals(default(T))
-                    : !IsValueType && EqualityComparer<T>.Default.Equals(value, default(T));
+                    : IsReferenceType && DefaultEqualityComparer.Equals(value, default(T));
         }
    }
 }

--- a/LanguageExt.Tests/DefaultTests.cs
+++ b/LanguageExt.Tests/DefaultTests.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {
-    public class NullDefaultTests
+    public class DefaultTests
     {
         [Fact]
         public void IsDefaultTests()

--- a/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
+++ b/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.NullChecks
+{
+    public abstract class AbstractNullCheckTests
+    {
+        protected abstract bool ExpectedWhenNull { get; }
+        protected abstract bool NullCheck<T>(T value);
+
+        protected bool ExpectedWhenNotNull => !ExpectedWhenNull;
+
+        [Fact]
+        public void NullCheck_NullString_AsExpectedWhenNull()
+        {
+            string value = null;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_HelloString_AsExpectedWhenNotNull()
+        {
+            string value = "hello";
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_ZeroInt_AsExpectedWhenNotNull()
+        {
+            int value = 0;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+
+    }
+}

--- a/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
+++ b/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
@@ -13,9 +13,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_NullObject_AsExpectedWhenNull()
         {
             object value = null;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNull, actual);
         }
 
@@ -23,9 +21,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_NonNullObject_AsExpectedWhenNotNull()
         {
             object value = new object();
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 
@@ -33,9 +29,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_NullString_AsExpectedWhenNull()
         {
             string value = null;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNull, actual);
         }
 
@@ -43,9 +37,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_HelloString_AsExpectedWhenNotNull()
         {
             string value = "hello";
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 
@@ -53,9 +45,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_NullCustomClass_AsExpectedWhenNull()
         {
             FooClass value = null;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNull, actual);
         }
 
@@ -63,19 +53,15 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_DefaultConstructorCustomClass_AsExpectedWhenNotNull()
         {
             FooClass value = new FooClass();
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
-        
+
         [Fact]
         public void NullCheck_NullNullableByte_AsExpectedWhenNull()
         {
             byte? value = null;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNull, actual);
         }
 
@@ -83,9 +69,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_ZeroNullableByte_AsExpectedWhenNotNull()
         {
             byte? value = 0;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 
@@ -93,9 +77,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_ZeroInt_AsExpectedWhenNotNull()
         {
             int value = 0;
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 
@@ -103,9 +85,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_DefaultCustomEnum_AsExpectedWhenNull()
         {
             FooEnum value = default(FooEnum);
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 
@@ -113,9 +93,7 @@ namespace LanguageExt.Tests.NullChecks
         public void NullCheck_DefaultConstructorCustomStruct_AsExpectedWhenNull()
         {
             FooStruct value = new FooStruct();
-
             var actual = NullCheck(value);
-
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
 

--- a/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
+++ b/LanguageExt.Tests/NullChecks/AbstractNullCheckTests.cs
@@ -7,7 +7,27 @@ namespace LanguageExt.Tests.NullChecks
         protected abstract bool ExpectedWhenNull { get; }
         protected abstract bool NullCheck<T>(T value);
 
-        protected bool ExpectedWhenNotNull => !ExpectedWhenNull;
+        private bool ExpectedWhenNotNull => !ExpectedWhenNull;
+
+        [Fact]
+        public void NullCheck_NullObject_AsExpectedWhenNull()
+        {
+            object value = null;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_NonNullObject_AsExpectedWhenNotNull()
+        {
+            object value = new object();
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
 
         [Fact]
         public void NullCheck_NullString_AsExpectedWhenNull()
@@ -30,6 +50,46 @@ namespace LanguageExt.Tests.NullChecks
         }
 
         [Fact]
+        public void NullCheck_NullCustomClass_AsExpectedWhenNull()
+        {
+            FooClass value = null;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_DefaultConstructorCustomClass_AsExpectedWhenNotNull()
+        {
+            FooClass value = new FooClass();
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+        
+        [Fact]
+        public void NullCheck_NullNullableByte_AsExpectedWhenNull()
+        {
+            byte? value = null;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_ZeroNullableByte_AsExpectedWhenNotNull()
+        {
+            byte? value = 0;
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+
+        [Fact]
         public void NullCheck_ZeroInt_AsExpectedWhenNotNull()
         {
             int value = 0;
@@ -38,6 +98,30 @@ namespace LanguageExt.Tests.NullChecks
 
             Assert.Equal(ExpectedWhenNotNull, actual);
         }
+
+        [Fact]
+        public void NullCheck_DefaultCustomEnum_AsExpectedWhenNull()
+        {
+            FooEnum value = default(FooEnum);
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+
+        [Fact]
+        public void NullCheck_DefaultConstructorCustomStruct_AsExpectedWhenNull()
+        {
+            FooStruct value = new FooStruct();
+
+            var actual = NullCheck(value);
+
+            Assert.Equal(ExpectedWhenNotNull, actual);
+        }
+
+        private class FooClass { }
+        private enum FooEnum { }
+        private struct FooStruct { }
 
     }
 }

--- a/LanguageExt.Tests/NullChecks/IsNullExtensionTests.cs
+++ b/LanguageExt.Tests/NullChecks/IsNullExtensionTests.cs
@@ -1,0 +1,8 @@
+﻿namespace LanguageExt.Tests.NullChecks
+{
+    public class IsNullExtensionTests : AbstractNullCheckTests
+    {
+        protected override bool ExpectedWhenNull => true;
+        protected override bool NullCheck<T>(T value) => value.IsNull();
+    }
+}

--- a/LanguageExt.Tests/NullChecks/isnullPreludeTests.cs
+++ b/LanguageExt.Tests/NullChecks/isnullPreludeTests.cs
@@ -1,0 +1,8 @@
+﻿namespace LanguageExt.Tests.NullChecks
+{
+    public class isnullPreludeTests : AbstractNullCheckTests
+    {
+        protected override bool ExpectedWhenNull => true;
+        protected override bool NullCheck<T>(T value) => Prelude.isnull(value);
+    }
+}

--- a/LanguageExt.Tests/NullChecks/notnullPreludeTests.cs
+++ b/LanguageExt.Tests/NullChecks/notnullPreludeTests.cs
@@ -1,0 +1,8 @@
+﻿namespace LanguageExt.Tests.NullChecks
+{
+    public class notnullPreludeTests : AbstractNullCheckTests
+    {
+        protected override bool ExpectedWhenNull => false;
+        protected override bool NullCheck<T>(T value) => Prelude.notnull(value);
+    }
+}

--- a/LanguageExt.Tests/NullDefaultTests.cs
+++ b/LanguageExt.Tests/NullDefaultTests.cs
@@ -9,35 +9,6 @@ namespace LanguageExt.Tests
     public class NullDefaultTests
     {
         [Fact]
-        public void IsNullTests()
-        {
-            string x = null;
-            string y = "hello";
-            int z = 0;
-
-            Assert.True(x.IsNull());
-            Assert.True(isnull(x));
-
-            Assert.False(y.IsNull());
-            Assert.False(isnull(y));
-
-            Assert.False(z.IsNull());
-            Assert.False(isnull(z));
-        }
-
-        [Fact]
-        public void NotNullTests()
-        {
-            string x = null;
-            string y = "hello";
-            int z = 0;
-
-            Assert.False(notnull(x));
-            Assert.True(notnull(y));
-            Assert.True(notnull(z));
-        }
-
-        [Fact]
         public void IsDefaultTests()
         {
             string x = null;


### PR DESCRIPTION
I refactored the tests for `object` extension method `IsNull` and `Prelude` methods `isnull` and `notnull` so that each test includes exactly one assert while also not duplicating any code.  I added more tests, especially tests for `null` and not `null` values of a `Nullable<>` type.  Then I slightly improved the readability of the implementation of `Check<T>.IsNull`.