### PR TITLE
adds failing test for Union serialization

### DIFF
--- a/LanguageExt.Tests/UnionTests.cs
+++ b/LanguageExt.Tests/UnionTests.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public partial class UnionTests
+    {
+        [Union]
+        public abstract partial class LightControl
+        {
+            public abstract LightControl OnOff(bool enabled);
+            public abstract LightControl Dimmer(int value);
+        }
+
+        [Fact]
+        public void FromJson()
+        {
+            var json = @"{""Value"": 100}";
+            var x = JsonConvert.DeserializeObject<Dimmer>(json);
+            Assert.Equal(100, x.Value);
+        }
+    }
+}


### PR DESCRIPTION
Some recent update made my serialization fail. This test shows why.

IMHO serialization should work when serialized property name has same case as code property, i.e. first letter upper case.

BTW:  I have a custom converter for Union itself which requires that I add two custom attributes to be able to detect via reflection whether a type is Union base type (Shape) and whether a type is one of those variants (Circle). Example code following in a separate issue.