### PR TITLE
Seq GetEnumerator laziness fix

### DIFF
--- a/LanguageExt.Core/DataTypes/Seq/Seq.cs
+++ b/LanguageExt.Core/DataTypes/Seq/Seq.cs
@@ -1244,29 +1244,30 @@ namespace LanguageExt
 
             lock (seq)
             {
-                end = start + count;
-
-                // First yield the already cached items
-                for (; i < end; i++)
-                {
-                    yield return data[i];
-                }
-
-                if (seq == null)
-                {
-                    yield break;
-                }
-
-                // Next stream the lazy items
                 bool success = true;
                 A value = default(A);
                 while (success)
                 {
-                    (success, value) = StreamNextItem();
-                    if (success)
+                    end = start + count;
+
+                    // First yield the already cached items
+                    if (i < end)
                     {
-                        yield return value;
+                        yield return data[i];
                     }
+                    else if (seq == null)
+                    {
+                        yield break;
+                    }
+                    else
+                    {
+                        (success, value) = StreamNextItem();
+                        if (success)
+                        {
+                            yield return value;
+                        }
+                    }
+                    i++;
                 }
             }
         }

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -202,5 +202,42 @@ namespace LanguageExt.Tests
 
             Assert.True(eq);
         }
+
+        /// <summary>
+        /// Test ensures that lazily evaluated Seq returns the same as strictly evaluated when multiple enumerations occur
+        /// </summary>
+        [Fact]
+        public void GetEnumeratorTest()
+        {           
+            var res1 = Seq.empty<int>();
+            var res2 = Seq.empty<int>();
+
+            IEnumerable<int> a = new List<int> { 1, 2, 3, 4 };
+
+            var s1 = a.ToSeq();
+            var s2 = a.ToSeq().Strict();
+
+            foreach (var s in s1)
+            {
+                if (s == 2)
+                {
+                    s1.FoldWhile("", (x, y) => "", x => x != 3);
+                }
+                res1 = res1.Add(s);
+            }
+
+            foreach (var s in s2)
+            {
+                if (s == 2)
+                {
+                    s2.FoldWhile("", (x, y) => "", x => x != 3);
+                }
+                res2 = res2.Add(s);
+            }
+
+            var eq = res1 == res2;
+
+            Assert.True(eq);
+        }
     }
 }


### PR DESCRIPTION
If you start enumerating over a lazy Seq (for example one created from an IEnumerable) the code goes into a while loop and calls `StreamNextItem()` yielding each value until it reaches the end of the IEnumerable.

If another enumeration of the same Seq occurs during this process and gets ahead of the index that the first enumerator is looking at `StreamNextItem()` is no longer the next value as the next value has been cached.

Example:

```csharp
var res1 = Seq.empty<int>();

IEnumerable<int> a = new List<int> { 1, 2, 3, 4 };

var s1 = a.ToSeq();

foreach (var s in s1)
{
    if (s == 2)
    {
        s1.FoldWhile("", (x, y) => "", x => x != 3);
    }
    res1 = res1.Add(s);
}
```

`res1` would be `{1,2,4}`

I have adjusted the `GetEnumerator` function to check the cache on each iteration and to return that value if the index is in there and if not only then call `StreamNextItem()`.

There's a new `SeqTests.GetEnumeratorTest()` that checks this too.