### PR TITLE
manyn0 parser now works correct for n==0

### DIFF
--- a/LanguageExt.Parsec/Parsers/Prim.cs
+++ b/LanguageExt.Parsec/Parsers/Prim.cs
@@ -398,49 +398,52 @@ namespace LanguageExt.Parsec
         /// Enumerable of the returned values of p.
         /// </returns>
         public static Parser<Seq<T>> manyn0<T>(Parser<T> p, int n) =>
-            inp =>
-            {
-                var current = inp;
-                var results = new List<T>();
-                ParserError error = null;
-
-                int count = 0;
-
-                while (true)
+            n <= 0 
+                ? result(Seq<T>.Empty)
+                : inp =>
                 {
-                    var t = p(current);
-                    count++;
+                    var current = inp;
+                    var results = new List<T>();
+                    ParserError error = null;
 
-                    // cok
-                    if (t.Tag == ResultTag.Consumed && t.Reply.Tag == ReplyTag.OK)
+                    int count = 0;
+
+                    while (true)
                     {
-                        results.Add(t.Reply.Result);
-                        current = t.Reply.State;
-                        error = t.Reply.Error;
-                        if (count == n)
+                        var t = p(current);
+                        count++;
+
+                        // cok
+                        if (t.Tag == ResultTag.Consumed && t.Reply.Tag == ReplyTag.OK)
                         {
-                            return EmptyOK(Seq(results), current, mergeError(error, t.Reply.Error));
+                            results.Add(t.Reply.Result);
+                            current = t.Reply.State;
+                            error = t.Reply.Error;
+                            if (count == n)
+                            {
+                                return EmptyOK(Seq(results), current, mergeError(error, t.Reply.Error));
+                            }
+
+                            continue;
                         }
-                        continue;
-                    }
 
-                    // eok
-                    if (t.Tag == ResultTag.Empty && t.Reply.Tag == ReplyTag.OK)
-                    {
-                        // eok, eerr
-                        return EmptyError<Seq<T>>(new ParserError(ParserErrorTag.SysUnexpect, current.Pos, "many: combinator 'manyn' is applied to a parser that accepts an empty string.", List.empty<string>()));
-                    }
+                        // eok
+                        if (t.Tag == ResultTag.Empty && t.Reply.Tag == ReplyTag.OK)
+                        {
+                            // eok, eerr
+                            return EmptyError<Seq<T>>(new ParserError(ParserErrorTag.SysUnexpect, current.Pos, "many: combinator 'manyn' is applied to a parser that accepts an empty string.", List.empty<string>()));
+                        }
 
-                    // cerr
-                    if (t.Tag == ResultTag.Consumed && t.Reply.Tag == ReplyTag.Error)
-                    {
-                        return ConsumedError<Seq<T>>(mergeError(error, t.Reply.Error));
-                    }
+                        // cerr
+                        if (t.Tag == ResultTag.Consumed && t.Reply.Tag == ReplyTag.Error)
+                        {
+                            return ConsumedError<Seq<T>>(mergeError(error, t.Reply.Error));
+                        }
 
-                    // eerr
-                    return EmptyOK(Seq(results), current, mergeError(error, t.Reply.Error));
-                }
-            };
+                        // eerr
+                        return EmptyOK(Seq(results), current, mergeError(error, t.Reply.Error));
+                    }
+                };
 
         /// <summary>
         /// manyn1(p) applies the parser p one or up to a maximum of n times.

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -550,6 +550,13 @@ namespace LanguageExt.Tests
         }
         
         [Fact]
+        public void ParseN0TimesZeroNegative()
+        {
+            Assert.True(parse(asString(manyn0(digit, 0)), "123").ToEither().IfLeft("x") == "");
+            Assert.True(parse(asString(manyn0(digit, -1)), "123").ToEither().IfLeft("x") == "");
+        }
+        
+        [Fact]
         public void ParallelCheck()
         {
             // works


### PR DESCRIPTION
I think n==0 is a valid input for `manyn0`. This change fixes it.

I copied the logic from `counti` implementation (i.e. negative values are ok, same result like 0).
Other parsers seem to have different results for out of range input values, e.g. `manyn1`:

``` 
[Fact]
        public void ParseN1TimesOutOfRange()
        {
            Assert.Equal("", parse(asString(manyn1(digit, 0)), "1").ToEither().IfLeft("x"));
            Assert.Equal("", parse(asString(manyn1(digit, 0)), "").ToEither().IfLeft("x"));
        }
```

Question: Should out of range input (here: negative `n`) result in error or should it work as if minimal viable input is given or should it produce empty result? (I'm ok with "undefined" for now...)