### PR TITLE
Fixed XML comments for BiConditions

### DIFF
--- a/LanguageExt.Core/ClassInstances/TInt.cs
+++ b/LanguageExt.Core/ClassInstances/TInt.cs
@@ -225,7 +225,7 @@ namespace LanguageExt.ClassInstances
         /// <summary>
         /// Bitwise bi-conditional. 
         /// </summary>
-        /// <returns>`XOr(Not(a), Not(b))`</returns>
+        /// <returns>`Not(XOr(a, b))`</returns>
         [Pure]
         public int BiCondition(int a, int b) =>
             Not(XOr(a, b));

--- a/LanguageExt.Core/ClassInstances/TLong.cs
+++ b/LanguageExt.Core/ClassInstances/TLong.cs
@@ -224,7 +224,7 @@ namespace LanguageExt.ClassInstances
         /// <summary>
         /// Bitwise bi-conditional. 
         /// </summary>
-        /// <returns>`XOr(Not(a), Not(b))`</returns>
+        /// <returns>`Not(XOr(a, b))`</returns>
         [Pure]
         public long BiCondition(long a, long b) =>
             Not(XOr(a, b));

--- a/LanguageExt.Core/ClassInstances/TShort.cs
+++ b/LanguageExt.Core/ClassInstances/TShort.cs
@@ -224,7 +224,7 @@ namespace LanguageExt.ClassInstances
         /// <summary>
         /// Bitwise bi-conditional. 
         /// </summary>
-        /// <returns>`XOr(Not(a), Not(b))`</returns>
+        /// <returns>`Not(XOr(a, b))`</returns>
         [Pure]
         public short BiCondition(short a, short b) =>
             Not(XOr(a, b));


### PR DESCRIPTION
It looks like a recent commit put the comments out of sync with the logic for some of the BiCondition functions.