### PR TITLE
Remove dead task inspection code

### DIFF
--- a/LanguageExt.Core/ClassInstances/Applicative/ApplTask.cs
+++ b/LanguageExt.Core/ClassInstances/Applicative/ApplTask.cs
@@ -131,10 +131,6 @@ namespace LanguageExt.ClassInstances
         public async Task<A> Apply(Task<Func<A, A>> fab, Task<A> fa)
         {
             await Task.WhenAll(fab, fa);
-
-            if (fab.IsFaulted) throw fab.Exception;
-            if (fa.IsFaulted) throw fa.Exception;
-
             return (await fab)(await fa);
         }
 

--- a/LanguageExt.Core/ClassInstances/Monad/MTaskFirst.cs
+++ b/LanguageExt.Core/ClassInstances/Monad/MTaskFirst.cs
@@ -149,10 +149,7 @@ namespace LanguageExt.ClassInstances
         public async Task<A> Apply(Func<A, A, A> f, Task<A> fa, Task<A> fb) 
         {
             await Task.WhenAll(fa, fb);
-            return fa.IsFaulted && fb.IsFaulted ? throw new AggregateException(fa.Exception, fb.Exception)
-                 : fa.IsFaulted                 ? throw new InnerException(fa.Exception)
-                 : fb.IsFaulted                 ? throw new InnerException(fb.Exception)
-                 : f(fa.Result, fb.Result);
+            f(fa.Result, fb.Result);
         }
 
         public async Task<B> MatchAsync<B>(Task<A> ma, Func<A, Task<B>> SomeAsync, Func<B> None)


### PR DESCRIPTION
As discussed in #377, removes the dead `Task` inspection code in cases where an exception was going to be thrown anyway.  I am not completely sure about the desired behavior for the remaining cases.  I will ask about them in #377.