### PR TITLE
make Ord<T> usable as IComparer<T>

### DIFF
--- a/LanguageExt.Core/TypeClasses/Ord/Ord.cs
+++ b/LanguageExt.Core/TypeClasses/Ord/Ord.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.Contracts;
 namespace LanguageExt.TypeClasses
 {
     [Typeclass("Ord*")]
-    public interface Ord<A> : Eq<A>
+    public interface Ord<A> : Eq<A>, System.Collections.Generic.IComparer<A>
     {
         /// <summary>
         /// Compare two values

--- a/LanguageExt.Tests/TypeClassORD.cs
+++ b/LanguageExt.Tests/TypeClassORD.cs
@@ -88,5 +88,26 @@ namespace LanguageExt.Tests
             Assert.True(min<OrdInt, int>(1, 1, 1, 1) == 1);
             Assert.True(max<OrdInt, int>(1, 1, 1, 1) == 1);
         }
+
+        private struct OrdReverse<ORD, T> : Ord<T> where ORD : struct, Ord<T>
+        {
+            public int GetHashCode(T x) => default(ORD).GetHashCode(x);
+
+            public bool Equals(T x, T y) => default(ORD).Equals(x, y);
+
+            public int Compare(T x, T y) => default(ORD).Compare(y, x);
+        }
+
+        [Fact]
+        public void OrderBy()
+        {
+            var items = Prelude.Seq("2", "1", "10");
+            
+            Assert.Equal(Prelude.Seq("1", "10", "2"), items.OrderBy(Prelude.identity,  default(OrdDefault<string>)));
+            Assert.Equal(Prelude.Seq("1", "2", "10"), items.OrderBy(System.Convert.ToInt32,  default(OrdDefault<int>)));
+            
+            Assert.Equal(Prelude.Seq("2", "10", "1"), items.OrderBy(Prelude.identity,  default(OrdReverse<OrdDefault<string>, string>)));
+            Assert.Equal(Prelude.Seq("10", "2", "1"), items.OrderBy(System.Convert.ToInt32,  default(OrdReverse<OrdDefault<int>, int>)));
+        }
     }
 }

--- a/LanguageExt.Tests/TypeClassORD.cs
+++ b/LanguageExt.Tests/TypeClassORD.cs
@@ -89,7 +89,7 @@ namespace LanguageExt.Tests
             Assert.True(max<OrdInt, int>(1, 1, 1, 1) == 1);
         }
 
-        private struct OrdReverse<ORD, T> : Ord<T> where ORD : struct, Ord<T>
+        private struct OrdDesc<ORD, T> : Ord<T> where ORD : struct, Ord<T>
         {
             public int GetHashCode(T x) => default(ORD).GetHashCode(x);
 
@@ -106,8 +106,8 @@ namespace LanguageExt.Tests
             Assert.Equal(Prelude.Seq("1", "10", "2"), items.OrderBy(Prelude.identity,  default(OrdDefault<string>)));
             Assert.Equal(Prelude.Seq("1", "2", "10"), items.OrderBy(System.Convert.ToInt32,  default(OrdDefault<int>)));
             
-            Assert.Equal(Prelude.Seq("2", "10", "1"), items.OrderBy(Prelude.identity,  default(OrdReverse<OrdDefault<string>, string>)));
-            Assert.Equal(Prelude.Seq("10", "2", "1"), items.OrderBy(System.Convert.ToInt32,  default(OrdReverse<OrdDefault<int>, int>)));
+            Assert.Equal(Prelude.Seq("2", "10", "1"), items.OrderBy(Prelude.identity,  default(OrdDesc<OrdDefault<string>, string>)));
+            Assert.Equal(Prelude.Seq("10", "2", "1"), items.OrderBy(System.Convert.ToInt32,  default(OrdDesc<OrdDefault<int>, int>)));
         }
     }
 }


### PR DESCRIPTION
I don't know whether this is a good or bad thing.

After trying to use `Ord` with other code (e.g. LINQ OrderBy) I see some demand for conversion to types like IComparer.
