### PR TITLE
Should solve request #550 (IfNone(Action) sideeffect)

### DIFF
--- a/LanguageExt.Core/DataTypes/Option/Option.cs
+++ b/LanguageExt.Core/DataTypes/Option/Option.cs
@@ -737,6 +737,17 @@ namespace LanguageExt
                 ? Value
                 : Check.NullReturn(None());
 
+
+        /// <summary>
+        /// Invokes the action if Option is in the None state, otherwise nothing happens.
+        /// </summary>
+        /// <param name="f">Action to invoke if Option is in the None state</param>
+        public Unit IfNone(Action None)
+        {
+            if (IsNone) None();
+            return unit;
+        }
+        
         /// <summary>
         /// Returns the noneValue if the optional is in a None state, otherwise
         /// the bound Some(x) value is returned.

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -195,6 +195,28 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void IfNoneSideEffect()
+        {
+            int sideEffectResult = 0;
+
+            Action sideEffectNone = () => sideEffectResult += 1;
+
+            Assert.Equal(0, Option<string>.Some("test").IfNone(sideEffectNone).Return(sideEffectResult));
+            Assert.Equal(1, Option<string>.None.IfNone(sideEffectNone).Return(sideEffectResult));
+        }
+
+        [Fact]
+        public void ISomeSideEffect()
+        {
+            int sideEffectResult = 0;
+
+            Action<string> sideEffectSome = _ => sideEffectResult += 2;
+
+            Assert.Equal(0, Option<string>.None.IfSome(sideEffectSome).Return(sideEffectResult));
+            Assert.Equal(2, Option<string>.Some("test").IfSome(sideEffectSome).Return(sideEffectResult));
+        }
+
+        [Fact]
         public void OptionMap_ToNull_ThrowsValueIsNullException()
         {
             var option = Some(new object());


### PR DESCRIPTION
see https://github.com/louthy/language-ext/issues/550

I personally would avoid this style but I see no point in having `IfSome(Action)` without having `IfNone(Action)`. 
