### PR TITLE
Feature/Improve existing benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ ModelManifest.xml
 /Parsec Tests.playlist
 /LanguageExt.Tests/LanguageExt.Tests.nuget.props
 /.idea/.idea.language-ext
+
+# Benchmark artifacts
+BenchmarkDotNet.Artifacts/

--- a/LanguageExt.Benchmarks/HashMapAddBenchmarks.cs
+++ b/LanguageExt.Benchmarks/HashMapAddBenchmarks.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Immutable;
 using BenchmarkDotNet.Attributes;
 using static LanguageExt.Prelude;
@@ -7,43 +6,55 @@ using static LanguageExt.Prelude;
 namespace LanguageExt.Benchmarks
 {
     [RPlotExporter, RankColumn]
-    public class HashMapAddBenchmark
+    [GenericTypeArguments(typeof(int))]
+    [GenericTypeArguments(typeof(string))]
+    public class HashMapAddBenchmark<T>
     {
-
         [Params(100, 1000, 10000, 100000)]
         public int N;
 
-        [Benchmark]
-        public void SysColImmutableDictionary()
-        {
-            var map = ImmutableDictionary.Create<int, int>();
+        Dictionary<T, T> values;
 
-            for (int j = 0; j < N; j++)
-            {
-                map = map.Add(j, j);
-            }
+        [GlobalSetup]
+        public void Setup()
+        {
+            values = ValuesGenerator.Default.GenerateDictionary<T, T>(N);
         }
 
         [Benchmark]
-        public void SysColDictionary()
+        public ImmutableDictionary<T, T> SysColImmutableDictionary()
         {
-            var map = new Dictionary<int, int>();
-
-            for (int j = 0; j < N; j++)
+            var map = ImmutableDictionary.Create<T, T>();
+            foreach (var kvp in values)
             {
-                map.Add(j, j);
+                map = map.Add(kvp.Key, kvp.Value);
             }
+
+            return map;
         }
 
         [Benchmark]
-        public void LangExtHashMap()
+        public Dictionary<T, T> SysColDictionary()
         {
-            var map = HashMap<int, int>();
-
-            for (int j = 0; j < N; j++)
+            var map = new Dictionary<T, T>();
+            foreach (var kvp in values)
             {
-                map = map.Add(j, j);
+                map.Add(kvp.Key, kvp.Value);
             }
+
+            return map;
+        }
+
+        [Benchmark]
+        public HashMap<T, T> LangExtHashMap()
+        {
+            var map = HashMap<T, T>();
+            foreach (var kvp in values)
+            {
+                map = map.Add(kvp.Key, kvp.Value);
+            }
+
+            return map;
         }
     }
 }

--- a/LanguageExt.Benchmarks/Program.cs
+++ b/LanguageExt.Benchmarks/Program.cs
@@ -1,17 +1,12 @@
-﻿using System;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 
 namespace LanguageExt.Benchmarks
 {
     class Program
     {
-        static void Main(string[] args)
-        {
-            var summary1 = BenchmarkRunner.Run<HashMapAddBenchmark>();
-            Console.Write(summary1);
-
-            var summary2 = BenchmarkRunner.Run<HashMapRandomReadBenchmark>();
-            Console.Write(summary2);
-        }
+        static void Main(string[] args) =>
+            BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(args);
     }
 }

--- a/LanguageExt.Benchmarks/ValuesGenerator.cs
+++ b/LanguageExt.Benchmarks/ValuesGenerator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LanguageExt.Benchmarks
+{
+    internal class ValuesGenerator
+    {
+        public static readonly ValuesGenerator Default = new ValuesGenerator(1234);
+
+        readonly Random rand;
+
+        public ValuesGenerator(int seed)
+        {
+            rand = new Random(seed);
+        }
+
+        public Dictionary<TKey, TValue> GenerateDictionary<TKey, TValue>(int count)
+        {
+            var dict = new Dictionary<TKey, TValue>(count);
+            while (dict.Count < count)
+            {
+                dict[GenerateValue<TKey>()] = GenerateValue<TValue>();
+            }
+
+            return dict;
+        }
+
+        public T[] GenerateUniqueValues<T>(int count)
+        {
+            var set = new System.Collections.Generic.HashSet<T>(count);
+            while (set.Count < count)
+            {
+                set.Add(GenerateValue<T>());
+            }
+
+            return set.ToArray();
+        }
+
+        public T GenerateValue<T>()
+        {
+            if (typeof(T) == typeof(int))
+            {
+                return (T)(object)rand.Next();
+            }
+
+            if (typeof(T) == typeof(string))
+            {
+                return (T)(object)GenerateString(1, 50);
+            }
+
+            throw new NotSupportedException($"Generating value of type {typeof(T)} is not supported");
+        }
+
+        private string GenerateString(int minLength, int maxLength)
+        {
+            var length = rand.Next(minLength, maxLength);
+            var sb = new StringBuilder(length);
+
+            for (var i = 0; i < length; i++)
+            {
+                switch (rand.Next(0, 3))
+                {
+                    case 0:
+                        sb.Append(rand.Next('0', '9'));
+                        break;
+
+                    case 1:
+                        sb.Append(rand.Next('A', 'Z'));
+                        break;
+
+                    default:
+                        sb.Append(rand.Next('a', 'z'));
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/LanguageExt.Benchmarks/ValuesGenerator.cs
+++ b/LanguageExt.Benchmarks/ValuesGenerator.cs
@@ -7,7 +7,7 @@ namespace LanguageExt.Benchmarks
 {
     internal class ValuesGenerator
     {
-        public static readonly ValuesGenerator Default = new ValuesGenerator(1234);
+        public static readonly ValuesGenerator Default = new ValuesGenerator(12345);
 
         readonly Random rand;
 
@@ -63,15 +63,15 @@ namespace LanguageExt.Benchmarks
                 switch (rand.Next(0, 3))
                 {
                     case 0:
-                        sb.Append(rand.Next('0', '9'));
+                        sb.Append((char)rand.Next('0', '9'));
                         break;
 
                     case 1:
-                        sb.Append(rand.Next('A', 'Z'));
+                        sb.Append((char)rand.Next('A', 'Z'));
                         break;
 
                     default:
-                        sb.Append(rand.Next('a', 'z'));
+                        sb.Append((char)rand.Next('a', 'z'));
                         break;
                 }
             }

--- a/LanguageExt.Benchmarks/ValuesGenerator.cs
+++ b/LanguageExt.Benchmarks/ValuesGenerator.cs
@@ -9,19 +9,21 @@ namespace LanguageExt.Benchmarks
     {
         public static readonly ValuesGenerator Default = new ValuesGenerator(12345);
 
-        readonly Random rand;
+        readonly int randSeed;
 
         public ValuesGenerator(int seed)
         {
-            rand = new Random(seed);
+            randSeed = seed;
         }
 
         public Dictionary<TKey, TValue> GenerateDictionary<TKey, TValue>(int count)
         {
+            var rand = new Random(randSeed);
+
             var dict = new Dictionary<TKey, TValue>(count);
             while (dict.Count < count)
             {
-                dict[GenerateValue<TKey>()] = GenerateValue<TValue>();
+                dict[GenerateValue<TKey>(rand)] = GenerateValue<TValue>(rand);
             }
 
             return dict;
@@ -29,16 +31,18 @@ namespace LanguageExt.Benchmarks
 
         public T[] GenerateUniqueValues<T>(int count)
         {
+            var rand = new Random(randSeed);
+
             var set = new System.Collections.Generic.HashSet<T>(count);
             while (set.Count < count)
             {
-                set.Add(GenerateValue<T>());
+                set.Add(GenerateValue<T>(rand));
             }
 
             return set.ToArray();
         }
 
-        public T GenerateValue<T>()
+        private T GenerateValue<T>(Random rand)
         {
             if (typeof(T) == typeof(int))
             {
@@ -47,13 +51,13 @@ namespace LanguageExt.Benchmarks
 
             if (typeof(T) == typeof(string))
             {
-                return (T)(object)GenerateString(1, 50);
+                return (T)(object)GenerateString(rand, 1, 50);
             }
 
             throw new NotSupportedException($"Generating value of type {typeof(T)} is not supported");
         }
 
-        private string GenerateString(int minLength, int maxLength)
+        private string GenerateString(Random rand, int minLength, int maxLength)
         {
             var length = rand.Next(minLength, maxLength);
             var sb = new StringBuilder(length);


### PR DESCRIPTION
Improving existing benchmarks in a way, that:

- benchmarks are generic, testing value (`int`) and reference (`string`) type
- benchmarks returning value to avoid dead code elimination (not the case here, following guidelines)
- change way how benchmark is discovered and executed, making use of BenchmarkDotNet functionality (to pick benchmark, run from cli with args, ...)

I hope these changes will help creating more benchmarks in the future.

---

## Results

### LanguageExt.Benchmarks.HashMapAddBenchmark\<Int32\>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|                    Method |      N |           Mean |         Error |        StdDev |         Median | Rank |
|-------------------------- |------- |---------------:|--------------:|--------------:|---------------:|-----:|
| **SysColImmutableDictionary** |    **100** |      **53.446 us** |     **0.7643 us** |     **0.6382 us** |      **53.542 us** |    **4** |
|          SysColDictionary |    100 |       3.399 us |     0.0118 us |     0.0104 us |       3.400 us |    1 |
|            LangExtHashMap |    100 |      27.270 us |     0.8227 us |     2.2520 us |      26.400 us |    2 |
| **SysColImmutableDictionary** |   **1000** |     **893.130 us** |     **4.9747 us** |     **4.6533 us** |     **891.881 us** |    **7** |
|          SysColDictionary |   1000 |      38.722 us |     0.7548 us |     0.7061 us |      38.567 us |    3 |
|            LangExtHashMap |   1000 |     314.437 us |    23.1194 us |    67.0737 us |     283.300 us |    5 |
| **SysColImmutableDictionary** |  **10000** |  **14,407.719 us** |    **87.9924 us** |    **73.4776 us** |  **14,387.444 us** |   **10** |
|          SysColDictionary |  10000 |     422.823 us |     2.0210 us |     1.8904 us |     422.299 us |    6 |
|            LangExtHashMap |  10000 |   3,953.675 us |   248.8433 us |   717.9699 us |   3,702.450 us |    8 |
| **SysColImmutableDictionary** | **100000** | **262,580.746 us** | **3,161.9018 us** | **2,802.9436 us** | **263,091.350 us** |   **12** |
|          SysColDictionary | 100000 |   5,928.890 us |    62.4692 us |    55.3774 us |   5,913.883 us |    9 |
|            LangExtHashMap | 100000 |  86,525.947 us | 1,300.7376 us | 1,216.7108 us |  86,157.900 us |   11 |

### LanguageExt.Benchmarks.HashMapAddBenchmark\<String\>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|                    Method |      N |           Mean |         Error |        StdDev |         Median | Rank |
|-------------------------- |------- |---------------:|--------------:|--------------:|---------------:|-----:|
| **SysColImmutableDictionary** |    **100** |      **73.077 us** |     **1.0679 us** |     **0.8917 us** |      **72.720 us** |    **3** |
|          SysColDictionary |    100 |       4.339 us |     0.0234 us |     0.0219 us |       4.344 us |    1 |
|            LangExtHashMap |    100 |      60.761 us |     2.7416 us |     7.3650 us |      59.000 us |    2 |
| **SysColImmutableDictionary** |   **1000** |   **1,168.522 us** |     **7.0777 us** |     **5.9102 us** |   **1,166.439 us** |    **6** |
|          SysColDictionary |   1000 |      59.776 us |     0.7000 us |     0.5845 us |      59.887 us |    2 |
|            LangExtHashMap |   1000 |     704.728 us |    44.3441 us |   130.0534 us |     640.300 us |    4 |
| **SysColImmutableDictionary** |  **10000** |  **18,577.576 us** |   **364.2152 us** |   **304.1362 us** |  **18,538.588 us** |    **9** |
|          SysColDictionary |  10000 |     774.591 us |    14.9721 us |    18.9350 us |     777.585 us |    5 |
|            LangExtHashMap |  10000 |   7,091.723 us |   527.1214 us | 1,545.9558 us |   7,032.300 us |    7 |
| **SysColImmutableDictionary** | **100000** | **313,514.831 us** | **6,251.6869 us** | **6,139.9925 us** | **314,982.350 us** |   **11** |
|          SysColDictionary | 100000 |   9,380.624 us |   205.5985 us |   267.3361 us |   9,303.041 us |    8 |
|            LangExtHashMap | 100000 | 134,937.640 us | 2,391.5249 us | 2,237.0339 us | 134,926.500 us |   10 |

### LanguageExt.Benchmarks.HashMapRandomReadBenchmark\<Int32\>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|                    Method |      N |            Mean |         Error |        StdDev | Rank |
|-------------------------- |------- |----------------:|--------------:|--------------:|-----:|
| **SysColImmutableDictionary** |    **100** |      **1,990.9 ns** |      **22.75 ns** |      **21.28 ns** |    **2** |
|          SysColDictionary |    100 |        918.0 ns |      12.60 ns |      11.78 ns |    1 |
|            LangExtHashMap |    100 |      2,069.3 ns |      13.16 ns |      12.31 ns |    3 |
| **SysColImmutableDictionary** |   **1000** |     **59,603.0 ns** |     **229.52 ns** |     **203.46 ns** |    **6** |
|          SysColDictionary |   1000 |     11,123.8 ns |      76.19 ns |      67.54 ns |    4 |
|            LangExtHashMap |   1000 |     25,138.6 ns |      87.96 ns |      82.28 ns |    5 |
| **SysColImmutableDictionary** |  **10000** |    **996,071.4 ns** |   **3,655.67 ns** |   **3,419.52 ns** |    **9** |
|          SysColDictionary |  10000 |    145,397.0 ns |     949.04 ns |     841.30 ns |    7 |
|            LangExtHashMap |  10000 |    319,919.5 ns |   2,076.71 ns |   1,840.95 ns |    8 |
| **SysColImmutableDictionary** | **100000** | **16,464,326.1 ns** | **162,308.45 ns** | **151,823.43 ns** |   **12** |
|          SysColDictionary | 100000 |  2,042,846.9 ns |  10,832.61 ns |  10,132.83 ns |   10 |
|            LangExtHashMap | 100000 |  6,020,580.3 ns |  49,893.48 ns |  41,663.31 ns |   11 |

### LanguageExt.Benchmarks.HashMapRandomReadBenchmark\<String\>

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


```
|                    Method |      N |          Mean |       Error |      StdDev | Rank |
|-------------------------- |------- |--------------:|------------:|------------:|-----:|
| **SysColImmutableDictionary** |    **100** |      **7.182 us** |   **0.1517 us** |   **0.2406 us** |    **3** |
|          SysColDictionary |    100 |      4.964 us |   0.0217 us |   0.0203 us |    1 |
|            LangExtHashMap |    100 |      6.903 us |   0.0458 us |   0.0428 us |    2 |
| **SysColImmutableDictionary** |   **1000** |    **126.123 us** |   **0.7013 us** |   **0.6217 us** |    **6** |
|          SysColDictionary |   1000 |     62.811 us |   0.2863 us |   0.2391 us |    4 |
|            LangExtHashMap |   1000 |     88.130 us |   0.1365 us |   0.1140 us |    5 |
| **SysColImmutableDictionary** |  **10000** |  **1,717.769 us** |   **6.5892 us** |   **5.8412 us** |    **9** |
|          SysColDictionary |  10000 |    741.590 us |   4.1520 us |   3.6807 us |    7 |
|            LangExtHashMap |  10000 |  1,053.507 us |   4.1371 us |   3.8699 us |    8 |
| **SysColImmutableDictionary** | **100000** | **26,636.958 us** | **141.9120 us** | **125.8013 us** |   **12** |
|          SysColDictionary | 100000 |  9,133.402 us |  70.2923 us |  58.6973 us |   10 |
|            LangExtHashMap | 100000 | 18,811.731 us | 112.1847 us | 104.9376 us |   11 |
