### PR TITLE
some tests and fixes around setitem/trysetitem for maps and sets

### DIFF
--- a/LanguageExt.Core/DataTypes/HashMap/HashMap.Internal.cs
+++ b/LanguageExt.Core/DataTypes/HashMap/HashMap.Internal.cs
@@ -534,6 +534,7 @@ namespace LanguageExt
         /// <param name="key">Key</param>
         /// <param name="value">Value</param>
         /// <exception cref="ArgumentNullException">Throws ArgumentNullException the key or value are null</exception>
+        /// <exception cref="ArgumentException">Throws ArgumentException if the item isn't found</exception>
         /// <returns>New Map with the item added</returns>
         [Pure]
         public HashMapInternal<EqK, K, V> SetItem(K key, V value)
@@ -545,11 +546,11 @@ namespace LanguageExt
             var bucket = ht.Find(hash);
             if (bucket.IsSome)
             {
-                return new HashMapInternal<EqK, K, V>(ht.SetItem(hash, bucket.Value.Map(x => default(EqK).Equals(x.Key, key) ? (x.Key, value) : x)), Count);
+                return new HashMapInternal<EqK, K, V>(ht.SetItem(hash, bucket.Value.Map(x => default(EqK).Equals(x.Key, key) ? (key, value) : x)), Count);
             }
             else
             {
-                return this;
+                throw new ArgumentException("Key not found in Map");
             }
         }
 
@@ -558,6 +559,7 @@ namespace LanguageExt
         /// put it back.
         /// </summary>
         /// <param name="key">Key to set</param>
+        /// <exception cref="ArgumentNullException">Throws ArgumentNullException the key or value are null</exception>
         /// <exception cref="ArgumentException">Throws ArgumentException if the item isn't found</exception>
         /// <exception cref="Exception">Throws Exception if Some returns null</exception>
         /// <returns>New map with the mapped value</returns>
@@ -571,11 +573,11 @@ namespace LanguageExt
             var bucket = ht.Find(hash);
             if (bucket.IsSome)
             {
-                return new HashMapInternal<EqK, K, V>(ht.SetItem(hash, bucket.Value.Map(x => default(EqK).Equals(x.Key, key) ? (x.Key, Some(x.Value)) : x)), Count);
+                return new HashMapInternal<EqK, K, V>(ht.SetItem(hash, bucket.Value.Map(x => default(EqK).Equals(x.Key, key) ? (key, Some(x.Value)) : x)), Count);
             }
             else
             {
-                return this;
+                throw new ArgumentException("Key not found in Map");
             }
         }
 

--- a/LanguageExt.Core/DataTypes/HashMap/HashMap.cs
+++ b/LanguageExt.Core/DataTypes/HashMap/HashMap.cs
@@ -362,7 +362,7 @@ namespace LanguageExt
         /// <returns>New map with the item set</returns>
         [Pure]
         public HashMap<K, V> TrySetItem(K key, Func<V, V> Some) =>
-            Wrap(Value.SetItem(key, Some));
+            Wrap(Value.TrySetItem(key, Some));
 
         /// <summary>
         /// Checks for existence of a key in the map

--- a/LanguageExt.Core/DataTypes/HashSet/HashSet.Internal.cs
+++ b/LanguageExt.Core/DataTypes/HashSet/HashSet.Internal.cs
@@ -301,7 +301,7 @@ namespace LanguageExt
             var bucket = ht.Find(hash);
             return bucket.IsSome
                 ? new HashSetInternal<EqA, A>(ht.SetItem(hash, bucket.Value.Map(x => default(EqA).Equals(x, key) ? key : x)), Count)
-                : this;
+                : throw new ArgumentException("Key not found in Set");
         }
 
         [Pure]

--- a/LanguageExt.Core/DataTypes/Map/Map.Internal.cs
+++ b/LanguageExt.Core/DataTypes/Map/Map.Internal.cs
@@ -1170,7 +1170,7 @@ namespace LanguageExt
             }
             else
             {
-                return new MapItem<K, V>(node.Height, node.Count, (node.KeyValue.Key, value), node.Left, node.Right);
+                return new MapItem<K, V>(node.Height, node.Count, (key, value), node.Left, node.Right);
             }
         }
 
@@ -1192,7 +1192,7 @@ namespace LanguageExt
             }
             else
             {
-                return new MapItem<K, V>(node.Height, node.Count, (node.KeyValue.Key, value), node.Left, node.Right);
+                return new MapItem<K, V>(node.Height, node.Count, (key, value), node.Left, node.Right);
             }
         }
 

--- a/LanguageExt.Tests/HashMapTests.cs
+++ b/LanguageExt.Tests/HashMapTests.cs
@@ -5,13 +5,14 @@ using static LanguageExt.HashMap;
 using Xunit;
 using System;
 using System.Linq;
