### PR TITLE
adds parseDateTimeOffset and tests

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -94,6 +94,10 @@ namespace LanguageExt
             Parse<DateTime>(DateTime.TryParse, value);
 
         [Pure]
+        public static Option<DateTimeOffset> parseDateTimeOffset(string value) =>
+            Parse<DateTimeOffset>(DateTimeOffset.TryParse, value);
+
+        [Pure]
         public static Option<TEnum> parseEnum<TEnum>(string value)
             where TEnum : struct =>
             Parse<TEnum>(Enum.TryParse, value);

--- a/LanguageExt.Tests/Parsing/parseDateTimeOffsetTests.cs
+++ b/LanguageExt.Tests/Parsing/parseDateTimeOffsetTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Xunit;
+
+namespace LanguageExt.Tests.Parsing
+{
+    public class parseDateTimeOffsetTests : AbstractParseTTests<DateTimeOffset>
+    {
+        protected override Option<DateTimeOffset> ParseT(string value) => Prelude.parseDateTimeOffset(value);
+
+        [Fact]
+        public void parseDateTimeOffset_ValidStringFromNewMillennium_SomeUtc() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(new DateTimeOffset(2001, 1, 1, 12, 0, 0, 0 * Prelude.hours));
+
+        [Fact]
+        public void parseDateTimeOffset_ValidStringFromNewMillennium_SomeBerlin() =>
+            ParseT_ValidStringFromGiven_SomeAsGiven(new DateTimeOffset(2001, 1, 1, 12, 0, 0, 1 * Prelude.hours));
+
+        [Fact]
+        public void parseDateTimeOffset_ISO8601_SomeBerlin() =>
+            Assert.Equal(Prelude.Some(new DateTimeOffset(2018, 1, 25, 15, 32, 5, 1 * Prelude.hours)), Prelude.parseDateTimeOffset("2018-01-25T15:32:05+01:00"));
+
+        [Fact]
+        public void parseDateTimeOffset_ISO8601_SomeUtc() =>
+            Assert.Equal(Prelude.Some(new DateTimeOffset(2018, 1, 25, 15, 32, 5, 0 * Prelude.hours)), Prelude.parseDateTimeOffset("2018-01-25T15:32:05Z"));
+
+        [Fact]
+        public void parseDateTimeOffset_Universal_SomeBerlin() =>
+            Assert.Equal(Prelude.Some(new DateTimeOffset(2018, 1, 25, 15, 32, 5, 1 * Prelude.hours)), Prelude.parseDateTimeOffset("2018-01-25 15:32:05+01:00"));
+
+        [Fact]
+        public void parseDateTimeOffset_Universal_SomeUtc() =>
+            Assert.Equal(Prelude.Some(new DateTimeOffset(2018, 1, 25, 15, 32, 5, 0 * Prelude.hours)), Prelude.parseDateTimeOffset("2018-01-25 15:32:05Z"));
+
+    }
+}


### PR DESCRIPTION
DateTimeOffset is more useful than DateTime for fixed points in time because it has timezone information.

This pull request adds parseDateTimeOffset.