### PR TITLE
fix logic bug with biconditional in bigint

### DIFF
--- a/LanguageExt.Core/ClassInstances/TBigInt.cs
+++ b/LanguageExt.Core/ClassInstances/TBigInt.cs
@@ -230,9 +230,9 @@ namespace LanguageExt.ClassInstances
         /// <summary>
         /// Bitwise bi-conditional. 
         /// </summary>
-        /// <returns>`XOr(Not(a), Not(b))`</returns>
+        /// <returns>`Not(XOr(a, b))`</returns>
         [Pure]
         public bigint BiCondition(bigint a, bigint b) =>
-            XOr(Not(a), Not(b));
+            Not(XOr(a, b));
     }
 }

--- a/LanguageExt.Core/ClassInstances/TInt.cs
+++ b/LanguageExt.Core/ClassInstances/TInt.cs
@@ -228,6 +228,6 @@ namespace LanguageExt.ClassInstances
         /// <returns>`XOr(Not(a), Not(b))`</returns>
         [Pure]
         public int BiCondition(int a, int b) =>
-            XOr(Not(a), Not(b));
+            Not(XOr(a, b));
     }
 }

--- a/LanguageExt.Core/ClassInstances/TLong.cs
+++ b/LanguageExt.Core/ClassInstances/TLong.cs
@@ -227,6 +227,6 @@ namespace LanguageExt.ClassInstances
         /// <returns>`XOr(Not(a), Not(b))`</returns>
         [Pure]
         public long BiCondition(long a, long b) =>
-            XOr(Not(a), Not(b));
+            Not(XOr(a, b));
     }
 }

--- a/LanguageExt.Core/ClassInstances/TShort.cs
+++ b/LanguageExt.Core/ClassInstances/TShort.cs
@@ -227,6 +227,6 @@ namespace LanguageExt.ClassInstances
         /// <returns>`XOr(Not(a), Not(b))`</returns>
         [Pure]
         public short BiCondition(short a, short b) =>
-            XOr(Not(a), Not(b));
+            Not(XOr(a, b));
     }
 }

--- a/LanguageExt.Tests/TypeClassBool.cs
+++ b/LanguageExt.Tests/TypeClassBool.cs
@@ -1,0 +1,48 @@
+﻿using Xunit;
+using System.Linq;
+using LanguageExt.TypeClasses;
+using LanguageExt.ClassInstances;
+using static LanguageExt.Prelude;
+using static LanguageExt.TypeClass;
+using LanguageExt;
+
+namespace LanguageExtTests
+{
+    public class TypeClassBool
+    {
+        [Fact]
+        public void BigIntXor()
+        {
+            var bigint1 = new bigint(0b0000_1100);
+            var bigint2 = new bigint(0b0000_0111);
+            var xorBigint = TBigInt.Inst.XOr(bigint1, bigint2);
+
+            Assert.True(new bigint(0b0000_1011) == xorBigint);
+            Assert.True(new bigint(0b0000_1011).Equals(xorBigint));
+            Assert.True(EqBigInt.Inst.Equals(new bigint(0b0000_1011), xorBigint));
+            // doesn't work: Assert.Equal(new bigint(0x03), xorBigint);
+        }
+
+        [Fact]
+        public void BigIntNot()
+        {
+            var bigint1 = new bigint(12);
+            
+            var notBigInt1 = TBigInt.Inst.Not(bigint1);
+            Assert.True(new bigint(-13) == notBigInt1);
+        }
+
+
+        [Fact]
+        public void BigIntBiConditional()
+        {
+            var bigint1 = new bigint(0b0000_1100);
+            var bigint2 = new bigint(0b0000_0111);
+
+            var biConditionBigint = TBigInt.Inst.BiCondition(bigint1, bigint2);
+            System.Console.WriteLine(biConditionBigint);
+            Assert.True(new bigint(0b1111_0100) == TBigInt.Inst.And(new bigint(0b1111_1111), biConditionBigint)); // least significant 8 bits
+            Assert.True(new bigint(~0 ^ 0b0000_1011) == biConditionBigint); // check all bits (signed 32bit integer)
+        }
+    }
+}

