### PR TITLE
Feature/reorganize null checking code

### DIFF
--- a/LanguageExt.Core/Extensions/ObjectExt.cs
+++ b/LanguageExt.Core/Extensions/ObjectExt.cs
@@ -41,15 +41,15 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNull<T>(this T value) =>
-            NullChecker<T>.IsNull(value);
+            Check<T>.IsNull(value);
 
-        private static class NullChecker<T>
+        private static class Check<T>
         {
             static readonly bool IsReferenceType;
             static readonly bool IsNullable;
             static readonly EqualityComparer<T> DefaultEqualityComparer;
 
-            static NullChecker()
+            static Check()
             {
                 IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
                 IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;

--- a/LanguageExt.Core/Extensions/ObjectExt.cs
+++ b/LanguageExt.Core/Extensions/ObjectExt.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace LanguageExt
 {

--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -330,7 +330,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool isnull<T>(T value) =>
-            Check<T>.IsNull(value);
+            NullChecker<T>.IsNull(value);
 
         /// <summary>
         /// Returns true if the value is not null, and does so without
@@ -352,7 +352,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool notnull<T>(T value) =>
-            !Check<T>.IsNull(value);
+            !NullChecker<T>.IsNull(value);
 
         /// <summary>
         /// Convert a value to string
@@ -361,13 +361,13 @@ namespace LanguageExt
         public static string toString<T>(T value) =>
             value?.ToString();
 
-        static class Check<T>
+        static class NullChecker<T>
         {
             static readonly bool IsReferenceType;
             static readonly bool IsNullable;
             static readonly EqualityComparer<T> DefaultEqualityComparer;
 
-            static Check()
+            static NullChecker()
             {
                 IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
                 IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;

--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -330,7 +330,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool isnull<T>(T value) =>
-            NullChecker<T>.IsNull(value);
+            value.IsNull();
 
         /// <summary>
         /// Returns true if the value is not null, and does so without
@@ -352,7 +352,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool notnull<T>(T value) =>
-            !NullChecker<T>.IsNull(value);
+            !isnull(value);
 
         /// <summary>
         /// Convert a value to string
@@ -360,25 +360,5 @@ namespace LanguageExt
         [Pure]
         public static string toString<T>(T value) =>
             value?.ToString();
-
-        static class NullChecker<T>
-        {
-            static readonly bool IsReferenceType;
-            static readonly bool IsNullable;
-            static readonly EqualityComparer<T> DefaultEqualityComparer;
-
-            static NullChecker()
-            {
-                IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
-                IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;
-                DefaultEqualityComparer = EqualityComparer<T>.Default;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static bool IsNull(T value) =>
-                IsNullable
-                    ? value.Equals(default(T))
-                    : IsReferenceType && DefaultEqualityComparer.Equals(value, default(T));
-        }
    }
 }

--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
Rearranged the decencies among the null checking methods.  Now, `Prelude.notnull` depends on `Prelude.isnull` which depends on the `IsNull` extension method.  My motivation for this change is to move some complexity from the higher complexity file `Prelude.cs` to to the lower complexity file `ObjectExt.cs`.