### PR TITLE
Clean flip code

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Flip.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Flip.cs
@@ -1,67 +1,61 @@
 ﻿using System;
-using System.Reflection;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Runtime.CompilerServices;
 
 namespace LanguageExt
 {
     public static partial class Prelude
     {
         /// <summary>
-        /// Reverse the order of the first two arguments of a curried function
+        /// Reverse the order of the arguments to a curried function
         /// </summary>
         [Pure]
         public static Func<B, Func<A, R>> flip<A, B, R>(Func<A, Func<B, R>> f) =>
             b => a => f(a)(b);
 
         /// <summary>
-        /// Reverse the order of the first and last arguments of a curried function
+        /// Reverse the order of the arguments to a curried function
         /// </summary>
         [Pure]
         public static Func<C, Func<B, Func<A, R>>> flip<A, B, C, R>(Func<A, Func<B, Func<C, R>>> f) =>
             c => b => a => f(a)(b)(c);
 
-
         /// <summary>
-        /// Reverse the order of the first two arguments of a curried function
+        /// Reverse the order of the arguments to a function
         /// </summary>
         [Pure]
-        public static Func<B, A, C> flip<A, B, C>(Func<A, B, C> f) =>
-            (arg2, arg1) => f(arg1, arg2);
+        public static Func<B, A, R> flip<A, B, R>(Func<A, B, R> f) =>
+            (b, a) => f(a, b);
 
         /// <summary>
-        /// Reverse the order of the first and last arguments of a curried function
+        /// Reverse the order of the arguments to a function
         /// </summary>
         [Pure]
         public static Func<C, B, A, R> flip<A, B, C, R>(Func<A, B, C, R> f) =>
             (c, b, a) => f(a, b, c);
 
-
         /// <summary>
-        /// Reverse the order of the first two arguments of a curried function
+        /// Reverse the order of the arguments to a curried function
         /// </summary>
         [Pure]
-        public static Func<B, Func<A, C>> Flip<A, B, C>(this Func<A, Func<B, C>> f) =>
-            arg2 => arg1 => f(arg1)(arg2);
+        public static Func<B, Func<A, R>> Flip<A, B, R>(this Func<A, Func<B, R>> f) =>
+            b => a => f(a)(b);
 
         /// <summary>
-        /// Reverse the order of the first and last arguments of a curried function
+        /// Reverse the order of the arguments to a curried function
         /// </summary>
         [Pure]
         public static Func<C, Func<B, Func<A, R>>> Flip<A, B, C, R>(this Func<A, Func<B, Func<C, R>>> f) =>
             c => b => a => f(a)(b)(c);
 
-
         /// <summary>
-        /// Reverse the order of the first two arguments of a curried function
+        /// Reverse the order of the arguments to a function
         /// </summary>
         [Pure]
-        public static Func<B, A, C> Flip<A, B, C>(this Func<A, B, C> f) =>
-            (arg2, arg1) => f(arg1, arg2);
+        public static Func<B, A, R> Flip<A, B, R>(this Func<A, B, R> f) =>
+            (b, a) => f(a, b);
 
         /// <summary>
-        /// Reverse the order of the first and last arguments of a curried function
+        /// Reverse the order of the arguments to a function
         /// </summary>
         [Pure]
         public static Func<C, B, A, R> Flip<A, B, C, R>(this Func<A, B, C, R> f) =>


### PR DESCRIPTION
As stated in my commit message:
> corrected and simplified documentation, standardized type parameter of return type to R, improved local variable names by having them match their type name, removed unused usings