### PR TITLE
Bug fix517 throw on option map to null

### DIFF
--- a/LanguageExt.Core/ClassInstances/Functor/FOption.cs
+++ b/LanguageExt.Core/ClassInstances/Functor/FOption.cs
@@ -17,6 +17,6 @@ namespace LanguageExt.ClassInstances
 
         [Pure]
         public Option<B> Map(Option<A> ma, Func<A, B> f) =>
-            MOption<A>.Inst.Bind<MOption<B>, Option<B>, B>(ma, a => MOption<B>.Inst.Return(f(a)));
+            MOption<A>.Inst.Bind<MOption<B>, Option<B>, B>(ma, a => Some(f(a)));
     }
 }

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -194,6 +194,13 @@ namespace LanguageExtTests
             Assert.Equal(2, way);
         }
 
+        [Fact]
+        public void OptionMap_ToNull_ThrowsValueIsNullException()
+        {
+            var option = Some(new object());
+            Assert.Throws<ValueIsNullException>(() => option.Map(_ => (object)null));
+        }
+
         private Option<string> GetStringNone()
         {
             // This should fail


### PR DESCRIPTION
Fixes #517.

I think this is the correct fix.  All the tests, including the newly added one, pass.