### PR TITLE
Fix Seq.TakeWhile inserting 4 empty elements to the resulting sequence

### DIFF
--- a/LanguageExt.Core/DataTypes/Seq/Seq.cs
+++ b/LanguageExt.Core/DataTypes/Seq/Seq.cs
@@ -850,7 +850,7 @@ namespace LanguageExt
             }
             return index == HalfDefaultCapacity
                 ? Empty
-                : new Seq<A>(new SeqStrict<A>(data, HalfDefaultCapacity, index, 0, 0));
+                : new Seq<A>(new SeqStrict<A>(data, HalfDefaultCapacity, index - HalfDefaultCapacity, 0, 0));
         }
 
         /// <summary>
@@ -882,7 +882,7 @@ namespace LanguageExt
             }
             return index == HalfDefaultCapacity
                 ? Empty
-                : new Seq<A>(new SeqStrict<A>(data, HalfDefaultCapacity, index, 0, 0));
+                : new Seq<A>(new SeqStrict<A>(data, HalfDefaultCapacity, index - HalfDefaultCapacity, 0, 0));
         }
 
         /// <summary>

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -72,6 +72,36 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void TakeWhileTest()
+        {
+            var str = "                          <p>The</p>";
+            Assert.Equal("                          ",
+                         String.Join("", str.ToSeq().TakeWhile(ch => ch == ' ')));
+        }
+
+        [Fact]
+        public void TakeWhileIndex()
+        {
+            var str = "                          <p>The</p>";
+            Assert.Equal("                          ",
+                         String.Join("", str.ToSeq().TakeWhile((ch, index) => index != 26)));
+        }
+
+        [Fact]
+        public void TakeWhile_HalfDefaultCapacityTest()
+        {
+            var str = "1234";
+            Assert.Equal("1234", String.Join("", str.ToSeq().TakeWhile(ch => true)));
+        }
+
+        [Fact]
+        public void TakeWhileIndex_HalfDefaultCapacityTest()
+        {
+            var str = "1234";
+            Assert.Equal("1234", String.Join("", str.ToSeq().TakeWhile((ch, index) => true)));
+        }
+
+        [Fact]
         public void FoldTest()
         {
             var input = Seq(1, 2, 3, 4, 5);


### PR DESCRIPTION
 - First commit contains the minimal fix, as I don't quite know what strictseq class is for and why does it have to have those empty elements in the front (I don't think it has to).
 - Second commit contains some tests for this function with an example which lead me to discover this bug.
 - Third commit contains proposed refactor/optimization - I don't think takeWhile should buffer the elements. Lazy sequence is the way to go.