### PR TITLE
Map.Equals test with different keys returns true

### DIFF
--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -339,6 +339,7 @@ namespace LanguageExtTests
             Assert.False(Map((1, 2)).Equals(emp));
             Assert.False(emp.Equals(Map((1, 2))));
             Assert.True(Map((1, 2)).Equals(Map((1, 2))));
+            Assert.True(Map((1, 2)).Equals(Map((1, 3))));
             Assert.False(Map((1, 2), (3, 4)).Equals(Map((1, 2))));
             Assert.False(Map((1, 2)).Equals(Map((1, 2), (3, 4))));
             Assert.True(Map((1, 2), (3, 4)).Equals(Map((1, 2), (3, 4))));


### PR DESCRIPTION
As revealed through #559 and #561, `Map.Equals` should return `true` when the two maps have unequal values for the same key.  This PR adds such a test.