### PR TITLE
Add missing Match overload from Seq to IEnumerables

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
@@ -40,6 +40,18 @@ public static class ListExtensions
         lhs.Concat(rhs);
 
     /// <summary>
+    /// Match empty list, or multi-item list
+    /// </summary>
+    /// <typeparam name="B">Return value type</typeparam>
+    /// <param name="Empty">Match for an empty list</param>
+    /// <param name="More">Match for a non-empty</param>
+    /// <returns>Result of match function invoked</returns>
+    public static B Match<A, B>(this IEnumerable<A> list,
+        Func<B> Empty,
+        Func<Seq<A>, B> More) =>
+        Seq(list).Match(Empty, More);
+
+    /// <summary>
     /// List pattern matching
     /// </summary>
     [Pure]

--- a/LanguageExt.Core/Prelude/Prelude_Collections.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Collections.cs
@@ -689,6 +689,18 @@ namespace LanguageExt
             items.AsQueryable();
 
         /// <summary>
+        /// Match empty list, or multi-item list
+        /// </summary>
+        /// <typeparam name="B">Return value type</typeparam>
+        /// <param name="Empty">Match for an empty list</param>
+        /// <param name="More">Match for a non-empty</param>
+        /// <returns>Result of match function invoked</returns>
+        public static B match<A, B>(IEnumerable<A> list,
+            Func<B> Empty,
+            Func<Seq<A>, B> More) =>
+            Seq(list).Match(Empty, More);
+
+        /// <summary>
         /// List pattern matching
         /// </summary>
         [Pure]


### PR DESCRIPTION
`Seq`  had an overload of `Match` that allowed

```csharp
Seq(1, 2, 3)
	.Match(
		Empty: () => "",
		Seq: xs => string.Join(", ", xs)
	);
```

This overload was missing for IEnumerables

```csharp
// does not compile
Set(1, 2, 3)
	.Match(
		Empty: () => "",
		More: xs => string.Join(", ", xs)
	);
```