### PR TITLE
Bugfix for Try / TryOption (mostly bottom state)

### DIFF
--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <FileVersion>3.0.0.0</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>

--- a/LanguageExt.Tests/TryBottom.cs
+++ b/LanguageExt.Tests/TryBottom.cs
@@ -1,0 +1,29 @@
+﻿using LanguageExt;
+using System;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExtTests
+{
+    public class TryBottom
+    {
+        [Fact]
+        public void TryBottomMatch()
+        {
+            var tryBottom = Try<string>((Exception)null); // produce bottom value
+            Assert.True(tryBottom.Try().IsBottom, "Try not in Bottom (test requirement)");
+            Assert.True(tryBottom.Match(some => false, ex => ex != null), "Try.Match in Bottom does give null as Exception");
+            Assert.True(tryBottom.Match(some => false, ex => ex is BottomException), "Try.Match in Bottom does not give BottomException");
+            Assert.Equal(nameof(BottomException), tryBottom.IfFail(ex => ex?.GetType().Name));
+            Assert.Throws<BottomException>(() => tryBottom.IfFailThrow());
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task TryBottomMatchAsync()
+        {
+            var tryAsyncBottom = Try<string>((Exception)null).ToAsync(); // produce bottom value
+            Assert.True((await tryAsyncBottom.Try()).IsBottom, "TryAsync not in Bottom (test requirement)");
+            Assert.True(await tryAsyncBottom.Match(some => false, ex => ex is BottomException), "TryAsync.Match in Bottom does not give BottomException");
+        }
+    }
+}

--- a/LanguageExt.Tests/TryOption.cs
+++ b/LanguageExt.Tests/TryOption.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Xunit;
 using LanguageExt;
 using static LanguageExt.Prelude;
@@ -28,5 +29,23 @@ namespace LanguageExtTests
     
         public TryOption<string> GetLastPathObj(string text) =>
             () => text.Split('/').Last();
+
+        [Fact]
+        public void TryOptionBottomMatch()
+        {
+            var tryOptionBottom = TryOption<string>((Exception) null); // produce bottom value
+            Assert.True(tryOptionBottom.Try().IsBottom, "TryOption not in Bottom (test requirement)");
+            Assert.True(tryOptionBottom.Match(some => false, () => false, ex => ex != null), "TryOption.Match in Bottom does give null as Exception");
+            Assert.True(tryOptionBottom.Match(some => false, () => false, ex => ex is BottomException), "TryOption.Match in Bottom does not give BottomException");
+            Assert.Equal(nameof(BottomException), tryOptionBottom.IfNoneOrFail(() => "", ex => ex?.GetType().Name));
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task TryOptionBottomMatchAsync()
+        {
+            var tryOptionBottom = TryOption<string>((Exception) null); // produce bottom value
+            Assert.True(tryOptionBottom.Try().IsBottom, "TryOption not in Bottom (test requirement)");
+            Assert.True(await tryOptionBottom.AsTask().MatchAsync(some => false, () => false, ex => ex is BottomException), "TryOption.Match in Bottom does not give BottomException");
+        }
     }
 }


### PR DESCRIPTION
I noticed some bugs around `Try` / `TryOption`.

The problem is that some operations (like `Sequence`/`Traverse`) might produce `Try` in `Bottom` state.

`Bottom` state means `Result`/`OptionalResult` will sometimes (`default`) have `Exception == null`.

Many methods like `Match` or `IfFail` don't check this but just pass `Exception` causing possible null errors.

(There was a small bug with order of state evaluation in TryOption, too.)

**Work in progress**: My PR fixes a few things but there is more to do as there are _many_ places to check. Before investing more time I ask for feedback:

a) What is the future of TryOption? Maybe this can be dropped (there is Try<Option>)?
b) What is the future of those Async variants. There are many overloads sometimes (but not complete).

c) Maybe change some things to make implementing the fix easier / code nicer.
One point: never call `Fail(result.Exception)` but create some helper property `Result.ToFail() => Fail(ex ?? new BottomException)` and call `result.ToFail()`.


