### PR TITLE
OptionAsyncTests.Issue206 fails

### DIFF
--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -78,6 +78,7 @@ namespace LanguageExt.Tests
             OptionAsync<int> optAsync = Some(4).ToAsync();
             var tskOptionAsync = optAsync.IfSome(async (i) =>
             {
+                await Task.Delay(100);
                 var x = DoWork();
 
                 lock (sync)
@@ -95,8 +96,8 @@ namespace LanguageExt.Tests
             }
             await tskOptionAsync;
 
-            Assert.True(tasks[0].Status == TaskStatus.RanToCompletion);
-            Assert.True(tasks[1].Status == TaskStatus.RanToCompletion);
+            Assert.Equal(TaskStatus.RanToCompletion, tasks[0].Status);
+            Assert.Equal(TaskStatus.RanToCompletion, tasks[1].Status);
         }
 
         [Fact]


### PR DESCRIPTION
Running the test OptionAsyncTests.Issue206 standalone worked fine mostly, but running a bunch of test not (probably due to exhausting task scheduler).

The commit e90fdf5 changes the test to improve reproducibility.

Problem is that `IfSome` is called with an async action which will not be awaited because it's only an `Action<T>` then. Replacing the call to `IfSomeAsync` (in test) should solve the issue.

How to avoid this? Could be a (really bad) issue for other async code... :-(

Maybe the best (clean) option is to drop support for `Action<A>` parameters for async types by deleting all async methods accepting `Action<A>`.

This will force to use `Func<A, Unit>` instead. One can still do bad things, but it's more difficult to do.

BTW: I found this on Stackoverflow: https://stackoverflow.com/questions/19024014/check-if-action-is-async-lambda which could be used to at least throw a runtime exception. But I'm not recommending this.