### PR TITLE
fix typo in Foldable documentation

### DIFF
--- a/LanguageExt.Core/TypeClasses/Foldable/Foldable.cs
+++ b/LanguageExt.Core/TypeClasses/Foldable/Foldable.cs
@@ -32,8 +32,8 @@ namespace LanguageExt.TypeClasses
         /// <summary>
         /// In the case of lists, 'FoldBack', when applied to a binary
         /// operator, a starting value(typically the left-identity of the operator),
-        /// and a list, reduces the list using the binary operator, from left to
-        /// right.
+        /// and a list, reduces the list using the binary operator, from right to
+        /// left.
         /// 
         /// Note that to produce the outermost application of the operator the
         /// entire input list must be traversed. 


### PR DESCRIPTION
Fixes #405.

It is funny actually.  While making this change, I realized that there isn't a technical sense in which anything is progressing from or to left or right.  `Fold` processes elements from front to back or beginning to end while `FoldBack` (as the name implies) processes elements from back to front or end to beginning.

I suppose we think of `Fold` as processing its elements from left to right because `Fold` processes its elements in the canonical order, which for us is right to left.  We read right to left.  Anyone that draws a number line does so with the values increasing from left to right.

I think the documentation would be better if "left" and "right" were replaced by "front" and "back".  Nevertheless, I am still offering up this humble PR to fix the existing terminology. :)