### PR TITLE
Fix union deserialisation

### DIFF
--- a/LanguageExt.CodeGen/CodeGenUtil.cs
+++ b/LanguageExt.CodeGen/CodeGenUtil.cs
@@ -1980,7 +1980,7 @@ namespace LanguageExt.CodeGen
                             Identifier(typeName))
                         .WithModifiers(
                             TokenList(
-                                Token(SyntaxKind.PublicKeyword)))
+                                Token(SyntaxKind.ProtectedKeyword)))
                         .WithParameterList(
                             ParameterList(
                                 SeparatedList<ParameterSyntax>(

--- a/LanguageExt.Tests/UnionTests.cs
+++ b/LanguageExt.Tests/UnionTests.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public partial class UnionTests
+    {
+        [Union]
+        public abstract partial class LightControl
+        {
+            public abstract LightControl OnOff(bool enabled);
+            public abstract LightControl Dimmer(int value);
+        }
+
+        [Fact]
+        public void FromJson()
+        {
+            var json = @"{""Value"": 100}";
+            var x = JsonConvert.DeserializeObject<Dimmer>(json);
+            Assert.Equal(100, x.Value);
+        }
+    }
+}


### PR DESCRIPTION
Some recent update made my serialization fail. This test shows why.

IMHO serialization should work when serialized property name has same case as code property, i.e. first letter upper case.

The serialization constructor probably should be fixed (case), but I think there is another related problem.

We can tell Newtonsoft.Json to not use ISerializable this way: 

```
new JsonSerializerSettings()
{ 
    ContractResolver =  new DefaultContractResolver(){IgnoreSerializableInterface = true, IgnoreIsSpecifiedMembers = true}
}
```
This does not work either because Newtonsoft.Json can't identify the regular constructor. According to
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2229?view=vs-2019
the serialization constructor should be private (resp. protected) which will solve the issue with the regular constructor not being found.

https://github.com/louthy/language-ext/blob/master/LanguageExt.CodeGen/CodeGenUtil.cs#L1983

BTW: related issue #681 -- how to make Union serialization work.