### PR TITLE
changes validation disjunction so it behaves naturally 

### DIFF
--- a/LanguageExt.Core/DataTypes/Validation/Validation.cs
+++ b/LanguageExt.Core/DataTypes/Validation/Validation.cs
@@ -541,11 +541,28 @@ namespace LanguageExt
             !(lhs == rhs);
 
         /// <summary>
-        /// Coalescing operator
+        /// Disjunction / Coalescing operator
         /// </summary>
         [Pure]
         public static Validation<MonoidFail, FAIL, SUCCESS> operator |(Validation<MonoidFail, FAIL, SUCCESS> lhs, Validation<MonoidFail, FAIL, SUCCESS> rhs) =>
-            default(FoldValidation<MonoidFail, FAIL, SUCCESS>).Append(lhs, rhs);
+            lhs.Match(
+                Succ: xs => lhs,
+                Fail: xf => rhs.Match(
+                    Succ: ys => rhs,
+                    Fail: yf => Validation<MonoidFail, FAIL, SUCCESS>.Fail(default(MonoidFail).Append(xf, yf))));
+
+        /// <summary>
+        /// Conjunction operator
+        /// </summary>
+        [Pure]
+        public static Validation<MonoidFail, FAIL, SUCCESS> operator &(Validation<MonoidFail, FAIL, SUCCESS> lhs, Validation<MonoidFail, FAIL, SUCCESS> rhs) =>
+            lhs.Match(
+                Succ: xs => rhs.Match(
+                    Succ: ys => lhs,
+                    Fail: yf => rhs),
+                Fail: xf => rhs.Match(
+                    Succ: ys =>lhs,
+                    Fail: yf => Validation<MonoidFail, FAIL, SUCCESS>.Fail(default(MonoidFail).Append(xf, yf))));
 
         /// <summary>
         /// Override of the True operator to return True if the Validation is Success

--- a/LanguageExt.Core/DataTypes/Validation/ValidationSeq.cs
+++ b/LanguageExt.Core/DataTypes/Validation/ValidationSeq.cs
@@ -533,11 +533,28 @@ namespace LanguageExt
             !(lhs == rhs);
 
         /// <summary>
-        /// Coalescing operator
+        /// Disjunction / Coalescing operator
         /// </summary>
         [Pure]
         public static Validation<FAIL, SUCCESS> operator |(Validation<FAIL, SUCCESS> lhs, Validation<FAIL, SUCCESS> rhs) =>
-            default(FoldValidation<FAIL, SUCCESS>).Append(lhs, rhs);
+            lhs.Match(
+                Succ: xs => lhs,
+                Fail: xf => rhs.Match(
+                    Succ: ys => rhs,
+                    Fail: yf => Validation<FAIL, SUCCESS>.Fail(default(MSeq<FAIL>).Append(xf, yf))));
+
+        /// <summary>
+        /// Conjunction operator
+        /// </summary>
+        [Pure]
+        public static Validation<FAIL, SUCCESS> operator &(Validation<FAIL, SUCCESS> lhs, Validation<FAIL, SUCCESS> rhs) =>
+            lhs.Match(
+                Succ: xs => rhs.Match(
+                    Succ: ys => lhs,
+                    Fail: yf => rhs),
+                Fail: xf => rhs.Match(
+                    Succ: ys => lhs,
+                    Fail: yf => Validation<FAIL, SUCCESS>.Fail(default(MSeq<FAIL>).Append(xf, yf))));
 
         /// <summary>
         /// Override of the True operator to return True if the Validation is Success


### PR DESCRIPTION
When validations are combined with disjunction operator they should behave like either data types (or options). That means they should be logically combined like their own "right"/"not right" or "true"/"false" state.

To combine validations that both should hold (AND),  use `&`.
To allow success if at least one validation holds (OR),  use `|`.


Implementation note:
I didn't change FoldValidation.Append. Maybe that should be changed to (other types have Append == Plus == OR).
