### PR TITLE
multithreading issue with static parser definition (eof)

### DIFF
--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -552,6 +552,10 @@ namespace LanguageExtTests
         [Fact]
         public void ParallelCheck()
         {
+            // works
+            Parallel.ForEach(Enumerable.Repeat("", 4), str => parse(from _ in notFollowedBy(anyChar).label("end of input") select unit, str));
+            
+            // sometimes crashes (net461)
             Parallel.ForEach(Enumerable.Repeat("", 4), str => parse(from _ in eof select unit, str));
         }
     }

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -548,5 +548,11 @@ namespace LanguageExtTests
             Assert.True(r4.IfLeft("x") == "1234");
             Assert.True(r5.IfLeft("x") == "1234");
         }
+        
+        [Fact]
+        public void ParallelCheck()
+        {
+            Parallel.ForEach(Enumerable.Repeat("", 4), str => parse(from _ in eof select unit, str));
+        }
     }
 }


### PR DESCRIPTION
This test fails with a NullReferenceException. I guess this is caused by static eof using static anychar being null in some execution path.