### PR TITLE
fixes iterator disposal issue with .HeadOrNone()

### DIFF
--- a/LanguageExt.Core/Extensions/Query.cs
+++ b/LanguageExt.Core/Extensions/Query.cs
@@ -13,7 +13,7 @@ namespace LanguageExt
         public static T head<T>(IQueryable<T> list) => list.First();
 
         public static Option<T> headOrNone<T>(IQueryable<T> list) =>
-            list.ToSeq().HeadOrNone();
+            list.AsEnumerable().HeadOrNone();
 
         public static Validation<S, T> headOrInvalid<S, T>(IQueryable<T> list, S fail) =>
             list.ToSeq().HeadOrInvalid(fail);

--- a/LanguageExt.Tests/QueryTests.cs
+++ b/LanguageExt.Tests/QueryTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
 using static LanguageExt.Prelude;
 using static LanguageExt.Query;
 
@@ -76,6 +79,49 @@ namespace LanguageExtTests
                         .Reduce((x, s) => s + x);
 
             Assert.True(res == 120);
+        }
+
+        [Fact]
+        public void QueryableHeadOrNoneDisposesEnumerator()
+        {
+            var enumerable = new MyEnumerable<int>();
+
+            enumerable.AsQueryable().HeadOrNone();
+
+            Assert.True(enumerable.Enumerator.IsDisposed);
+        }
+
+        private class MyEnumerable<T> : IEnumerable<T>
+        {
+            public MyEnumerable()
+            {
+                this.Enumerator = new MyEnumerator<T>();
+            }
+            public MyEnumerator<T> Enumerator { get; }
+            public IEnumerator<T> GetEnumerator() => Enumerator;
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+        private class MyEnumerator<T> : IEnumerator<T>
+        {
+            public MyEnumerator()
+            {
+                this.IsDisposed = false;
+
+            }
+            public bool IsDisposed { get; private set; }
+            public bool MoveNext() => true;
+
+            public void Reset() { }
+
+            public T Current => default;
+
+            object IEnumerator.Current => default;
+
+            public void Dispose()
+            {
+                this.IsDisposed = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the issue with calling `.HeadOrNone()` on an `IQueryable` not disposing the enumerator
#488