### PR TITLE
Compose missing variant + useful(?) extensions

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude_Func.cs
+++ b/LanguageExt.Core/Prelude/Prelude_Func.cs
@@ -681,6 +681,14 @@ namespace LanguageExt
         /// <summary>
         /// Function composition
         /// </summary>
+        /// <returns>b(a(()))</returns>
+        [Pure]
+        public static Func<T2> compose<T1, T2>(Func<T1> a, Func<T1, T2> b) =>
+            () => b(a());
+        
+        /// <summary>
+        /// Function composition
+        /// </summary>
         /// <returns>b(a(v))</returns>
         [Pure]
         public static Func<T1, T3> compose<T1, T2, T3>(Func<T1, T2> a, Func<T2, T3> b) =>

--- a/LanguageExt.Parsec/Parser.cs
+++ b/LanguageExt.Parsec/Parser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using LanguageExt;
 using LanguageExt.Parsec;
 using static LanguageExt.Prelude;
 using static LanguageExt.Parsec.Prim;
@@ -174,4 +175,16 @@ public static class ParserExtensions
                 // eerr
                 return EmptyError<V>(t.Reply.Error);
             };
+
+    public static Parser<T> Flatten<T>(this Parser<Option<T>> p, Func<string> failureText) =>
+        from value in p
+        from returnValue in value.Match(result, compose(failureText, failure<T>))
+        select returnValue;
+
+    public static Parser<R> Flatten<L, R>(this Parser<Either<L, R>> p, Func<L, string> failureText) =>
+        from value in p
+        from returnValue in value.Match(result, compose(failureText, failure<R>))
+        select returnValue;
+    
+    public static Parser<R> Flatten<R>(this Parser<Either<string,R>> p) => Flatten(p, identity);
 }


### PR DESCRIPTION
Hi,

1. Commit: Feature PR (https://github.com/louthy/language-ext/commit/4482d003cf7eec54d7b2dc7d8b23444385f0ae39)

I think this smallest version in Prelude was just missing (exists as method).

2. Commit: Question (https://github.com/louthy/language-ext/commit/4b1abf38fc9e74e801c93cdb0465501aac613550): 

After I started to work with Parsers I often look for something like these. I guess my naming is bad and perhaps this is the wrong location for extensions like this, so ***you probably do not want to merge this as is***. Perhaps you don't want Parser to be cluttered with stuff like this (?). Anyway I'm interested in your opinion how this can be done better (in user code) with existing options or whether you like extensions like this (then guidance about naming and location would be nice).
