### PR TITLE
Fixed - Bug in ReaderResult Match

### DIFF
--- a/LanguageExt.Core/DataTypes/Reader/Reader.cs
+++ b/LanguageExt.Core/DataTypes/Reader/Reader.cs
@@ -46,8 +46,8 @@ namespace LanguageExt
 
         public B Match<B>(Func<A, B> Succ, Func<Error, B> Fail) =>
             IsFaulted
-                ? Succ(Value)
-                : Fail(ErrorInt);
+                ? Fail(ErrorInt)
+                : Succ(Value);
 
         public A IfFail(A value) =>
             IsFaulted

--- a/LanguageExt.Tests/ReaderResultTests.cs
+++ b/LanguageExt.Tests/ReaderResultTests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public class ValidationResultTests
+    {
+        [Fact]
+        public void MatchWhenNotFaulted()
+        {
+            // This will throw an InvalidCastException
+            var expected = "Some value";
+            var actual = ReaderResult<string>.New(expected).Match(s => s, error => error.Message);
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void MatchWhenFaulted()
+        {
+            var expected = "Some error";
+            var actual = ReaderResult<string>.New(Common.Error.New(expected)).Match(s => s, error => error.Message);
+            Assert.Equal(expected, actual);
+        }
+
+    }
+}


### PR DESCRIPTION
**Test that should surface the bug**

```c#
using Xunit;

namespace LanguageExt.Tests
{
    public class ReaderResultTests
    {
        [Fact]
        public void MatchWhenNotFaulted()
        {
            // This will throw an InvalidCastException
            var expected = "Some value";
            var actual = ReaderResult<string>.New(expected).Match(s => s, error => error.Message);
            Assert.Equal(expected, actual);
        }
        
        [Fact]
        public void MatchWhenFaulted()
        {
            var expected = "Some error";
            var actual = ReaderResult<string>.New(Common.Error.New(expected)).Match(s => s, error => error.Message);
            Assert.Equal(expected, actual);
        }
        
        
    }
}
```
