### PR TITLE
now passing call to namof to ArgumentNullException constructor

### DIFF
--- a/LanguageExt.Core/ClassInstances/Monad/MOption.cs
+++ b/LanguageExt.Core/ClassInstances/Monad/MOption.cs
@@ -150,7 +150,7 @@ namespace LanguageExt.ClassInstances
         [Pure]
         public Option<A> Some(A x) =>
             x.IsNull()
-                ? throw new ArgumentNullException("Option doesn't support null values.  Use OptionUnsafe if this is desired behaviour")
+                ? throw new ArgumentNullException(nameof(x), "Option doesn't support null values.  Use OptionUnsafe if this is desired behaviour")
                 : new Option<A>(OptionData.Some(x));
 
         [Pure]

--- a/LanguageExt.Core/ClassInstances/Monad/MOptionAsync.cs
+++ b/LanguageExt.Core/ClassInstances/Monad/MOptionAsync.cs
@@ -204,7 +204,7 @@ namespace LanguageExt.ClassInstances
         [Pure]
         public OptionAsync<A> SomeAsync(A x) =>
             x.IsNull()
-                ? throw new ArgumentNullException("Option doesn't support null values.  Use OptionUnsafe if this is desired behaviour")
+                ? throw new ArgumentNullException(nameof(x), "Option doesn't support null values.  Use OptionUnsafe if this is desired behaviour")
                 : new OptionAsync<A>(OptionDataAsync.Some(x));
 
         [Pure]

--- a/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
@@ -524,7 +524,7 @@ public static class TryExtensions
         {
             if (self == null)
             {
-                throw new ArgumentNullException("this is null");
+                throw new ArgumentNullException(nameof(self));
             }
             return self();
         }

--- a/LanguageExt.Core/DataTypes/TryAsync/TryAsync.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/TryAsync/TryAsync.Extensions.cs
@@ -38,7 +38,7 @@ public static class TryAsyncExtensions
     /// <param name="Succ">Delegate to invoke if successful</param>
     public static async Task<Unit> IfSucc<A>(this TryAsync<A> self, Action<A> Succ)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Succ)) throw new ArgumentNullException(nameof(Succ));
 
         try
@@ -65,7 +65,7 @@ public static class TryAsyncExtensions
     [Pure]
     public static async Task<A> IfFail<A>(this TryAsync<A> self, A failValue)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(failValue)) throw new ArgumentNullException(nameof(failValue));
 
         try
@@ -91,7 +91,7 @@ public static class TryAsyncExtensions
     [Pure]
     public static async Task<A> IfFail<A>(this TryAsync<A> self, Func<Task<A>> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
         try
@@ -117,7 +117,7 @@ public static class TryAsyncExtensions
     [Pure]
     public static async Task<A> IfFail<A>(this TryAsync<A> self, Func<A> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
         try
@@ -141,7 +141,7 @@ public static class TryAsyncExtensions
     [Pure]
     public static async Task<A> IfFail<A>(this TryAsync<A> self, Func<Exception, Task<A>> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
         try
@@ -165,7 +165,7 @@ public static class TryAsyncExtensions
     [Pure]
     public static async Task<A> IfFail<A>(this TryAsync<A> self, Func<Exception, A> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
         try
@@ -879,7 +879,7 @@ public static class TryAsyncExtensions
         {
             if (self == null)
             {
-                throw new ArgumentNullException("this");
+                throw new ArgumentNullException(nameof(self));
             }
             try
             {

--- a/LanguageExt.Core/DataTypes/TryOption/TryOption.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/TryOption/TryOption.Extensions.cs
@@ -705,7 +705,7 @@ public static class TryOptionExtensions
         {
             if (self == null)
             {
-                throw new ArgumentNullException("this is null");
+                throw new ArgumentNullException(nameof(self));
             }
             return self();
         }

--- a/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Extensions.cs
@@ -38,7 +38,7 @@ public static class TryOptionAsyncExtensions
     /// <param name="Some">Delegate to invoke if successful</param>
     public static async Task<Unit> IfSome<A>(this TryOptionAsync<A> self, Action<A> Some)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(Some)) throw new ArgumentNullException(nameof(Some));
 
         try
@@ -98,7 +98,7 @@ public static class TryOptionAsyncExtensions
     /// <param name="Some">Delegate to invoke if successful</param>
     public static async Task<A> IfNoneOrFail<A>(this TryOptionAsync<A> self, Func<A> None, Func<Exception, A> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(None)) throw new ArgumentNullException(nameof(None));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
@@ -124,7 +124,7 @@ public static class TryOptionAsyncExtensions
     /// <param name="Some">Delegate to invoke if successful</param>
     public static async Task<A> IfNoneOrFail<A>(this TryOptionAsync<A> self, Func<Task<A>> None, Func<Exception, A> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(None)) throw new ArgumentNullException(nameof(None));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
@@ -150,7 +150,7 @@ public static class TryOptionAsyncExtensions
     /// <param name="Some">Delegate to invoke if successful</param>
     public static async Task<A> IfNoneOrFail<A>(this TryOptionAsync<A> self, Func<A> None, Func<Exception, Task<A>> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(None)) throw new ArgumentNullException(nameof(None));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
@@ -176,7 +176,7 @@ public static class TryOptionAsyncExtensions
     /// <param name="Some">Delegate to invoke if successful</param>
     public static async Task<A> IfNoneOrFail<A>(this TryOptionAsync<A> self, Func<Task<A>> None, Func<Exception, Task<A>> Fail)
     {
-        if (isnull(self)) throw new ArgumentNullException("this");
+        if (isnull(self)) throw new ArgumentNullException(nameof(self));
         if (isnull(None)) throw new ArgumentNullException(nameof(None));
         if (isnull(Fail)) throw new ArgumentNullException(nameof(Fail));
 
@@ -1473,7 +1473,7 @@ public static class TryOptionAsyncExtensions
         {
             if (self == null)
             {
-                throw new ArgumentNullException("this");
+                throw new ArgumentNullException(nameof(slef));
             }
             try
             {


### PR DESCRIPTION
Made the first argument of these `ArgumentNullException` constructor calls the name of the null argument via a call to `nameof`.