### PR TITLE
fixed typo from use_nameof_with_ArgumentNullException branch

### DIFF
--- a/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/TryOptionAsync/TryOptionAsync.Extensions.cs
@@ -1473,7 +1473,7 @@ public static class TryOptionAsyncExtensions
         {
             if (self == null)
             {
-                throw new ArgumentNullException(nameof(slef));
+                throw new ArgumentNullException(nameof(self));
             }
             try
             {


### PR DESCRIPTION
:( found another typo (this time from [this PR](https://github.com/louthy/language-ext/pull/393))... *another sheepish grin* :)