### PR TITLE
Bug fix for #699 where manyn parses short strings

### DIFF
--- a/LanguageExt.Parsec/Parsers/Prim.cs
+++ b/LanguageExt.Parsec/Parsers/Prim.cs
@@ -429,7 +429,7 @@ namespace LanguageExt.Parsec
                         if (t.Tag == ResultTag.Empty && t.Reply.Tag == ReplyTag.OK)
                         {
                             // eok, eerr
-                            return EmptyError<Seq<T>>(new ParserError(ParserErrorTag.SysUnexpect, current.Pos, "many: combinator 'manyn' is applied to a parser that accepts an empty string.", List.empty<string>()));
+                            return EmptyError<Seq<T>>(new ParserError(ParserErrorTag.SysUnexpect, current.Pos, "many: combinator 'manyn0' is applied to a parser that accepts an empty string.", List.empty<string>()));
                         }
 
                         // cerr

--- a/LanguageExt.Parsec/Parsers/Prim.cs
+++ b/LanguageExt.Parsec/Parsers/Prim.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using LanguageExt;
@@ -380,9 +380,7 @@ namespace LanguageExt.Parsec
                     }
 
                     // eerr
-                    return count == n
-                        ? ConsumedError<Seq<T>>(mergeError(error, t.Reply.Error))
-                        : EmptyOK(Seq(results), current, mergeError(error, t.Reply.Error));
+                    return EmptyError<Seq<T>>(mergeError(error, t.Reply.Error));
                 }
             };
 

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -491,12 +491,16 @@ namespace LanguageExt.Tests
             Assert.True(r.IfLeft("") == "1234");
         }
 
-        [Fact]
-        public void ParseNTimesFail()
+        [Theory]
+        [InlineData("")]
+        [InlineData("1")]
+        [InlineData("12")]
+        [InlineData("123")]
+        public void ParseNTimesFail(string input)
         {
             var p = asString(manyn(digit, 4));
 
-            var r = parse(p, "123").ToEither();
+            var r = parse(p, input).ToEither();
 
             Assert.True(r.IsLeft);
         }

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -481,12 +481,17 @@ namespace LanguageExt.Tests
             Assert.True(r.Reply.Result == "/abc");
         }
 
-        [Fact]
-        public void ParseNTimes()
+        [Theory]
+        [InlineData("1234")]
+        [InlineData("12345")]
+        [InlineData("123456")]
+        [InlineData("1234567")]
+        [InlineData("12345678")]
+        public void ParseNTimes(string input)
         {
             var p = asString(manyn(digit, 4));
 
-            var r = parse(p, "12345678").ToEither();
+            var r = parse(p, input).ToEither();
 
             Assert.True(r.IfLeft("") == "1234");
         }
@@ -505,22 +510,19 @@ namespace LanguageExt.Tests
             Assert.True(r.IsLeft);
         }
 
-        [Fact]
-        public void ParseN1Times()
+        [Theory]
+        [InlineData("1", "1")]
+        [InlineData("12", "12")]
+        [InlineData("123", "123")]
+        [InlineData("1234", "1234")]
+        [InlineData("12345", "1234")]
+        public void ParseN1Times(string input, string expected)
         {
             var p = asString(manyn1(digit, 4));
 
-            var r1 = parse(p, "1").ToEither();
-            var r2 = parse(p, "12").ToEither();
-            var r3 = parse(p, "123").ToEither();
-            var r4 = parse(p, "1234").ToEither();
-            var r5 = parse(p, "12345").ToEither();
+            var r = parse(p, input).ToEither();
 
-            Assert.True(r1.IfLeft("") == "1");
-            Assert.True(r2.IfLeft("") == "12");
-            Assert.True(r3.IfLeft("") == "123");
-            Assert.True(r4.IfLeft("") == "1234");
-            Assert.True(r5.IfLeft("") == "1234");
+            Assert.True(r.IfLeft("") == expected);
         }
 
         [Fact]
@@ -533,24 +535,20 @@ namespace LanguageExt.Tests
             Assert.True(r.IsLeft);
         }
 
-        [Fact]
-        public void ParseN0Times()
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("1", "1")]
+        [InlineData("12", "12")]
+        [InlineData("123", "123")]
+        [InlineData("1234", "1234")]
+        [InlineData("12345", "1234")]
+        public void ParseN0Times(string input, string expected)
         {
             var p = asString(manyn0(digit, 4));
 
-            var r0 = parse(p, "").ToEither();
-            var r1 = parse(p, "1").ToEither();
-            var r2 = parse(p, "12").ToEither();
-            var r3 = parse(p, "123").ToEither();
-            var r4 = parse(p, "1234").ToEither();
-            var r5 = parse(p, "12345").ToEither();
+            var r = parse(p, input).ToEither();
 
-            Assert.True(r0.IfLeft("x") == "");
-            Assert.True(r1.IfLeft("x") == "1");
-            Assert.True(r2.IfLeft("x") == "12");
-            Assert.True(r3.IfLeft("x") == "123");
-            Assert.True(r4.IfLeft("x") == "1234");
-            Assert.True(r5.IfLeft("x") == "1234");
+            Assert.True(r.IfLeft("") == expected);
         }
         
         [Fact]


### PR DESCRIPTION
Fixes #699 

I arrived a this change (in the [second commit](https://github.com/louthy/language-ext/commit/4eda0278dd57a955d146db4c6d6c1e853bd5645c)) by trial-and-error with good guessing.  Or, said another way, I didn't really know what I was doing, but I found this solution that seems to work.

In particular, the parsing error message for the test case @Jmaharman gave in #699 (when trying to parse 4 digits but only given "12") is
> error at (line 1, column 3): unexpected end of stream, expecting digit

I think that is the correct error message.

The code I deleted allowed the `manyn` parser to return after processing fewer than `n` things.  I think this bug is partially due to copying and pasting the nearly identical code for the `many` and `manyn0` parsers, which do not have a minimum number of items they need to parse in order to return success.

The thing I understood the least was what error message to return.  I knew I wanted to return a parser error created from the function `EmptyError`, but I am totally guessing that the parser error to pass into that call should be `mergeError(error, t.Reply.Error)`.  It does seem like a good guess though, because the example error message that I shared above looks good to me.