### PR TITLE
EitherData Left status from IsRight to IsLeft

### DIFF
--- a/LanguageExt.Core/DataTypes/Either-Shared/EItherData.cs
+++ b/LanguageExt.Core/DataTypes/Either-Shared/EItherData.cs
@@ -9,7 +9,7 @@ namespace LanguageExt.DataTypes.Serialisation
             new EitherData<L, R>(EitherStatus.IsRight, rightValue, default(L));
 
         public static EitherData<L, R> Left<L, R>(L leftValue) =>
-            new EitherData<L, R>(EitherStatus.IsRight, default(R), leftValue);
+            new EitherData<L, R>(EitherStatus.IsLeft, default(R), leftValue);
 
         public static EitherData<L, R> Bottom<L, R>() =>
             EitherData<L, R>.Bottom;


### PR DESCRIPTION
Noticed this when doing TryAsync(_Task in failed state_).ToEither(). The result was always in the Right state.
As a side note, I'd like to say how much I'm enjoying using this library. It's made programming in C# fun again. Keep up the good work!