### PR TITLE
Fix inconsistency in LanguageExt.Tests namespace

### DIFF
--- a/LanguageExt.Tests/Appendable.cs
+++ b/LanguageExt.Tests/Appendable.cs
@@ -3,7 +3,7 @@ using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 using static LanguageExt.TypeClass;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class Appendable
     {

--- a/LanguageExt.Tests/ArrayTests.cs
+++ b/LanguageExt.Tests/ArrayTests.cs
@@ -5,7 +5,7 @@ using LanguageExt;
 using static LanguageExt.Prelude;
 using static LanguageExt.List;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class ArrayTests
     {

--- a/LanguageExt.Tests/CompositionTests.cs
+++ b/LanguageExt.Tests/CompositionTests.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class CompositionTests
     {

--- a/LanguageExt.Tests/CondTest.cs
+++ b/LanguageExt.Tests/CondTest.cs
@@ -9,7 +9,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.CondExt;
 using Newtonsoft.Json;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class CondTest
     {

--- a/LanguageExt.Tests/DelayTests.cs
+++ b/LanguageExt.Tests/DelayTests.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 using Xunit;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class DelayTests
     {

--- a/LanguageExt.Tests/Divisible.cs
+++ b/LanguageExt.Tests/Divisible.cs
@@ -4,7 +4,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class Divisible
     {

--- a/LanguageExt.Tests/EitherApply.cs
+++ b/LanguageExt.Tests/EitherApply.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class EitherApply
     {

--- a/LanguageExt.Tests/EitherCoalesceTests.cs
+++ b/LanguageExt.Tests/EitherCoalesceTests.cs
@@ -2,7 +2,7 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class EitherCoalesceTests
     {

--- a/LanguageExt.Tests/EitherTests.cs
+++ b/LanguageExt.Tests/EitherTests.cs
@@ -2,7 +2,7 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class EitherTests

--- a/LanguageExt.Tests/EitherUnsafeApply.cs
+++ b/LanguageExt.Tests/EitherUnsafeApply.cs
@@ -3,7 +3,7 @@ using Xunit;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class EitherUnsafeApply
     {

--- a/LanguageExt.Tests/EnumerableTTests.cs
+++ b/LanguageExt.Tests/EnumerableTTests.cs
@@ -5,7 +5,7 @@ using LanguageExt;
 using static LanguageExt.Prelude;
 using Xunit;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class EnumerableTTests
     {

--- a/LanguageExt.Tests/EqualityTests.cs
+++ b/LanguageExt.Tests/EqualityTests.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class EqualityTests

--- a/LanguageExt.Tests/ExceptionMatching.cs
+++ b/LanguageExt.Tests/ExceptionMatching.cs
@@ -3,7 +3,7 @@ using System;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class ExceptionMatching

--- a/LanguageExt.Tests/FunTests.cs
+++ b/LanguageExt.Tests/FunTests.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class FunTests

--- a/LanguageExt.Tests/HashMapTests.cs
+++ b/LanguageExt.Tests/HashMapTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.Linq;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class HashMapTests
     {

--- a/LanguageExt.Tests/HashSetTests.cs
+++ b/LanguageExt.Tests/HashSetTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class HashSetTests
     {

--- a/LanguageExt.Tests/LinqTests.cs
+++ b/LanguageExt.Tests/LinqTests.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class LinqTests

--- a/LanguageExt.Tests/ListMatchingTests.cs
+++ b/LanguageExt.Tests/ListMatchingTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class ListMatchingTests

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -5,7 +5,7 @@ using LanguageExt;
 using static LanguageExt.Prelude;
 using static LanguageExt.List;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class ListTests
     {

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -6,7 +6,7 @@ using System;
 using System.Linq;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class MapTests

--- a/LanguageExt.Tests/MemoTests.cs
+++ b/LanguageExt.Tests/MemoTests.cs
@@ -5,7 +5,7 @@ using LanguageExt;
 using static LanguageExt.List;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class MemoTests

--- a/LanguageExt.Tests/MonadTests.cs
+++ b/LanguageExt.Tests/MonadTests.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class MonadTests

--- a/LanguageExt.Tests/Multiplicable.cs
+++ b/LanguageExt.Tests/Multiplicable.cs
@@ -8,7 +8,7 @@ using static LanguageExt.Prelude;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class Multiplicable
     {

--- a/LanguageExt.Tests/NewTypeTests.cs
+++ b/LanguageExt.Tests/NewTypeTests.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 using System.Reflection;
 using System.Runtime.Serialization;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class Metres : NumType<Metres, TInt, int>
     {

--- a/LanguageExt.Tests/NonNullTests.cs
+++ b/LanguageExt.Tests/NonNullTests.cs
@@ -3,7 +3,7 @@ using LanguageExt;
 using static LanguageExt.Prelude;
 using Xunit;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class NonNullTests
     {

--- a/LanguageExt.Tests/OptionApply.cs
+++ b/LanguageExt.Tests/OptionApply.cs
@@ -5,7 +5,7 @@ using LanguageExt.ClassInstances;
 using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class OptionApply
     {

--- a/LanguageExt.Tests/OptionCoalesceTests.cs
+++ b/LanguageExt.Tests/OptionCoalesceTests.cs
@@ -2,7 +2,7 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
 
     public class OptionCoalesceTests

--- a/LanguageExt.Tests/OptionTTests.cs
+++ b/LanguageExt.Tests/OptionTTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 using LanguageExt.ClassInstances;
 using System;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
 
     public class OptionTTests

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class OptionTests

--- a/LanguageExt.Tests/OptionUnsafeApply.cs
+++ b/LanguageExt.Tests/OptionUnsafeApply.cs
@@ -2,7 +2,7 @@
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class OptionUnsafeApply
     {

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -15,7 +15,7 @@ using static LanguageExt.Parsec.Expr;
 using static LanguageExt.Parsec.Token;
 using LanguageExt.UnitsOfMeasure;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class ParsecTests
     {

--- a/LanguageExt.Tests/PartialAndCurryingTests.cs
+++ b/LanguageExt.Tests/PartialAndCurryingTests.cs
@@ -1,7 +1,7 @@
 ﻿using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class PartialAndCurryingTests
     {

--- a/LanguageExt.Tests/QueryTests.cs
+++ b/LanguageExt.Tests/QueryTests.cs
@@ -2,7 +2,7 @@
 using static LanguageExt.Prelude;
 using static LanguageExt.Query;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class QueryTests

--- a/LanguageExt.Tests/QueueTests.cs
+++ b/LanguageExt.Tests/QueueTests.cs
@@ -4,7 +4,7 @@ using static LanguageExt.Queue;
 using Xunit;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class QueueTests

--- a/LanguageExt.Tests/SerialisationTests.cs
+++ b/LanguageExt.Tests/SerialisationTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 using Newtonsoft.Json;
 using System.Runtime.Serialization;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class SerialisationTests

--- a/LanguageExt.Tests/StackTests.cs
+++ b/LanguageExt.Tests/StackTests.cs
@@ -4,7 +4,7 @@ using static LanguageExt.Stack;
 using Xunit;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class StackTests

--- a/LanguageExt.Tests/Subtractable.cs
+++ b/LanguageExt.Tests/Subtractable.cs
@@ -6,7 +6,7 @@ using LanguageExt;
 using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class Subtractable
     {
@@ -83,4 +83,3 @@ namespace LanguageExtTests
         }
     }
 }
-  

--- a/LanguageExt.Tests/TaskTests.cs
+++ b/LanguageExt.Tests/TaskTests.cs
@@ -7,7 +7,7 @@ using LanguageExt;
 using System.Net.Http;
 using Nito.AsyncEx;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TaskTests
     {

--- a/LanguageExt.Tests/TryApply.cs
+++ b/LanguageExt.Tests/TryApply.cs
@@ -3,7 +3,7 @@ using System;
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TryApply
     {

--- a/LanguageExt.Tests/TryBottom.cs
+++ b/LanguageExt.Tests/TryBottom.cs
@@ -3,7 +3,7 @@ using System;
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TryBottom
     {

--- a/LanguageExt.Tests/TryMonadTests.cs
+++ b/LanguageExt.Tests/TryMonadTests.cs
@@ -5,7 +5,7 @@ using LanguageExt.ClassInstances;
 using System;
 using System.Net.Http;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
 
     public class TryOptionMonadTests

--- a/LanguageExt.Tests/TryOption.cs
+++ b/LanguageExt.Tests/TryOption.cs
@@ -4,7 +4,7 @@ using LanguageExt;
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TryOptionTests
     {

--- a/LanguageExt.Tests/TryOptionApply.cs
+++ b/LanguageExt.Tests/TryOptionApply.cs
@@ -3,7 +3,7 @@ using System;
 using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TryOptionApply
     {

--- a/LanguageExt.Tests/TryOptionMonadTests.cs
+++ b/LanguageExt.Tests/TryOptionMonadTests.cs
@@ -5,7 +5,7 @@ using static LanguageExt.Prelude;
 using System.Collections.Generic;
 using System;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class TryMonadTests

--- a/LanguageExt.Tests/TryOutTests.cs
+++ b/LanguageExt.Tests/TryOutTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 using static LanguageExt.Prelude;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class TryOutTests

--- a/LanguageExt.Tests/TrySimpleTests.cs
+++ b/LanguageExt.Tests/TrySimpleTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TrySimpleTests
     {

--- a/LanguageExt.Tests/TupleTests.cs
+++ b/LanguageExt.Tests/TupleTests.cs
@@ -1,7 +1,7 @@
 ﻿using Xunit;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class TupleTests

--- a/LanguageExt.Tests/TypeClassBiFunctor.cs
+++ b/LanguageExt.Tests/TypeClassBiFunctor.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassBiFunctor
     {

--- a/LanguageExt.Tests/TypeClassBool.cs
+++ b/LanguageExt.Tests/TypeClassBool.cs
@@ -7,7 +7,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassBool
     {

--- a/LanguageExt.Tests/TypeClassEQ.cs
+++ b/LanguageExt.Tests/TypeClassEQ.cs
@@ -3,7 +3,7 @@ using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
 using static LanguageExt.TypeClass;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassEQ
     {

--- a/LanguageExt.Tests/TypeClassFoldable.cs
+++ b/LanguageExt.Tests/TypeClassFoldable.cs
@@ -7,7 +7,7 @@ using static LanguageExt.TypeClass;
 using LanguageExt;
 using System;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassFoldable
     {

--- a/LanguageExt.Tests/TypeClassFunctor.cs
+++ b/LanguageExt.Tests/TypeClassFunctor.cs
@@ -7,7 +7,7 @@ using static LanguageExt.TypeClass;
 using LanguageExt;
 using System;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassFunctor
     {

--- a/LanguageExt.Tests/TypeClassMonad.cs
+++ b/LanguageExt.Tests/TypeClassMonad.cs
@@ -7,7 +7,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassMonad
     {

--- a/LanguageExt.Tests/TypeClassMonoid.cs
+++ b/LanguageExt.Tests/TypeClassMonoid.cs
@@ -6,7 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassMonoid
     {

--- a/LanguageExt.Tests/TypeClassORD.cs
+++ b/LanguageExt.Tests/TypeClassORD.cs
@@ -3,7 +3,7 @@ using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
 using static LanguageExt.TypeClass;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class TypeClassORD
     {

--- a/LanguageExt.Tests/UnitsOfMeasureTests.cs
+++ b/LanguageExt.Tests/UnitsOfMeasureTests.cs
@@ -9,7 +9,7 @@ using LanguageExt;
 using LanguageExt.UnitsOfMeasure;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     public class UnitsOfMeasureTests
     {

--- a/LanguageExt.Tests/UnsafeTests.cs
+++ b/LanguageExt.Tests/UnsafeTests.cs
@@ -2,7 +2,7 @@
 using LanguageExt;
 using static LanguageExt.Prelude;
 
-namespace LanguageExtTests
+namespace LanguageExt.Tests
 {
     
     public class UnsafeTests


### PR DESCRIPTION
Change namespace from LanguageExtTests to LanguageExt.Tests in some of the files