+using LanguageExt.ClassInstances;
 
 namespace LanguageExtTests
 {
     public class HashMapTests
     {
         [Fact]
-        public void MapGeneratorTest()
+        public void HashMapGeneratorTest()
         {
             var m1 = HashMap<int, string>();
             m1 = add(m1, 100, "hello");
@@ -199,6 +200,19 @@ namespace LanguageExtTests
                 max--;
                 Assert.True(m.Count == max);
             }
+        }
+
+        [Fact]
+        public void HashMapSetTest()
+        {
+            var map = HashMap<EqStringOrdinalIgnoreCase, string, int>(("one", 1), ("two",2), ("three", 3));
+            var map2 = map.SetItem("One", -1);
+            Assert.Equal(3, map2.Count);
+            Assert.Equal(-1, map2["one"]);
+            Assert.DoesNotContain("one", map2.Keys); // make sure key got replaced, too
+            Assert.Contains("One", map2.Keys); // make sure key got replaced, too
+
+            Assert.Throws<ArgumentException>(() => map.SetItem("four", identity));
         }
 
         [Fact]

--- a/LanguageExt.Tests/HashSetTests.cs
+++ b/LanguageExt.Tests/HashSetTests.cs
@@ -4,6 +4,7 @@ using static LanguageExt.HashSet;
 using Xunit;
 using System;
 using System.Linq;
+using LanguageExt.ClassInstances;
 
 namespace LanguageExtTests
 {
@@ -68,7 +69,7 @@ namespace LanguageExtTests
         }
 
         [Fact]
-        public void MapAddInReverseOrderTest()
+        public void HashSetAddInReverseOrderTest()
         {
             var m = HashSet(1);
             m.Find(1).IfNone(() => failwith<int>("Broken"));
@@ -97,7 +98,7 @@ namespace LanguageExtTests
         }
 
         [Fact]
-        public void MapAddInMixedOrderTest()
+        public void HashSetAddInMixedOrderTest()
         {
             var m = HashSet(5, 1, 3, 2, 4);
             m.Find(1).IfNone(() => failwith<int>("Broken"));
@@ -115,7 +116,7 @@ namespace LanguageExtTests
         }
 
         [Fact]
-        public void MapRemoveTest()
+        public void HashSetRemoveTest()
         {
             var m = HashSet("a", "b", "c", "d", "e");
 
@@ -156,6 +157,33 @@ namespace LanguageExtTests
             m = remove(m, "e");
             Assert.True(m.Count == 0);
             Assert.True(m.Find("e").IsNone);
+        }
+
+        [Fact]
+        public void HashSetKeyTypeTests()
+        {
+            var set = HashSet<EqStringOrdinalIgnoreCase, string>("one", "two", "three");
+
+            Assert.True(set.Contains("one"));
+            Assert.True(set.Contains("ONE"));
+
+            Assert.True(set.Contains("two"));
+            Assert.True(set.Contains("Two"));
+
+            Assert.True(set.Contains("three"));
+            Assert.True(set.Contains("thREE"));
+        }
+
+        [Fact]
+        public void HashSetSetTest()
+        {
+            var set = HashSet<EqStringOrdinalIgnoreCase, string>("one", "two", "three");
+            var set2 = set.SetItem("One");
+            Assert.Equal(3, set2.Count);
+            Assert.False(set2.ToSeq().Freeze().Contains("one"));
+            Assert.True(set2.ToSeq().Freeze().Contains("One"));
+
+            Assert.Throws<ArgumentException>(() => set.SetItem("four"));
         }
 
         [Fact]

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -5,6 +5,7 @@ using static LanguageExt.Map;
 using Xunit;
 using System;
 using System.Linq;
+using LanguageExt.ClassInstances;
 
 namespace LanguageExtTests
 {
@@ -55,6 +56,29 @@ namespace LanguageExtTests
                 Some: v => Assert.True(v == "x"),
                 None: () => Assert.False(true)
                 );
+
+            Assert.Throws<ArgumentException>(() => setItem(m1, 4, "y"));
+        }
+
+        
+        [Fact]
+        public void MapOrdSetTest()
+        {
+            var m1 = Map<OrdStringOrdinalIgnoreCase, string, int>(("one", 1), ("two",2), ("three", 3));
+            var m2 = m1.SetItem("One", -1);
+            
+            Assert.Equal(3, m2.Count);
+            Assert.Equal(-1, m2["one"]);
+            Assert.DoesNotContain("one", m2.Keys); // make sure key got replaced, too
+            Assert.Contains("One", m2.Keys); // make sure key got replaced, too
+
+            Assert.Throws<ArgumentException>(() => m1.SetItem("four", identity));
+
+            var m3 = m1.TrySetItem("four", 0).Add("five", 0).TrySetItem("Five", 5);
+            Assert.Equal(5, m3["fiVe"]);
+            Assert.DoesNotContain("four", m3.Keys);
+            Assert.DoesNotContain("five", m3.Keys);
+            Assert.Contains("Five", m3.Keys);
         }
 
         [Fact]

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -26,21 +26,7 @@ namespace LanguageExt.Tests
             Assert.True(set.Contains("thREE"));
         }
 
-        [Fact]
-        public void HashSetKeyTypeTests()
-        {
-            var set = HashSet<EqStringOrdinalIgnoreCase, string>("one", "two", "three");
-
-            Assert.True(set.Contains("one"));
-            Assert.True(set.Contains("ONE"));
-
-            Assert.True(set.Contains("two"));
-            Assert.True(set.Contains("Two"));
-
-            Assert.True(set.Contains("three"));
-            Assert.True(set.Contains("thREE"));
-        }
-
+  
         [Fact]
         public void EqualsTest()
         {


### PR DESCRIPTION
Besides some bugs (see diff) I changed two more things that aren't bugs:

1. I changed some test names and moved one test to another file, hope this is better now.

2. I modified all SetItem/Set/TrySetItem/TrySet variants so the key is replaced always. This makes it more consistent and I hope this does not have issues I didn't see. 
I don't think it is a good idea to rely on this feature in user code (key is defined as equal there), but at least LanguageExt data types have to decide which key to store. Using always the latest key makes it e.g. consistent with Remove(oldKey).Add(newKey, newValue).

I hope I found all issues. 
