### PR TITLE
Test and fix for Seq.Add issue

### DIFF
--- a/LanguageExt.Core/DataTypes/Seq/SeqStrict.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqStrict.cs
@@ -76,7 +76,7 @@ namespace LanguageExt
         /// Add an item to the end of the sequence
         /// </summary>
         /// <remarks>
-        /// Forces evaluation of the entire lazy sequence so the item
+        /// Forces evaluation of the entire lazy sequence so the item 
         /// can be appended
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -145,7 +145,7 @@ namespace LanguageExt
                 // value
                 System.Array.Copy(data, 0, ndata, data.Length, data.Length);
 
-                // The new head position will be 1 cell to to left of the
+                // The new head position will be 1 cell to to left of the 
                 // middle of the newly allocated block.
                 var nstart = data.Length == 0
                                 ? 0
@@ -157,13 +157,13 @@ namespace LanguageExt
                 // Set the value in the new data block
                 ndata[nstart] = value;
 
-                // Return everything
+                // Return everything 
                 return new SeqStrict<A>(ndata, nstart, ncount, 0, 0);
             }
             else
             {
                 // We're cloning because there are multiple cons operations
-                // from the same Seq.  We can't keep walking along the same
+                // from the same Seq.  We can't keep walking along the same 
                 // array, so we clone with the exact same settings and insert
 
                 var ndata = new A[data.Length];
@@ -197,7 +197,7 @@ namespace LanguageExt
             // Set the value in the new data block
             ndata[end] = value;
 
-            // Return everything
+            // Return everything 
             return new SeqStrict<A>(ndata, start, count + 1, 0, 0);
         }
 
@@ -219,7 +219,7 @@ namespace LanguageExt
             // Set the value in the new data block
             System.Array.Copy(values, valuesStart, ndata, end, valuesCount);
 
-            // Return everything
+            // Return everything 
             return new SeqStrict<A>(ndata, start, count + valuesCount, 0, 0);
         }
 
@@ -250,7 +250,7 @@ namespace LanguageExt
         /// Returns true if the sequence is empty
         /// </summary>
         /// <remarks>
-        /// For lazy streams this will have to peek at the first
+        /// For lazy streams this will have to peek at the first 
         /// item.  So, the first item will be consumed.
         /// </summary>
         public bool IsEmpty
@@ -302,7 +302,7 @@ namespace LanguageExt
         }
 
         /// <summary>
-        /// Fold the sequence from the last item to the first.  For
+        /// Fold the sequence from the last item to the first.  For 
         /// sequences that are not lazy and are less than 5000 items
         /// long, FoldBackRec is called instead, because it is faster.
         /// </summary>

--- a/LanguageExt.Core/DataTypes/Seq/SeqStrict.cs
+++ b/LanguageExt.Core/DataTypes/Seq/SeqStrict.cs
@@ -76,7 +76,7 @@ namespace LanguageExt
         /// Add an item to the end of the sequence
         /// </summary>
         /// <remarks>
-        /// Forces evaluation of the entire lazy sequence so the item 
+        /// Forces evaluation of the entire lazy sequence so the item
         /// can be appended
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -145,7 +145,7 @@ namespace LanguageExt
                 // value
                 System.Array.Copy(data, 0, ndata, data.Length, data.Length);
 
-                // The new head position will be 1 cell to to left of the 
+                // The new head position will be 1 cell to to left of the
                 // middle of the newly allocated block.
                 var nstart = data.Length == 0
                                 ? 0
@@ -157,13 +157,13 @@ namespace LanguageExt
                 // Set the value in the new data block
                 ndata[nstart] = value;
 
-                // Return everything 
+                // Return everything
                 return new SeqStrict<A>(ndata, nstart, ncount, 0, 0);
             }
             else
             {
                 // We're cloning because there are multiple cons operations
-                // from the same Seq.  We can't keep walking along the same 
+                // from the same Seq.  We can't keep walking along the same
                 // array, so we clone with the exact same settings and insert
 
                 var ndata = new A[data.Length];
@@ -179,8 +179,12 @@ namespace LanguageExt
 
         SeqStrict<A> CloneAdd(A value)
         {
+            var end = start + count;
+
             // Find the new size of the data array
-            var nlength = Math.Max(data.Length << 1, 1);
+            var nlength = data.Length == end
+                ? Math.Max(data.Length << 1, 1)
+                : data.Length;
 
             // Allocate it
             var ndata = new A[nlength];
@@ -191,9 +195,9 @@ namespace LanguageExt
             System.Array.Copy(data, 0, ndata, 0, data.Length);
 
             // Set the value in the new data block
-            ndata[data.Length] = value;
+            ndata[end] = value;
 
-            // Return everything 
+            // Return everything
             return new SeqStrict<A>(ndata, start, count + 1, 0, 0);
         }
 
@@ -215,12 +219,12 @@ namespace LanguageExt
             // Set the value in the new data block
             System.Array.Copy(values, valuesStart, ndata, end, valuesCount);
 
-            // Return everything 
+            // Return everything
             return new SeqStrict<A>(ndata, start, count + valuesCount, 0, 0);
         }
 
         /// <summary>
-        /// Head item in the sequence.  NOTE:  If `IsEmpty` is true then Head 
+        /// Head item in the sequence.  NOTE:  If `IsEmpty` is true then Head
         /// is undefined.  Call HeadOrNone() if for maximum safety.
         /// </summary>
         public A Head
@@ -246,7 +250,7 @@ namespace LanguageExt
         /// Returns true if the sequence is empty
         /// </summary>
         /// <remarks>
-        /// For lazy streams this will have to peek at the first 
+        /// For lazy streams this will have to peek at the first
         /// item.  So, the first item will be consumed.
         /// </summary>
         public bool IsEmpty
@@ -298,7 +302,7 @@ namespace LanguageExt
         }
 
         /// <summary>
-        /// Fold the sequence from the last item to the first.  For 
+        /// Fold the sequence from the last item to the first.  For
         /// sequences that are not lazy and are less than 5000 items
         /// long, FoldBackRec is called instead, because it is faster.
         /// </summary>

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -254,5 +254,20 @@ namespace LanguageExt.Tests
             Assert.Equal("a|c", string.Join("|", c));
 
         }
+
+        [Fact]
+        public void ConsTest()
+        {
+            var a = Seq1("a");
+
+            var b = "b".Cons(a);
+
+            var c = "c".Cons(a);
+
+            Assert.Equal("a", string.Join("|", a));
+            Assert.Equal("b|a", string.Join("|", b));
+            Assert.Equal("c|a", string.Join("|", c));
+
+        }
     }
 }

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -239,5 +239,20 @@ namespace LanguageExt.Tests
 
             Assert.True(eq);
         }
+
+        [Fact]
+        public void AddTest()
+        {
+            var a = Seq1("a");
+
+            var b = a.Add("b");
+
+            var c = a.Add("c");
+
+            Assert.Equal("a", string.Join("|", a));
+            Assert.Equal("a|b", string.Join("|", b));
+            Assert.Equal("a|c", string.Join("|", c));
+
+        }
     }
 }


### PR DESCRIPTION
In relation to #635 

Seq.Add calls CloneAdd when the Seq has already been added to. CloneAdd assumed the array needed to be expanded each time however this is not always the case and when it's not the next value was inserted in the wrong place and a value from another Seq leaked through.