--- a/LanguageExt.Tests/TypeClassBool.cs
+++ b/LanguageExt.Tests/TypeClassBool.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
@@ -13,36 +14,102 @@ namespace LanguageExtTests
         [Fact]
         public void BigIntXor()
         {
-            var bigint1 = new bigint(0b0000_1100);
-            var bigint2 = new bigint(0b0000_0111);
-            var xorBigint = TBigInt.Inst.XOr(bigint1, bigint2);
+            var xorValue = TBigInt.Inst.XOr(new bigint(0b0000_1100), new bigint(0b0000_0111));
 
-            Assert.True(new bigint(0b0000_1011) == xorBigint);
-            Assert.True(new bigint(0b0000_1011).Equals(xorBigint));
-            Assert.True(EqBigInt.Inst.Equals(new bigint(0b0000_1011), xorBigint));
+            Assert.True(new bigint(0b0000_1011) == xorValue);
+            Assert.True(new bigint(0b0000_1011).Equals(xorValue));
+            Assert.True(EqBigInt.Inst.Equals(new bigint(0b0000_1011), xorValue));
             // doesn't work: Assert.Equal(new bigint(0x03), xorBigint);
         }
 
         [Fact]
         public void BigIntNot()
         {
-            var bigint1 = new bigint(12);
-            
-            var notBigInt1 = TBigInt.Inst.Not(bigint1);
-            Assert.True(new bigint(-13) == notBigInt1);
+            var notValue = TBigInt.Inst.Not(new bigint(12));
+            Assert.True(new bigint(-13) == notValue);
         }
-
 
         [Fact]
         public void BigIntBiConditional()
         {
-            var bigint1 = new bigint(0b0000_1100);
-            var bigint2 = new bigint(0b0000_0111);
+            var biConditionValue = TBigInt.Inst.BiCondition(new bigint(0b0000_1100), new bigint(0b0000_0111));
 
-            var biConditionBigint = TBigInt.Inst.BiCondition(bigint1, bigint2);
-            System.Console.WriteLine(biConditionBigint);
-            Assert.True(new bigint(0b1111_0100) == TBigInt.Inst.And(new bigint(0b1111_1111), biConditionBigint)); // least significant 8 bits
-            Assert.True(new bigint(~0 ^ 0b0000_1011) == biConditionBigint); // check all bits (signed 32bit integer)
+            Assert.True(new bigint(0b1111_0100) == TBigInt.Inst.And(new bigint(0b1111_1111), biConditionValue)); // least significant 8 bits
+            Assert.True(new bigint(~0 ^ 0b0000_1011) == biConditionValue); // check all bits (signed 32bit integer)
+        }
+
+        [Fact]
+        public void ShortXor()
+        {
+            var xorValue = TShort.Inst.XOr(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b0000_1011 == xorValue);
+        }
+
+        [Fact]
+        public void ShortNot()
+        {
+            var notValue = TShort.Inst.Not(12);
+            Assert.True(-13 == notValue);
+        }
+
+        [Fact]
+        public void ShortBiConditional()
+        {
+            var biConditionValue = TShort.Inst.BiCondition(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b1111_0100 == TShort.Inst.And(0b1111_1111, biConditionValue)); // least significant 8 bits
+            Console.WriteLine((~0 ^ 0b0000_1011));
+            Console.WriteLine(biConditionValue);
+            Assert.True((~0 ^ 0b0000_1011) == biConditionValue); 
+        }
+
+        [Fact]
+        public void IntXor()
+        {
+            var xorValue = TInt.Inst.XOr(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b0000_1011 == xorValue);
+        }
+
+        [Fact]
+        public void IntNot()
+        {
+            var notValue = TInt.Inst.Not(12);
+            Assert.True(-13 == notValue);
+        }
+
+        [Fact]
+        public void IntBiConditional()
+        {
+            var biConditionValue = TInt.Inst.BiCondition(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b1111_0100 == TInt.Inst.And(0b1111_1111, biConditionValue)); // least significant 8 bits
+            Assert.True((~0 ^ 0b0000_1011) == biConditionValue); 
+        }
+
+        [Fact]
+        public void LongXor()
+        {
+            var xorValue = TLong.Inst.XOr(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b0000_1011 == xorValue);
+        }
+
+        [Fact]
+        public void LongNot()
+        {
+            var notValue = TLong.Inst.Not(12);
+            Assert.True(-13 == notValue);
+        }
+
+        [Fact]
+        public void LongBiConditional()
+        {
+            var biConditionValue = TLong.Inst.BiCondition(0b0000_1100, 0b0000_0111);
+
+            Assert.True(0b1111_0100 == TLong.Inst.And(0b1111_1111, biConditionValue)); // least significant 8 bits
+            Assert.True((~0L ^ 0b0000_1011L) == biConditionValue); 
         }
     }
 }


### PR DESCRIPTION
Seems like a logic bug here. Is this fix correct? If you want I can add this for the other types (same thing with at least TInt, TLong).