### PR TITLE
Fix Try.Filter / Try.BiFilter

### DIFF
--- a/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
@@ -473,7 +473,7 @@ public static class TryExtensions
     public static Try<A> Filter<A>(this Try<A> self, Func<A, bool> pred) => Memo(() =>
     {
         var res = self();
-        return pred(res.Value)
+        return res.IsFaulted || pred(res.Value)
             ? res
             : raise<A>(new BottomException());
     });

--- a/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Try/Try.Extensions.cs
@@ -484,7 +484,7 @@ public static class TryExtensions
         var res = self.Try();
         return res.IsFaulted
             ? Fail(res.Exception)
-                ? res.Value
+                ? res
                 : raise<A>(new BottomException())
             : Succ(res.Value)
                 ? res.Value

--- a/LanguageExt.Tests/TryMonadTests.cs
+++ b/LanguageExt.Tests/TryMonadTests.cs
@@ -76,6 +76,60 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void TryLinqWhere1()
+        {
+            var res = match(from x in Num(10, true)
+                where x == 10
+                select 5,
+                Succ: toString,
+                Fail: _ => _.GetType().Name);
+
+            Assert.Equal("5", res);
+        }
+
+        [Fact]
+        public void TryLinqWhere2()
+        {
+            var res = match(from x in Num(10, true)
+                where x == 0
+                select 5,
+                Succ: toString,
+                Fail: _ => _.GetType().Name);
+            
+            Assert.Equal(nameof(BottomException), res);
+        }
+
+        [Fact]
+        public void TryLinqWhere3()
+        {
+            var res = match(from x in Num(10, false).Strict()
+                where x != 0
+                select 5,
+                Succ: toString,
+                Fail: _ => _.GetType().Name);
+
+            Assert.Equal(nameof(Exception), res);
+        }
+
+        [Fact]
+        public void TryFilter1()
+        {
+            var actual = Try(() => failwith<HttpResponseMessage>("fail"))
+                .Filter(_ => _.IsSuccessStatusCode)
+                .Match(_ => "success", ex => ex.GetType().Name);
+            Assert.Equal(nameof(Exception), actual);
+        }
+        
+        [Fact]
+        public void TryBiFilter1()
+        {
+            var actual = Try(() => failwith<HttpResponseMessage>("fail"))
+                .BiFilter(_ => _.IsSuccessStatusCode, ex => true)
+                .Match(_ => "success", ex => ex.GetType().Name);
+            Assert.Equal(nameof(Exception), actual);
+        }
+        
+        [Fact]
         public void TryMatchSuccessTest1()
         {
             GetValue(true).Match(

--- a/LanguageExt.Tests/TryMonadTests.cs
+++ b/LanguageExt.Tests/TryMonadTests.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 namespace LanguageExt.Tests
 {
 
-    public class TryOptionMonadTests
+    public class TryMonadTests
     {
         [Fact]
         public void TryOddNumber1()

--- a/LanguageExt.Tests/TryOptionMonadTests.cs
+++ b/LanguageExt.Tests/TryOptionMonadTests.cs
@@ -8,7 +8,7 @@ using System;
 namespace LanguageExt.Tests
 {
     
-    public class TryMonadTests
+    public class TryOptionMonadTests
     {
         [Fact]
         public void TryOptionListTest()


### PR DESCRIPTION
1. `Filter` of `Try` should not execute `pred` if in faulted state.

2. `BiFilter` of `Try` should probably not be allowed to switch from faulted state back to success. This was the case when the `Fail` predicate returned `true`. `res.Value` should not be used when in faulted state and I stumbled upon getting success state with a default value. My fix would mean that `Fail` predicate can just decide whether to stay in faulted state with original exception (Fail pred => true) or to go to bottom state (Fail pred => false). I compared with `Either` but seems there is no `bifilter`. I personally wouldn't mind to remove `Try.BiFilter`.

