### PR TITLE
Improve FoldValidation

### DIFF
--- a/LanguageExt.Core/ClassInstances/Foldable/FoldValidationSeq.cs
+++ b/LanguageExt.Core/ClassInstances/Foldable/FoldValidationSeq.cs
@@ -1,7 +1,5 @@
-﻿using LanguageExt.TypeClasses;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt.ClassInstances
 {
@@ -20,8 +18,8 @@ namespace LanguageExt.ClassInstances
 
         public S BiFold<S>(Validation<FAIL, SUCCESS> foldable, S state, Func<S, FAIL, S> fa, Func<S, SUCCESS, S> fb) =>
             foldable.Match(
-                Fail:    f => f.Fold(state, fa),
-                Succ:    s => fb(state, s));
+                Fail: f => f.Fold(state, fa),
+                Succ: s => fb(state, s));
 
         public S BiFoldBack<S>(Validation<FAIL, SUCCESS> foldable, S state, Func<S, FAIL, S> fa, Func<S, SUCCESS, S> fb) =>
             foldable.Match(
@@ -36,7 +34,7 @@ namespace LanguageExt.ClassInstances
         public Validation<FAIL, SUCCESS> Empty() =>
             Validation<FAIL, SUCCESS>.Fail(Seq<FAIL>.Empty);
 
-        public Func<Unit, S> Fold<S>(Validation<FAIL, SUCCESS> fa, S state, Func<S, SUCCESS, S> f) => _ => 
+        public Func<Unit, S> Fold<S>(Validation<FAIL, SUCCESS> fa, S state, Func<S, SUCCESS, S> f) => _ =>
             fa.Match(
                 Fail: x => state,
                 Succ: s => f(state, s));

--- a/LanguageExt.Core/ClassInstances/Foldable/FoldValidationSeq.cs
+++ b/LanguageExt.Core/ClassInstances/Foldable/FoldValidationSeq.cs
@@ -12,13 +12,11 @@ namespace LanguageExt.ClassInstances
         Foldable<Validation<FAIL, SUCCESS>, SUCCESS>
     {
         public Validation<FAIL, SUCCESS> Append(Validation<FAIL, SUCCESS> x, Validation<FAIL, SUCCESS> y) =>
-            x.Match(
-                Succ: xs => y.Match(
-                    Succ: ys => x,
-                    Fail: yf => y),
-                Fail: xf => y.Match(
-                    Succ: ys => x,
-                    Fail: yf => Validation<FAIL, SUCCESS>.Fail(default(MSeq<FAIL>).Append(xf, yf))));
+            y.Match(
+                Succ: ys => x,
+                Fail: yf => x.Match(
+                    Succ: xs => y,
+                    Fail: xf => Validation<FAIL, SUCCESS>.Fail(default(MSeq<FAIL>).Append(xf, yf))));
 
         public S BiFold<S>(Validation<FAIL, SUCCESS> foldable, S state, Func<S, FAIL, S> fa, Func<S, SUCCESS, S> fb) =>
             foldable.Match(

--- a/LanguageExt.Tests/ValidationTests.cs
+++ b/LanguageExt.Tests/ValidationTests.cs
@@ -257,9 +257,10 @@ namespace LanguageExt.Tests
         /// </summary>
         public static Validation<Error, CreditCard> ValidateCreditCard(string cardHolder, string number, string expMonth, string expYear)
         {
+            var fakeDateTime = new DateTime(year: 2019, month: 1, day: 1);
             var cardHolderV = ValidateCardHolder(cardHolder);
             var numberV = DigitsOnly(number) | MaxStrLength(16)(number);
-            var validToday = ValidExpiration(DateTime.Now.Month, DateTime.Now.Year);
+            var validToday = ValidExpiration(fakeDateTime.Month, fakeDateTime.Year);
 
             // This falls back to monadic behaviour because validToday needs both
             // a month and year to continue.  


### PR DESCRIPTION
Small simplification and optimization in `FoldValidation.Apply`.

Also fixed the "infamous" [Y2020M11 bug](https://github.com/louthy/language-ext/commits?author=bender2k14) :P

(Otherwise, [this test](https://github.com/louthy/language-ext/blob/master/LanguageExt.Tests/ValidationTests.cs#L136) would start on failing November 1, 2020.)