### PR TITLE
Fixing EitherAsync.Bottom 

### DIFF
--- a/LanguageExt.Core/DataTypes/EitherAsync/EitherAsync.cs
+++ b/LanguageExt.Core/DataTypes/EitherAsync/EitherAsync.cs
@@ -31,11 +31,11 @@ namespace LanguageExt
     public struct EitherAsync<L, R> :
         IEitherAsync
     {
-        public readonly static EitherAsync<L, R> Bottom = new EitherAsync<L, R>(null);
+        public readonly static EitherAsync<L, R> Bottom = default; // new EitherAsync<L, R>();
         internal readonly Task<EitherData<L, R>> data;
 
         internal EitherAsync(Task<EitherData<L, R>> data) =>
-            this.data = data ?? EitherData<L, R>.Bottom.AsTask();
+            this.data = data ?? throw new ArgumentNullException(nameof(data)); // EitherData<L, R>.Bottom.AsTask();
 
         /// <summary>
         /// State of the Either
@@ -45,21 +45,21 @@ namespace LanguageExt
         ///     IsBottom
         /// </summary>
         public Task<EitherStatus> State =>
-            data.Select(x => x.State);
+            data == null ? Task.FromResult(EitherStatus.IsBottom) : data.Select(x => x.State);
 
         /// <summary>
         /// Is the Either in a Right state?
         /// </summary>
         [Pure]
         public Task<bool> IsRight =>
-            data.Map(x => x.State == EitherStatus.IsRight);
+            data == null ? Task.FromResult(false) : data.Map(x => x.State == EitherStatus.IsRight);
 
         /// <summary>
         /// Is the Either in a Left state?
         /// </summary>
         [Pure]
         public Task<bool> IsLeft =>
-            data.Map(x => x.State == EitherStatus.IsLeft);
+            data == null ? Task.FromResult(false) : data.Map(x => x.State == EitherStatus.IsLeft);
 
         /// <summary>
         /// Is the Either in a Bottom state?
@@ -76,7 +76,7 @@ namespace LanguageExt
         /// </summary>
         [Pure]
         public Task<bool> IsBottom =>
-            data.Map(x => x.State == EitherStatus.IsBottom);
+            data == null ? Task.FromResult(true) : data.Map(x => x.State == EitherStatus.IsBottom);
 
         /// <summary>
         /// Implicit conversion operator from R to Either R L

--- a/LanguageExt.Core/DataTypes/EitherAsync/EitherAsync.cs
+++ b/LanguageExt.Core/DataTypes/EitherAsync/EitherAsync.cs
@@ -31,7 +31,7 @@ namespace LanguageExt
     public struct EitherAsync<L, R> :
         IEitherAsync
     {
-        public readonly static EitherAsync<L, R> Bottom = new EitherAsync<L, R>();
+        public readonly static EitherAsync<L, R> Bottom = new EitherAsync<L, R>(null);
         internal readonly Task<EitherData<L, R>> data;
 
         internal EitherAsync(Task<EitherData<L, R>> data) =>

--- a/LanguageExt.Tests/EitherAsyncTests.cs
+++ b/LanguageExt.Tests/EitherAsyncTests.cs
@@ -10,6 +10,16 @@ namespace LanguageExt.Tests
 
     public class EitherAsyncTests
     {
+        /// <summary>
+        /// Tests for bug / PR #508
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task BottomTest()
+        {
+            Assert.True(await EitherAsync<int, string>.Bottom.IsBottom);
+        }
+
         [Fact]
         public async Task ToAsyncExtensionLeftTest()
         {

--- a/LanguageExt.Tests/EitherAsyncTests.cs
+++ b/LanguageExt.Tests/EitherAsyncTests.cs
@@ -15,9 +15,19 @@ namespace LanguageExt.Tests
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task BottomTest()
+        public async Task BottomIsBottomTest()
         {
             Assert.True(await EitherAsync<int, string>.Bottom.IsBottom);
+        }
+
+        /// <summary>
+        /// default EitherAsync must be bottom
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task DefaultIsBottomTest()
+        {
+            Assert.True(await default(EitherAsync<int, string>).IsBottom);
         }
 
         [Fact]


### PR DESCRIPTION
Internal `data` was null (runtime error when calling IsBottom).

Same fix is included in #502 but that PR might not be ready to merge now.