### PR TITLE
Fix bug 559 map equals

### DIFF
--- a/LanguageExt.Core/DataTypes/Map/Map.Internal.cs
+++ b/LanguageExt.Core/DataTypes/Map/Map.Internal.cs
@@ -1338,6 +1338,7 @@ namespace LanguageExt
                 iterA.MoveNext();
                 iterB.MoveNext();
                 if (!default(OrdK).Equals(iterA.Current.Key, iterB.Current.Key)) return false;
+                if (!iterA.Current.Value.Equals(iterB.Current.Value)) return false;
             }
             return true;
         }

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -339,6 +339,7 @@ namespace LanguageExtTests
             Assert.False(Map((1, 2)).Equals(emp));
             Assert.False(emp.Equals(Map((1, 2))));
             Assert.True(Map((1, 2)).Equals(Map((1, 2))));
+            Assert.False(Map((1, 2)).Equals(Map((1, 3))));
             Assert.False(Map((1, 2), (3, 4)).Equals(Map((1, 2))));
             Assert.False(Map((1, 2)).Equals(Map((1, 2), (3, 4))));
             Assert.True(Map((1, 2), (3, 4)).Equals(Map((1, 2), (3, 4))));


### PR DESCRIPTION
Fixes bug found in #559

`Map.Equals` was returning `true` when it should have returned `false`.  This was because it was checking that the key sets were equal but was ignoring the corresponding values.  I added a line to check for equality of the values using the `object.Equals` instance method on one of the values.  (I checked and `Map` forbids the value to be `null`.)

On the other hand, maybe not checking for equality among values is the intended behavior.