### PR TITLE
Additional New method fails

### DIFF
--- a/LanguageExt.Tests/RecordCodeGenTests.cs
+++ b/LanguageExt.Tests/RecordCodeGenTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public partial class RecordCodeGenTests
+    {
+        [Record]
+        public partial class MyRecord
+        {
+            public int DateId { get; }
+    
+            // BUG(?): this works only if method is named @New
+            public static MyRecord New(DateTime dt) => MyRecord.New(dt.Year * 10000 + dt.Month * 100 + dt.Day);
+        }
+    
+        [Fact]
+        void TestAdditionalNew()
+        {
+            Assert.Equal(20201231, MyRecord.New(20201231).DateId);
+            Assert.Equal(20201231, MyRecord.New(new DateTime(2020, 12, 31)).DateId);
+            
+        }
+    }
+}


### PR DESCRIPTION
Minor issue (if any), just stumbled upon this.

The test below fails. I you add `@` in line 14 before `New` (method name `@New`) it works.
This PR is based on commit 88600b71 (newer commits don't compile at my machine).