### PR TITLE
IEnumerable.Map invokes lambda exactly once for each element

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Module.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Module.cs
@@ -153,7 +153,7 @@ namespace LanguageExt
         /// <returns>Mapped enumerable</returns>
         [Pure]
         public static IEnumerable<R> map<T, R>(IEnumerable<T> list, Func<T, R> map) =>
-            list.Select(map);
+            list.Select(map).ToList();
 
         /// <summary>
         /// Partial application map

--- a/LanguageExt.Tests/EnumerableTTests.cs
+++ b/LanguageExt.Tests/EnumerableTTests.cs
@@ -51,6 +51,22 @@ namespace LanguageExtTests
             Assert.True(Enumerable.SequenceEqual(actual, expected), $"Expected {toString(expected)} but was {toString(actual)}");
         }
 
+        [Fact]
+        public void EnumerableMapIsCalculatedOnceTest() {
+            var n = 1;
+
+            int NextValue() {
+                return n++;
+            }
+
+            var actual = Enumerable.Range(0, 5).Map(_ => NextValue());
+            var expected = List(1, 2, 3, 4, 5);
+            Assert.True(Enumerable.SequenceEqual(actual, expected), $"Expected {toString(expected)} but was {toString(actual)}");
+            
+            // ensure the result of Map isn't recalculated each time it's iterated over
+            Assert.True(Enumerable.SequenceEqual(actual, expected), $"Expected {toString(expected)} but was {toString(actual)}");
+        }
+        
         //[Fact]
         //public void WrappedMapTest()
         //{


### PR DESCRIPTION
Was broken for Iterators.
Fixes issue #374