### PR TITLE
Use full name for EqDefault and OrdDefault in code gen

### DIFF
--- a/LanguageExt.CodeGen/CodeGenUtil.cs
+++ b/LanguageExt.CodeGen/CodeGenUtil.cs
@@ -778,7 +778,7 @@ namespace LanguageExt.CodeGen
                                                             SyntaxKind.SimpleMemberAccessExpression,
                                                             DefaultExpression(
                                                                 GenericName(
-                                                                    Identifier("EqDefault"))
+                                                                    Identifier("LanguageExt.ClassInstances.EqDefault"))
                                                                 .WithTypeArgumentList(
                                                                     TypeArgumentList(
                                                                         SingletonSeparatedList<TypeSyntax>(
@@ -1049,7 +1049,7 @@ namespace LanguageExt.CodeGen
                                             SyntaxKind.SimpleMemberAccessExpression,
                                             DefaultExpression(
                                                 GenericName(
-                                                    Identifier("OrdDefault"))
+                                                    Identifier("LanguageExt.ClassInstances.OrdDefault"))
                                                 .WithTypeArgumentList(
                                                     TypeArgumentList(
                                                         SingletonSeparatedList(m.Type)))),
@@ -1131,7 +1131,7 @@ namespace LanguageExt.CodeGen
                                     SyntaxKind.SimpleMemberAccessExpression,
                                     DefaultExpression(
                                         GenericName(
-                                            Identifier("EqDefault"))
+                                            Identifier("LanguageExt.ClassInstances.EqDefault"))
                                         .WithTypeArgumentList(
                                             TypeArgumentList(
                                                 SingletonSeparatedList(m.Type)))),


### PR DESCRIPTION
This fixes first point in https://github.com/louthy/language-ext/issues/665. Not sure if this is the correct fix, maybe we want the appropriate `using` to be added instead? So feel free to reject this PR.

The issue can be reproduced by adding a new file in the TestBed project with:
```c#
using LanguageExt;
using static LanguageExt.Prelude;

namespace TestBed
{
    [Union]
    public abstract partial class Foo<T>
    {
        public abstract Foo<T> Bar(T x);
        public abstract Foo<T> Baz(T x);
    }
}
```