### PR TITLE
moved None from Prelude to Option.Prelude

### DIFF
--- a/LanguageExt.Core/DataTypes/Option/Option.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/Option/Option.Prelude.cs
@@ -66,6 +66,12 @@ namespace LanguageExt
             value.IsNone;
 
         /// <summary>
+        /// 'No value' state of Option T.
+        /// </summary>
+        public static OptionNone None =>
+            OptionNone.Default;
+
+        /// <summary>
         /// Create a Some of T (Option<T>)
         /// </summary>
         /// <typeparam name="T">T</typeparam>

--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -28,12 +28,6 @@ namespace LanguageExt
     public static partial class Prelude
     {
         /// <summary>
-        /// 'No value' state of Option T.
-        /// </summary>
-        public static OptionNone None =>
-            OptionNone.Default;
-
-        /// <summary>
         /// Unit constructor
         /// </summary>
         public static Unit unit =>


### PR DESCRIPTION
Moved the location of `public static OptionNone None` from `Prelude.cs` to `Option.Prelude.cs`.