### PR TITLE
Simplify seq list construction

### DIFF
--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -36,10 +36,10 @@ namespace LanguageExt
         public override bool IsEmpty =>
             false;
 
-        public static Seq<A> New(IList<A> seq, int index = 0, int count = -1) =>
-            seq.Count == 0
+        public static Seq<A> New(IList<A> list, int index = 0, int count = -1) =>
+            list.Count == 0
                 ? Empty
-                : new SeqList<A>(seq, index, count);
+                : new SeqList<A>(list, index, count);
 
         /// <summary>
         /// Stream as an enumerable

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -66,7 +66,7 @@ namespace LanguageExt
         /// </summary>
         public override Seq<A> Skip(int skipCount)
         {
-            if (skipCount == 0) return this;
+            if (skipCount <= 0) return this;
             if (skipCount >= count) return Empty;
             return new SeqList<A>(list, index + skipCount, count - skipCount);
         }

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -22,9 +22,7 @@ namespace LanguageExt
         {
             this.list = list;
             this.index = index;
-            this.count = count == -1
-                ? list.Count - index
-                : count;
+            this.count = count;
         }
 
         public override int Count =>
@@ -39,7 +37,9 @@ namespace LanguageExt
         public static Seq<A> New(IList<A> list, int index = 0, int count = -1) =>
             list.Count == 0
                 ? Empty
-                : new SeqList<A>(list, index, count);
+                : new SeqList<A>(list, index, count == -1
+                  ? list.Count - index
+                  : count);
 
         /// <summary>
         /// Stream as an enumerable

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -34,12 +34,10 @@ namespace LanguageExt
         public override bool IsEmpty =>
             false;
 
-        public static Seq<A> New(IList<A> list, int index = 0, int count = -1) =>
+        public static Seq<A> New(IList<A> list) =>
             list.Count == 0
                 ? Empty
-                : new SeqList<A>(list, index, count == -1
-                  ? list.Count - index
-                  : count);
+                : new SeqList<A>(list, 0, list.Count);
 
         /// <summary>
         /// Stream as an enumerable

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -5,6 +5,12 @@ namespace LanguageExt
 {
     internal class SeqList<A> : Seq<A>
     {
+        /*
+         * These fields satisfy
+         * 0 <= index <  list.Count
+         * 0 <  count <= list.Count
+         * 0 < index + count <= list.Count
+         */
         readonly IList<A> list;
         readonly int index;
         readonly int count;

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -107,10 +107,12 @@ namespace LanguageExt
             return true;
         }
 
-        public override Seq<A> Take(int takeCount) =>
-            takeCount > 0 && takeCount < count
-                ? new SeqList<A>(list, index, takeCount)
-                : this;
+        public override Seq<A> Take(int takeCount)
+        {
+            if (takeCount <= 0) return this;
+            if (takeCount >= count) return this;
+            return new SeqList<A>(list, index, takeCount);
+        }
 
         public override Seq<A> TakeWhile(Func<A, bool> pred)
         {

--- a/LanguageExt.Core/DataTypes/Seq/SeqList.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqList.cs
@@ -109,7 +109,7 @@ namespace LanguageExt
 
         public override Seq<A> Take(int takeCount)
         {
-            if (takeCount <= 0) return this;
+            if (takeCount <= 0) return Empty;
             if (takeCount >= count) return this;
             return new SeqList<A>(list, index, takeCount);
         }

--- a/LanguageExt.Tests/SeqTypes/SeqListTests.cs
+++ b/LanguageExt.Tests/SeqTypes/SeqListTests.cs
@@ -22,5 +22,13 @@ namespace LanguageExt.Tests.SeqTypes
             Assert.Equal(actual, SeqEmpty.Default);
         }
 
+        [Fact]
+        public void Skip_NegativeFromNonempty_Unchanged()
+        {
+            var expected = Seq(new List<int> { 0 });
+            var actual = expected.Skip(-1);
+            Assert.Equal(actual, expected);
+        }
+
     }
 }

--- a/LanguageExt.Tests/SeqTypes/SeqListTests.cs
+++ b/LanguageExt.Tests/SeqTypes/SeqListTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.SeqTypes
+{
+    public class SeqListTests
+    {
+        [Fact]
+        public void Take_ZeroFromNonempty_Empty()
+        {
+            var seq = Seq(new List<int> { 0 });
+            var actual = seq.Take(0);
+            Assert.Equal(actual, SeqEmpty.Default);
+        }
+
+        [Fact]
+        public void Take_NegativeFromNonempty_Empty()
+        {
+            var seq = Seq(new List<int> { 0 });
+            var actual = seq.Take(-1);
+            Assert.Equal(actual, SeqEmpty.Default);
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes issues raised in #383.  In particular, I modified `Skip` and `Take` to make their outputs match that from their counterparts on `Enumerable`.