### PR TITLE
Reproduce problem #530 (tests fail)

### DIFF
--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <FileVersion>3.0.0.0</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>


### PR DESCRIPTION
Record type IL code feature fails in .net Framework, e.g. net46 or net462.

This change adds net46 to targetframeworks of the test project which will make some tests fail.
See #530.