### PR TITLE
Improvements to the parse family of methods

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Parse.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Parse.cs
@@ -54,6 +54,10 @@ namespace LanguageExt
             Parse<char>(char.TryParse, value);
 
         [Pure]
+        public static Option<sbyte> parseSByte(string value) =>
+            Parse<sbyte>(sbyte.TryParse, value);
+
+        [Pure]
         public static Option<byte> parseByte(string value) =>
             Parse<byte>(byte.TryParse, value);
 

--- a/LanguageExt.Tests/Parsing/parseSByteTests.cs
+++ b/LanguageExt.Tests/Parsing/parseSByteTests.cs
@@ -1,0 +1,12 @@
+﻿namespace LanguageExt.Tests.Parsing
+{
+    public class parseSByteTests : AbstractParseTSignedPrecisionIntervalTests<sbyte>
+    {
+        protected override Option<sbyte> ParseT(string value) => Prelude.parseSByte(value);
+
+        protected override sbyte MinValue => sbyte.MinValue;
+        protected override sbyte MaxValue => sbyte.MaxValue;
+        protected override sbyte NegativeOne => -1;
+        protected override sbyte PositiveOne => 1;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1142,14 +1142,14 @@ So to solve it we now have methods that instead of returning `bool`, return `Opt
 `out` method variants
 * `IDictionary<K, V>.TryGetValue`
 * `IReadOnlyDictionary<K, V>.TryGetValue`
-* `Int32.TryParse` becomes `parseInt`
-* `Int64.TryParse` becomes `parseLong`
-* `Int16.TryParse` becomes `parseShort`
-* `Char.TryParse` becomes `parseChar`
-* `Byte.TryParse` becomes `parseByte`
-* `UInt64.TryParse` becomes `parseULong`
-* `UInt32.TryParse` becomes `parseUInt`
-* `UInt16.TryParse` becomes `parseUShort`
+* `int.TryParse` becomes `parseInt`
+* `long.TryParse` becomes `parseLong`
+* `short.TryParse` becomes `parseShort`
+* `char.TryParse` becomes `parseChar`
+* `byte.TryParse` becomes `parseByte`
+* `ulong.TryParse` becomes `parseULong`
+* `uint.TryParse` becomes `parseUInt`
+* `ushort.TryParse` becomes `parseUShort`
 * `float.TryParse` becomes `parseFloat`
 * `double.TryParse` becomes `parseDouble`
 * `decimal.TryParse` becomes `parseDecimal`

--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,8 @@ So to solve it we now have methods that instead of returning `bool`, return `Opt
 * `bool.TryParse` becomes `parseBool`
 * `Guid.TryParse` becomes `parseGuid`
 * `DateTime.TryParse` becomes `parseDateTime`
+* `DateTimeOffset.TryParse` becomes `parseDateTimeOffset`
+* `Enum.TryParse` becomes `parseEnum`
 
 _any others you think should be included, please get in touch_
 

--- a/README.md
+++ b/README.md
@@ -1146,6 +1146,7 @@ So to solve it we now have methods that instead of returning `bool`, return `Opt
 * `long.TryParse` becomes `parseLong`
 * `short.TryParse` becomes `parseShort`
 * `char.TryParse` becomes `parseChar`
+* `sbyte.TryParse` becomes `parseSByte`
 * `byte.TryParse` becomes `parseByte`
 * `ulong.TryParse` becomes `parseULong`
 * `uint.TryParse` becomes `parseUInt`


### PR DESCRIPTION
Addresses issue raised in #331 as well as added `parseDateTimeOffset` and `parseEnum` that were missing from the documentation.