### PR TITLE
improve parse methods

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -28,7 +28,7 @@ namespace LanguageExt
         public static Option<long> parseLong(string value)
         {
             long result;
-            return Int64.TryParse(value, out result)
+            return long.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -37,7 +37,7 @@ namespace LanguageExt
         public static Option<int> parseInt(string value)
         {
             int result;
-            return Int32.TryParse(value, out result)
+            return int.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -59,7 +59,7 @@ namespace LanguageExt
         public static Option<short> parseShort(string value)
         {
             short result;
-            return Int16.TryParse(value, out result)
+            return short.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -68,7 +68,7 @@ namespace LanguageExt
         public static Option<char> parseChar(string value)
         {
             char result;
-            return Char.TryParse(value, out result)
+            return char.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -77,7 +77,7 @@ namespace LanguageExt
         public static Option<byte> parseByte(string value)
         {
             byte result;
-            return Byte.TryParse(value, out result)
+            return byte.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -86,7 +86,7 @@ namespace LanguageExt
         public static Option<ulong> parseULong(string value)
         {
             ulong result;
-            return UInt64.TryParse(value, out result)
+            return ulong.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -95,7 +95,7 @@ namespace LanguageExt
         public static Option<uint> parseUInt(string value)
         {
             uint result;
-            return UInt32.TryParse(value, out result)
+            return uint.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }
@@ -104,7 +104,7 @@ namespace LanguageExt
         public static Option<ushort> parseUShort(string value)
         {
             ushort result;
-            return UInt16.TryParse(value, out result)
+            return ushort.TryParse(value, out result)
                 ? Some(result)
                 : None;
         }

--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -25,22 +25,12 @@ namespace LanguageExt
         }
 
         [Pure]
-        public static Option<long> parseLong(string value)
-        {
-            long result;
-            return long.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<long> parseLong(string value) =>
+            Parse<long>(long.TryParse, value);
 
         [Pure]
-        public static Option<int> parseInt(string value)
-        {
-            int result;
-            return int.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<int> parseInt(string value) =>
+            Parse<int>(int.TryParse, value);
 
         [Pure]
         public static Option<int> parseInt(string value, int fromBase)
@@ -56,121 +46,63 @@ namespace LanguageExt
         }
 
         [Pure]
-        public static Option<short> parseShort(string value)
-        {
-            short result;
-            return short.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<short> parseShort(string value) =>
+            Parse<short>(short.TryParse, value);
 
         [Pure]
-        public static Option<char> parseChar(string value)
-        {
-            char result;
-            return char.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<char> parseChar(string value) =>
+            Parse<char>(char.TryParse, value);
 
         [Pure]
-        public static Option<byte> parseByte(string value)
-        {
-            byte result;
-            return byte.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<byte> parseByte(string value) =>
+            Parse<byte>(byte.TryParse, value);
 
         [Pure]
-        public static Option<ulong> parseULong(string value)
-        {
-            ulong result;
-            return ulong.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<ulong> parseULong(string value) =>
+            Parse<ulong>(ulong.TryParse, value);
 
         [Pure]
-        public static Option<uint> parseUInt(string value)
-        {
-            uint result;
-            return uint.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<uint> parseUInt(string value) =>
+            Parse<uint>(uint.TryParse, value);
 
         [Pure]
-        public static Option<ushort> parseUShort(string value)
-        {
-            ushort result;
-            return ushort.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<ushort> parseUShort(string value) =>
+            Parse<ushort>(ushort.TryParse, value);
 
         [Pure]
-        public static Option<float> parseFloat(string value)
-        {
-            float result;
-            return float.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<float> parseFloat(string value) =>
+            Parse<float>(float.TryParse, value);
 
         [Pure]
-        public static Option<double> parseDouble(string value)
-        {
-            double result;
-            return double.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<double> parseDouble(string value) =>
+            Parse<double>(double.TryParse, value);
 
         [Pure]
-        public static Option<decimal> parseDecimal(string value)
-        {
-            decimal result;
-            return decimal.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<decimal> parseDecimal(string value) =>
+            Parse<decimal>(decimal.TryParse, value);
 
         [Pure]
-        public static Option<bool> parseBool(string value)
-        {
-            bool result;
-            return bool.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<bool> parseBool(string value) =>
+            Parse<bool>(bool.TryParse, value);
 
         [Pure]
-        public static Option<Guid> parseGuid(string value)
-        {
-            Guid result;
-            return Guid.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<Guid> parseGuid(string value) =>
+            Parse<Guid>(Guid.TryParse, value);
 
         [Pure]
-        public static Option<DateTime> parseDateTime(string value)
-        {
-            DateTime result;
-            return DateTime.TryParse(value, out result)
-                ? Some(result)
-                : None;
-        }
+        public static Option<DateTime> parseDateTime(string value) =>
+            Parse<DateTime>(DateTime.TryParse, value);
 
         [Pure]
         public static Option<TEnum> parseEnum<TEnum>(string value)
-            where TEnum : struct
-        {
-            TEnum result;
-            return Enum.TryParse(value, out result)
+            where TEnum : struct =>
+            Parse<TEnum>(Enum.TryParse, value);
+
+        private delegate bool TryParse<T>(string value, out T result);
+
+        private static Option<T> Parse<T>(TryParse<T> tryParse, string value) =>
+            tryParse(value, out T result)
                 ? Some(result)
                 : None;
-        }
     }
 }

--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -165,7 +165,7 @@ namespace LanguageExt
 
         [Pure]
         public static Option<TEnum> parseEnum<TEnum>(string value)
-            where TEnum: struct
+            where TEnum : struct
         {
             TEnum result;
             return Enum.TryParse(value, out result)

--- a/LanguageExt.Tests/Parsing/AbstractParseTPrecisionIntervalTests.cs
+++ b/LanguageExt.Tests/Parsing/AbstractParseTPrecisionIntervalTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public abstract class AbstractParseTPrecisionIntervalTests<T>
+        : AbstractParseTTests<T>
+        where T : struct
+    {
+        protected abstract T MinValue { get; }
+        protected abstract T MaxValue { get; }
+
+        [Fact]
+        public void ParseT_ValidStringFromMinValue_SomeMinValue() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(MinValue);
+
+        [Fact]
+        public void ParseT_ValidStringFromMaxValue_SomeMaxValue() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(MaxValue);
+
+    }
+}

--- a/LanguageExt.Tests/Parsing/AbstractParseTSignedPrecisionIntervalTests.cs
+++ b/LanguageExt.Tests/Parsing/AbstractParseTSignedPrecisionIntervalTests.cs
@@ -1,0 +1,21 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public abstract class AbstractParseTSignedPrecisionIntervalTests<T>
+        : AbstractParseTPrecisionIntervalTests<T>
+        where T : struct
+    {
+        protected abstract T NegativeOne { get; }
+        protected abstract T PositiveOne { get; }
+
+        [Fact]
+        public void ParseT_ValidStringFromNegativeOne_SomeNegativeOne() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(NegativeOne);
+
+        [Fact]
+        public void ParseT_ValidStringFromPositiveOne_SomePositiveOne() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(PositiveOne);
+
+    }
+}

--- a/LanguageExt.Tests/Parsing/AbstractParseTTests.cs
+++ b/LanguageExt.Tests/Parsing/AbstractParseTTests.cs
@@ -1,0 +1,38 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public abstract class AbstractParseTTests<T> where T : struct
+    {
+        protected abstract Option<T> ParseT(string value);
+
+        [Fact]
+        public void ParseT_NullString_None()
+        {
+            Option<T> expected = None;
+            var actual = ParseT(null);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseT_EmptyString_None()
+        {
+            Option<T> expected = None;
+            var actual = ParseT("");
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ParseT_ValidStringFromDefaultValue_SomeDefaultValue() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(default(T));
+
+        protected void ParseT_ValidStringFromGiven_SomeAsGiven(T expected)
+        {
+            var value = expected.ToString();
+            var actual = ParseT(value);
+            Assert.Equal(expected, actual);
+        }
+
+    }
+}

--- a/LanguageExt.Tests/Parsing/AbstractParseTUnsignedPrecisionIntervalTests.cs
+++ b/LanguageExt.Tests/Parsing/AbstractParseTUnsignedPrecisionIntervalTests.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public abstract class AbstractParseTUnsignedPrecisionIntervalTests<T>
+        : AbstractParseTPrecisionIntervalTests<T>
+        where T : struct
+    {
+        protected abstract T PositiveOne { get; }
+        protected abstract T PositiveTwo { get; }
+
+        [Fact]
+        public void ParseT_ValidStringFromPositiveOne_SomePositiveOne() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(PositiveOne);
+
+        [Fact]
+        public void ParseT_ValidStringFromPositiveTwo_SomePositiveTwo() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(PositiveTwo);
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseBoolTests.cs
+++ b/LanguageExt.Tests/Parsing/parseBoolTests.cs
@@ -1,0 +1,13 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseBoolTests : AbstractParseTTests<bool>
+    {
+        protected override Option<bool> ParseT(string value) => Prelude.parseBool(value);
+
+        [Fact]
+        public void parseBool_ValidStringFromTrue_SomeTrue() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(true);
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseByteTests.cs
+++ b/LanguageExt.Tests/Parsing/parseByteTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseByteTests : AbstractParseTUnsignedPrecisionIntervalTests<byte>
+    {
+        protected override Option<byte> ParseT(string value) => Prelude.parseByte(value);
+
+        protected override byte MinValue => byte.MinValue;
+        protected override byte MaxValue => byte.MaxValue;
+        protected override byte PositiveOne => 1;
+        protected override byte PositiveTwo => 2;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseCharTests.cs
+++ b/LanguageExt.Tests/Parsing/parseCharTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseCharTests : AbstractParseTPrecisionIntervalTests<char>
+    {
+        protected override Option<char> ParseT(string value) => Prelude.parseChar(value);
+
+        protected override char MinValue => char.MinValue;
+        protected override char MaxValue => char.MaxValue;
+
+        [Theory]
+        [InlineData('a')]
+        [InlineData('1')]
+        [InlineData(' ')]
+        public void parseChar_ValidStringFromGiven_SomeAsGiven(char value) =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(value);
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseDateTimeTests.cs
+++ b/LanguageExt.Tests/Parsing/parseDateTimeTests.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseDateTimeTests : AbstractParseTTests<DateTime>
+    {
+        protected override Option<DateTime> ParseT(string value) => Prelude.parseDateTime(value);
+
+        [Fact]
+        public void parseDateTime_ValidStringFromNewMillennium_SomeNewMillennium() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(new DateTime(2001, 1, 1));
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseDecimalTests.cs
+++ b/LanguageExt.Tests/Parsing/parseDecimalTests.cs
@@ -1,0 +1,10 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseDecimalTests : AbstractParseTPrecisionIntervalTests<decimal>
+    {
+        protected override Option<decimal> ParseT(string value) => Prelude.parseDecimal(value);
+
+        protected override decimal MinValue => decimal.MinValue;
+        protected override decimal MaxValue => decimal.MaxValue;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseDoubleTests.cs
+++ b/LanguageExt.Tests/Parsing/parseDoubleTests.cs
@@ -1,0 +1,18 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseDoubleTests : AbstractParseTTests<double>
+    {
+        protected override Option<double> ParseT(string value) => Prelude.parseDouble(value);
+
+        [Theory]
+        [InlineData(0.5)]
+        [InlineData(-0.5)]
+        [InlineData(double.Epsilon)]
+        [InlineData(double.NegativeInfinity)]
+        [InlineData(double.PositiveInfinity)]
+        public void parseDouble_ValidStringFromGiven_SomeAsGiven(double value) =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(value);
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseEnumTests.cs
+++ b/LanguageExt.Tests/Parsing/parseEnumTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseEnumTests : AbstractParseTTests<FooBarEnum>
+    {
+        protected override Option<FooBarEnum> ParseT(string value) => Prelude.parseEnum<FooBarEnum>(value);
+
+        [Fact]
+        public void parseEnum_ValidStringFromFoo_SomeFoo() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(FooBarEnum.Foo);
+
+        [Fact]
+        public void parseEnum_ValidStringFromBar_SomeBar() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(FooBarEnum.Bar);
+
+    }
+
+    public enum FooBarEnum
+    {
+        Foo,
+        Bar
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseFloatTests.cs
+++ b/LanguageExt.Tests/Parsing/parseFloatTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseFloatTests : AbstractParseTTests<float>
+    {
+        protected override Option<float> ParseT(string value) => Prelude.parseFloat(value);
+
+        [Theory]
+        [InlineData(0.5)]
+        [InlineData(-0.5)]
+        [InlineData(float.Epsilon)]
+        [InlineData(float.NegativeInfinity)]
+        [InlineData(float.PositiveInfinity)]
+        [InlineData(float.NaN)]
+        public void parseFloat_ValidStringFromGiven_SomeAsGiven(float value) =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(value);
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseGuidTests.cs
+++ b/LanguageExt.Tests/Parsing/parseGuidTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseGuidTests : AbstractParseTTests<Guid>
+    {
+        protected override Option<Guid> ParseT(string value) => Prelude.parseGuid(value);
+
+        [Fact]
+        public void ParseGuid_ValidStringFixedGuid_SomeOfSameFixedGuid()
+        {
+            var guid = Guid.Parse("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4");
+            ParseT_ValidStringFromGiven_SomeAsGiven(guid);
+        }
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseIntTests.cs
+++ b/LanguageExt.Tests/Parsing/parseIntTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseIntTests : AbstractParseTSignedPrecisionIntervalTests<int>
+    {
+        protected override Option<int> ParseT(string value) => Prelude.parseInt(value);
+
+        protected override int MinValue => int.MinValue;
+        protected override int MaxValue => int.MaxValue;
+        protected override int NegativeOne => -1;
+        protected override int PositiveOne => 1;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseLongTests.cs
+++ b/LanguageExt.Tests/Parsing/parseLongTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseLongTests : AbstractParseTSignedPrecisionIntervalTests<long>
+    {
+        protected override Option<long> ParseT(string value) => Prelude.parseLong(value);
+
+        protected override long MinValue => long.MinValue;
+        protected override long MaxValue => long.MaxValue;
+        protected override long NegativeOne => -1;
+        protected override long PositiveOne => 1;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseShortTests.cs
+++ b/LanguageExt.Tests/Parsing/parseShortTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseShortTests : AbstractParseTSignedPrecisionIntervalTests<short>
+    {
+        protected override Option<short> ParseT(string value) => Prelude.parseShort(value);
+
+        protected override short MinValue => short.MinValue;
+        protected override short MaxValue => short.MaxValue;
+        protected override short NegativeOne => -1;
+        protected override short PositiveOne => 1;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseUIntTests.cs
+++ b/LanguageExt.Tests/Parsing/parseUIntTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseUIntTests : AbstractParseTUnsignedPrecisionIntervalTests<uint>
+    {
+        protected override Option<uint> ParseT(string value) => Prelude.parseUInt(value);
+
+        protected override uint MinValue => uint.MinValue;
+        protected override uint MaxValue => uint.MaxValue;
+        protected override uint PositiveOne => 1;
+        protected override uint PositiveTwo => 2;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseULongTests.cs
+++ b/LanguageExt.Tests/Parsing/parseULongTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseULongTests : AbstractParseTUnsignedPrecisionIntervalTests<ulong>
+    {
+        protected override Option<ulong> ParseT(string value) => Prelude.parseULong(value);
+
+        protected override ulong MinValue => ulong.MinValue;
+        protected override ulong MaxValue => ulong.MaxValue;
+        protected override ulong PositiveOne => 1;
+        protected override ulong PositiveTwo => 2;
+    }
+}

--- a/LanguageExt.Tests/Parsing/parseUShortTests.cs
+++ b/LanguageExt.Tests/Parsing/parseUShortTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseUShortTests : AbstractParseTUnsignedPrecisionIntervalTests<ushort>
+    {
+        protected override Option<ushort> ParseT(string value) => Prelude.parseUShort(value);
+
+        protected override ushort MinValue => ushort.MinValue;
+        protected override ushort MaxValue => ushort.MaxValue;
+        protected override ushort PositiveOne => 1;
+        protected override ushort PositiveTwo => 2;
+    }
+}


### PR DESCRIPTION
Added several tests for the family of `parseT` methods for various types `T`.  Then extracted the common logic from the implementation of those methods.

I learned two interesting things during this work.

First, the C# type system is smart enough to know that `Parse<int>(long.TryParse, value)` doesn't makes sense but not smart enough to infer that the type parameter must be `long`.

Second, `double.NaN` _cannot_ be parsed but `float.NaN` _can_.  More specifically,
```
double.TryParse(double.NaN.ToString(), out double result)
```
returns `false` but
```
float.TryParse(float.NaN.ToString(), out float result)
```
returns `true`.