### PR TITLE
Updated the Use extensions to not call use on fail

### DIFF
--- a/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
@@ -549,16 +549,16 @@ public static class TryExtensions
             return new Result<T>(e);
         }
     }
-
+    
     [Pure]
     public static Try<U> Use<T, U>(this Try<T> self, Func<T, U> select)
-        where T : IDisposable => () =>
-        use(self().Value, select);
+        where T : IDisposable => 
+        self.Map(x => use(x, select));
 
     [Pure]
     public static Try<U> Use<T, U>(this Try<T> self, Func<T, Try<U>> select)
-        where T : IDisposable => () =>
-        use(self().Value, select)().Value;
+        where T : IDisposable =>
+        self.Bind(x => use(x, select));
 
     [Pure]
     public static int Sum(this Try<int> self) =>

--- a/LanguageExt.Tests/UseFamilyTests.cs
+++ b/LanguageExt.Tests/UseFamilyTests.cs
@@ -118,6 +118,145 @@ namespace LanguageExt.Tests
             Assert.False(actual.IsFaulted);
         }
         #endregion
+            
+        #region Disposable Constructor Exception Tests
+        [Fact]
+        public void tryuseFuncMap_TryException_IsFaulted()
+        {
+            Func<IDisposable> m = () => throw new Exception();
+            Func<IDisposable, Unit> f = _ => unit;
+
+            var actual = tryuse(m, f)();
+
+            Assert.True(actual.IsFaulted);
+        }
+
+        [Fact]
+        public void useTryMap_TryException_IsFaulted()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            Func<IDisposable, Unit> f = _ => unit;
+
+            var actual = use(m, f)();
+
+            Assert.True(actual.IsFaulted);
+        }
+
+        [Fact]
+        public void useTryBind_TryException_IsFaulted()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            Func<IDisposable, Try<Unit>> f = _ => Try(unit);
+
+            var actual = use(m, f)();
+
+            Assert.True(actual.IsFaulted);
+        }
+
+        [Fact]
+        public void UseTryMap_TryException_IsFaulted()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            Func<IDisposable, Unit> f = _ => unit;
+
+            var actual = m.Use(f)();
+
+            Assert.True(actual.IsFaulted);
+        }
+
+        [Fact]
+        public void UseTryBind_TryException_IsFaulted()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            Func<IDisposable, Try<Unit>> f = _ => Try(unit);
+
+            var actual = m.Use(f)();
+
+            Assert.True(actual.IsFaulted);
+        }
+
+        [Fact]
+        public void tryuseFuncMap_TryException_SelectNotInvoked()
+        {
+            Func<IDisposable> m =() => throw new Exception();
+            var selectInvoked = false;
+            Func<IDisposable, Unit> f = _ =>
+            {
+                selectInvoked = true;
+                return unit;
+            };
+
+            tryuse(m, f)();
+
+            Assert.False(selectInvoked);
+        }
+
+        [Fact]
+        public void useTryMap_TryException_SelectNotInvoked()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            var selectInvoked = false;
+            Func<IDisposable, Unit> f = _ =>
+            {
+                selectInvoked = true;
+                return unit;
+            };
+
+            use(m, f)();
+
+            Assert.False(selectInvoked);
+        }
+
+        [Fact]
+        public void useTryBind_TryException_SelectNotInvoked()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+            var selectInvoked = false;
+            Func<IDisposable, Try<Unit>> f = _ =>
+            {
+                selectInvoked = true;
+                return Try(unit);
+            };
+
+            use(m, f)();
+
+            Assert.False(selectInvoked);
+        }
+
+        [Fact]
+        public void UseTryMap_TryException_SelectNotInvoked()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+
+            var selectInvoked = false;
+            Func<IDisposable, Unit> f = _ =>
+            {
+                selectInvoked = true;
+                return unit;
+            };
+
+            m.Use(f)();
+
+            Assert.False(selectInvoked);
+        }
+
+        [Fact]
+        public void UseTryBind_TryException_SelectNotInvoked()
+        {
+            var m = Try<IDisposable>(() => throw new Exception());
+
+            var selectInvoked = false;
+            Func<IDisposable, Try<Unit>> f = _ =>
+            {
+                selectInvoked = true;
+                return Try(unit);
+            };
+
+            m.Use(f)();
+
+            Assert.False(selectInvoked);
+        }
+        #endregion
 
         #region Disposable Disposed Tests
         [Fact]


### PR DESCRIPTION
#450 
The use extensions previously passed `self().Value` directly into `Prelude.use`, which resulted in a null input value to the consuming function when the initial `Try` was in a faulted state