### PR TITLE
utilzing the Check class to implement IsDefault extension method

### DIFF
--- a/LanguageExt.Core/Extensions/ObjectExt.cs
+++ b/LanguageExt.Core/Extensions/ObjectExt.cs
@@ -45,14 +45,12 @@ namespace LanguageExt
 
         private static class Check<T>
         {
-            static readonly T DefaultT;
             static readonly bool IsReferenceType;
             static readonly bool IsNullable;
             static readonly EqualityComparer<T> DefaultEqualityComparer;
 
             static Check()
             {
-                DefaultT = default(T);
                 IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
                 IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;
                 DefaultEqualityComparer = EqualityComparer<T>.Default;
@@ -60,13 +58,13 @@ namespace LanguageExt
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static bool IsDefault(T value) =>
-                DefaultEqualityComparer.Equals(value, DefaultT);
+                DefaultEqualityComparer.Equals(value, default(T));
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static bool IsNull(T value) =>
                 IsNullable
-                    ? value.Equals(DefaultT)
-                    : IsReferenceType && DefaultEqualityComparer.Equals(value, DefaultT);
+                    ? value.Equals(default(T))
+                    : IsReferenceType && DefaultEqualityComparer.Equals(value, default(T));
         }
     }
 }

--- a/LanguageExt.Core/Extensions/ObjectExt.cs
+++ b/LanguageExt.Core/Extensions/ObjectExt.cs
@@ -21,7 +21,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsDefault<T>(this T value) =>
-            EqualityComparer<T>.Default.Equals(value, default(T));
+            Check<T>.IsDefault(value);
 
         /// <summary>
         /// Returns true if the value is null, and does so without
@@ -45,22 +45,28 @@ namespace LanguageExt
 
         private static class Check<T>
         {
+            static readonly T DefaultT;
             static readonly bool IsReferenceType;
             static readonly bool IsNullable;
             static readonly EqualityComparer<T> DefaultEqualityComparer;
 
             static Check()
             {
+                DefaultT = default(T);
                 IsNullable = Nullable.GetUnderlyingType(typeof(T)) != null;
                 IsReferenceType = !typeof(T).GetTypeInfo().IsValueType;
                 DefaultEqualityComparer = EqualityComparer<T>.Default;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static bool IsDefault(T value) =>
+                DefaultEqualityComparer.Equals(value, DefaultT);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal static bool IsNull(T value) =>
                 IsNullable
-                    ? value.Equals(default(T))
-                    : IsReferenceType && DefaultEqualityComparer.Equals(value, default(T));
+                    ? value.Equals(DefaultT)
+                    : IsReferenceType && DefaultEqualityComparer.Equals(value, DefaultT);
         }
     }
 }


### PR DESCRIPTION
The extension method `IsDefault` is now defined via the `Check<T>` class.