### PR TITLE
adds consume-only version of Iter extension

### DIFF
--- a/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
@@ -757,10 +757,10 @@ public static class ListExtensions
     /// Iterate each item in the enumerable in order (consume items)
     /// </summary>
     /// <typeparam name="T">Enumerable item type</typeparam>
-    /// <param name="list">Enumerable to iterate</param>
+    /// <param name="list">Enumerable to consume</param>
     /// <returns>Unit</returns>
-    public static Unit Iter<T>(this IEnumerable<T> list) =>
-        LanguageExt.List.iter(list);
+    public static Unit Consume<T>(this IEnumerable<T> list) =>
+        LanguageExt.List.consume(list);
 
     /// <summary>
     /// Returns true if all items in the enumerable match a predicate (Any in LINQ)

--- a/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Extensions.cs
@@ -754,6 +754,15 @@ public static class ListExtensions
         LanguageExt.List.iter(list, action);
 
     /// <summary>
+    /// Iterate each item in the enumerable in order (consume items)
+    /// </summary>
+    /// <typeparam name="T">Enumerable item type</typeparam>
+    /// <param name="list">Enumerable to iterate</param>
+    /// <returns>Unit</returns>
+    public static Unit Iter<T>(this IEnumerable<T> list) =>
+        LanguageExt.List.iter(list);
+
+    /// <summary>
     /// Returns true if all items in the enumerable match a predicate (Any in LINQ)
     /// </summary>
     /// <typeparam name="T">Enumerable item type</typeparam>

--- a/LanguageExt.Core/DataTypes/List/Lst.Module.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Module.cs
@@ -891,9 +891,9 @@ namespace LanguageExt
         /// Iterate each item in the enumerable in order (consume items)
         /// </summary>
         /// <typeparam name="T">Enumerable item type</typeparam>
-        /// <param name="list">Enumerable to iterate</param>
+        /// <param name="list">Enumerable to consume</param>
         /// <returns>Unit</returns>
-        public static Unit iter<T>(IEnumerable<T> list)
+        public static Unit consume<T>(IEnumerable<T> list)
         {
             foreach (var item in list)
             {

--- a/LanguageExt.Core/DataTypes/List/Lst.Module.cs
+++ b/LanguageExt.Core/DataTypes/List/Lst.Module.cs
@@ -888,6 +888,20 @@ namespace LanguageExt
         }
 
         /// <summary>
+        /// Iterate each item in the enumerable in order (consume items)
+        /// </summary>
+        /// <typeparam name="T">Enumerable item type</typeparam>
+        /// <param name="list">Enumerable to iterate</param>
+        /// <returns>Unit</returns>
+        public static Unit iter<T>(IEnumerable<T> list)
+        {
+            foreach (var item in list)
+            {
+            }
+            return unit;
+        }
+
+        /// <summary>
         /// Returns true if all items in the enumerable match a predicate (Any in LINQ)
         /// </summary>
         /// <typeparam name="T">Enumerable item type</typeparam>

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -297,16 +297,16 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
-        public void IterNoopTest()
+        public void ConsumeTest()
         {
             var embeddedSideEffectResult = 0;
-            var expression = from dummy in Some(unit)
+            System.Collections.Generic.IEnumerable<int> expression = from dummy in Some(unit)
                 from i in List(2, 3, 5)
                 let _ = fun(() => embeddedSideEffectResult += i)()
                 select i;
 
             Assert.Equal(0, embeddedSideEffectResult);
-            expression.Iter();
+            expression.Consume();
             Assert.Equal(2 + 3+ 5, embeddedSideEffectResult);
         }
         

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -261,6 +261,56 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void IterSimpleTest()
+        {
+            var embeddedSideEffectResult = 0;
+            var expression = from dummy in Some(unit)
+                from i in List(2, 3, 5)
+                let _ = fun(() => embeddedSideEffectResult += i)()
+                select i;
+
+            Assert.Equal(0, embeddedSideEffectResult);
+
+            var sideEffectByAction = 0;
+
+            expression.Iter(i => sideEffectByAction += i * i);
+            Assert.Equal(2 + 3 + 5, embeddedSideEffectResult);
+            Assert.Equal(2 * 2 + 3 * 3 + 5 * 5, sideEffectByAction);
+        }
+
+        [Fact]
+        public void IterPositionalTest()
+        {
+            var embeddedSideEffectResult = 0;
+            var expression = from dummy in Some(unit)
+                from i in List(2, 3, 5)
+                let _ = fun(() => embeddedSideEffectResult += i)()
+                select i;
+
+            Assert.Equal(0, embeddedSideEffectResult);
+
+            var sideEffectByAction = 0;
+
+            expression.Iter((pos, i) => sideEffectByAction += i * pos);
+            Assert.Equal(2 + 3 + 5, embeddedSideEffectResult);
+            Assert.Equal(2 * 0 + 3 * 1 + 5 * 2, sideEffectByAction);
+        }
+
+        [Fact]
+        public void IterNoopTest()
+        {
+            var embeddedSideEffectResult = 0;
+            var expression = from dummy in Some(unit)
+                from i in List(2, 3, 5)
+                let _ = fun(() => embeddedSideEffectResult += i)()
+                select i;
+
+            Assert.Equal(0, embeddedSideEffectResult);
+            expression.Iter();
+            Assert.Equal(2 + 3+ 5, embeddedSideEffectResult);
+        }
+        
+        [Fact]
         public void SkipLastTest1()
         {
             var list = List(1, 2, 3, 4, 5);


### PR DESCRIPTION
This is a very minor feature request (with code + tests).

Background I often have LINQ expressions resulting in `IEnumerable<T>` with side-effects (legacy code). I need to just execute it (no return value).

This is similar to e.g. `Consume` extension function in MoreLinq but returns `Unit`.

This new `.Iter()` version could be replaced by existing `.Iter(dummy => {})` but the latter is IMHO an ugly workaround.

I don't expect this commit to be merged -- it's just a feature request.

