### PR TITLE
Lst.Traverse tests

### DIFF
--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Arr.cs
@@ -1,0 +1,56 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class ArrLst
+    {
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Arr<Lst<int>> ma = Empty;
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Arr<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void ArrLstCrossProduct()
+        {
+            var ma = Array(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+
+            var mc = List(Array(1, 10), Array(1, 20), Array(1, 30), Array(2, 10), Array(2, 20), Array(2, 30));
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void ArrOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = Array(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = List<Arr<int>>();
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void ArrOfEmptiesIsEmpty()
+        {
+            var ma = Array(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = List<Arr<int>>();
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
@@ -6,9 +6,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {
     public class HashSetLst
     {
-        private readonly ITestOutputHelper _log;
-        public HashSetLst(ITestOutputHelper log) => _log = log;
-
         [Fact]
         public void EmptyEmptyIsEmptyEmpty()
         {
@@ -30,9 +27,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
             var mb = ma.Sequence();
 
             var mc = List(HashSet(1, 10), HashSet(1, 20), HashSet(1, 30), HashSet(2, 10), HashSet(2, 20), HashSet(2, 30));
-            
-            _log.WriteLine(mb.ToFullString());
-            _log.WriteLine(mc.ToFullString());
             
             Assert.True(mb == mc);
         }

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
@@ -23,7 +23,7 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
         
         // TODO: failing
         [Fact]
-        public void HashSetHashSetCrossProduct()
+        public void HashSetLstCrossProduct()
         {
             var ma = HashSet(List(1, 2), List(10, 20, 30));
 

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
@@ -1,0 +1,65 @@
+using Xunit;
+using Xunit.Abstractions;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class HashSetLst
+    {
+        private readonly ITestOutputHelper _log;
+        public HashSetLst(ITestOutputHelper log) => _log = log;
+
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            HashSet<Lst<int>> ma = Empty;
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<HashSet<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        // TODO: failing
+        [Fact]
+        public void HashSetHashSetCrossProduct()
+        {
+            var ma = HashSet(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+
+            var mc = List(HashSet(1, 10), HashSet(1, 20), HashSet(1, 30), HashSet(2, 10), HashSet(2, 20), HashSet(2, 30));
+            
+            _log.WriteLine(mb.ToFullString());
+            _log.WriteLine(mc.ToFullString());
+            
+            Assert.True(mb == mc);
+        }
+        
+                
+        [Fact]
+        public void HashSetOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = HashSet(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<HashSet<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void HashSetOfEmptiesIsEmpty()
+        {
+            var ma = HashSet(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<HashSet<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/IEnumerable.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Xunit;
+using G = System.Collections.Generic;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    using static Prelude;
+    
+    public class IEnumerableLst
+    {
+        G.IEnumerable<T> mkEnum<T>(params T[] ts)
+        {
+            foreach (var t in ts)
+                yield return t;
+        }
+        
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            var ma = Enumerable.Empty<Lst<int>>();
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<G.IEnumerable<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void EnumLstCrossProduct()
+        {
+            var ma = mkEnum(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+
+            var mc = List(mkEnum(1, 10), mkEnum(1, 20), mkEnum(1, 30), mkEnum(2, 10), mkEnum(2, 20), mkEnum(2, 30));
+            
+            Assert.True(mb.Map(toList) == mc.Map(toList));
+            
+        }
+                
+        [Fact]
+        public void SeqOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = mkEnum(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<G.IEnumerable<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SeqOfEmptiesIsEmpty()
+        {
+            var ma = mkEnum(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<G.IEnumerable<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Lst.cs
@@ -1,0 +1,57 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class LstLst
+    {
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Lst<Lst<int>> ma = Empty;
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Lst<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void LstLstCrossProduct()
+        {
+            var ma = List(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+
+            var mc = List(List(1, 10), List(1, 20), List(1, 30), List(2, 10), List(2, 20), List(2, 30));
+            
+            Assert.True(mb == mc);
+        }
+        
+                
+        [Fact]
+        public void LstOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = List(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Lst<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void LstOfEmptiesIsEmpty()
+        {
+            var ma = List(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Lst<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Que.cs
@@ -1,0 +1,57 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class QueLst
+    {
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Que<Lst<int>> ma = Empty;
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Que<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void QueLstCrossProduct()
+        {
+            var ma = Queue(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = List(Queue(1, 10), Queue(1, 20), Queue(1, 30), Queue(2, 10), Queue(2, 20), Queue(2, 30));
+            
+            Assert.True(mb == mc);
+        }
+        
+                
+        [Fact]
+        public void QueOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = Queue(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Que<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void QueOfEmptiesIsEmpty()
+        {
+            var ma = Queue(List<int>(), List<int>());
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Que<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Seq.cs
@@ -1,0 +1,56 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class SeqLst
+    {
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Seq<Lst<int>> ma = Empty;
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Seq<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SeqLstCrossProduct()
+        {
+            var ma = Seq(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+
+            var mc = List(Seq(1, 10), Seq(1, 20), Seq(1, 30), Seq(2, 10), Seq(2, 20), Seq(2, 30));
+            
+            Assert.True(mb == mc);
+        }
+                
+        [Fact]
+        public void SeqOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = Seq(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Seq<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SeqOfEmptiesIsEmpty()
+        {
+            var ma = Seq(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Seq<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Set.cs
@@ -1,0 +1,59 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class SetLst
+    {
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Set<Lst<int>> ma = Empty;
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Set<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SetLstCrossProduct()
+        {
+            var ma = Set(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Sequence();
+            var mbb = ma.Traverse(identity);
+
+            var mc = List(Set(1, 10), Set(1, 20), Set(1, 30), Set(2, 10), Set(2, 20), Set(2, 30));
+            
+            Assert.True(mb == mc);
+            Assert.True(mbb == mc);
+        }
+        
+                
+        [Fact]
+        public void SetOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = Set(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Set<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SetOfEmptiesIsEmpty()
+        {
+            var ma = Set(List<int>(), List<int>());
+
+            var mb = ma.Sequence();
+
+            var mc = Lst<Set<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
@@ -5,10 +5,7 @@ using static LanguageExt.Prelude;
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {
     public class StckLst
-    { 
-        private readonly ITestOutputHelper _log;
-        public StckLst(ITestOutputHelper log) => _log = log;
-        
+    {
         [Fact]
         public void EmptyEmptyIsEmptyEmpty()
         {
@@ -29,9 +26,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
             var mb = ma.Traverse(identity);
 
             var mc = List(Stack(1, 10), Stack(1, 20), Stack(1, 30), Stack(2, 10), Stack(2, 20), Stack(2, 30));
-            
-            _log.WriteLine(mb.ToFullString());
-            _log.WriteLine(mc.ToFullString());
             
             Assert.True(mb == mc);
         }

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
@@ -1,0 +1,64 @@
+using Xunit;
+using Xunit.Abstractions;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
+{
+    public class StckLst
+    { 
+        private readonly ITestOutputHelper _log;
+        public StckLst(ITestOutputHelper log) => _log = log;
+        
+        [Fact]
+        public void EmptyEmptyIsEmptyEmpty()
+        {
+            Stck<Lst<int>> ma = Empty;
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Stck<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void StckLstCrossProduct()
+        {
+            var ma = Stack(List(1, 2), List(10, 20, 30));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = List(Stack(1, 10), Stack(1, 20), Stack(1, 30), Stack(2, 10), Stack(2, 20), Stack(2, 30));
+            
+            _log.WriteLine(mb.ToFullString());
+            _log.WriteLine(mc.ToFullString());
+            
+            Assert.True(mb == mc);
+        }
+        
+                
+        [Fact]
+        public void StckOfEmptiesAndNonEmptiesIsEmpty()
+        {
+            var ma = Stack(List<int>(), List(1, 2, 3));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Stck<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void StckOfEmptiesIsEmpty()
+        {
+            var ma = Stack(List<int>(), List<int>());
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Lst<Stck<int>>.Empty;
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Either.cs
@@ -1,0 +1,40 @@
+using System;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class EitherLst
+    {
+        [Fact]
+        public void LeftIsSingletonLeft()
+        {
+            var ma = Left<Error, Lst<int>>(Error.New("alt"));
+            var mb = ma.Sequence();
+            var mc = List(Left<Error, int>(new Exception("alt")));
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void RightEmptyIsEmpty()
+        {
+            var ma = Right<Error, Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<Either<Error, int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void RightNonEmptyLstIsLstRight()
+        {
+            var ma = Right<Error, Lst<int>>(List(1, 2, 3, 4));
+            var mb = ma.Sequence();
+            var mc = List(Right<Error, int>(1), Right<Error, int>(2), Right<Error, int>(3), Right<Error, int>(4));
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/EitherUnsafe.cs
@@ -1,0 +1,40 @@
+using System;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class EitherUnsafeLst
+    {
+        [Fact]
+        public void LeftIsSingletonLeft()
+        {
+            var ma = LeftUnsafe<Error, Lst<int>>(Error.New("alt"));
+            var mb = ma.Sequence();
+            var mc = List(LeftUnsafe<Error, int>(new Exception("alt")));
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void RightEmptyIsEmpty()
+        {
+            var ma = RightUnsafe<Error, Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<EitherUnsafe<Error, int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void RightNonEmptyLstIsLstRight()
+        {
+            var ma = RightUnsafe<Error, Lst<int>>(List(1, 2, 3, 4));
+            var mb = ma.Sequence();
+            var mc = List(RightUnsafe<Error, int>(1), RightUnsafe<Error, int>(2), RightUnsafe<Error, int>(3), RightUnsafe<Error, int>(4));
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Identity.cs
@@ -1,0 +1,28 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class IdentityLst
+    {
+        [Fact]
+        public void IdEmptyIsEmpty()
+        {
+            var ma = Id<Lst<int>>(Empty);
+            var mb = ma.Traverse(identity);
+            var mc = List<Identity<int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void IdNonEmptyLstIsLstId()
+        {
+            var ma = Id(List(1, 2, 3));
+            var mb = ma.Traverse(identity);
+            var mc = List(Id(1), Id(2), Id(3));
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Option.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class OptionLst
+    {
+        [Fact]
+        public void NoneIsSingletonNone()
+        {
+            var ma = Option<Lst<int>>.None;
+            var mb = ma.Sequence();
+            var mc = List(Option<int>.None);
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SomeEmptyIsEmpty()
+        {
+            var ma = Some<Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<Option<int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SomeNonEmptyLstIsLstSomes()
+        {
+            var ma = Some(List(1, 2, 3));
+            var mb = ma.Sequence();
+            var mc = List(Some(1), Some(2), Some(3)); 
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/OptionUnsafe.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class OptionUnsafeLst
+    {
+        [Fact]
+        public void NoneIsSingletonNone()
+        {
+            var ma = OptionUnsafe<Lst<int>>.None;
+            var mb = ma.Sequence();
+            var mc = List(OptionUnsafe<int>.None);
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SomeEmptyIsEmpty()
+        {
+            var ma = SomeUnsafe<Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<OptionUnsafe<int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SomeNonEmptyLstIsLstSomes()
+        {
+            var ma = SomeUnsafe(List(1, 2, 3));
+            var mb = ma.Sequence();
+            var mc = List(SomeUnsafe(1), SomeUnsafe(2), SomeUnsafe(3)); 
+            
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
@@ -1,0 +1,46 @@
+using System;
+using Xunit;
+using Xunit.Abstractions;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class TryLst
+    {
+        private readonly ITestOutputHelper _log;
+        public TryLst(ITestOutputHelper log) => _log = log;
+        
+        [Fact]
+        public void FailIsSingletonNone()
+        {
+            var ma = TryFail<Lst<int>>(new Exception("fail"));
+            var mb = ma.Sequence();
+            var mc = List(TryFail<int>(new Exception("fail")));
+
+            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
+            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SuccEmptyIsEmpty()
+        {
+            var ma = TrySucc<HashSet<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = HashSet<Try<int>>();
+
+            Assert.True(mb == mc);
+        }
+
+        [Fact]
+        public void SuccNonEmptyLstIsHashSetSuccs()
+        {
+            var ma = TrySucc(HashSet(1, 2, 3));
+            var mb = ma.Sequence();
+            var mc = HashSet(TrySucc(1), TrySucc(2), TrySucc(3));
+
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
@@ -7,8 +7,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {
     public class TryLst
     {
-        private readonly ITestOutputHelper _log;
-        public TryLst(ITestOutputHelper log) => _log = log;
         
         [Fact]
         public void FailIsSingletonNone()
@@ -16,9 +14,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
             var ma = TryFail<Lst<int>>(new Exception("fail"));
             var mb = ma.Sequence();
             var mc = List(TryFail<int>(new Exception("fail")));
-
-            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
-            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
             
             Assert.True(mb == mc);
         }

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
@@ -8,18 +8,12 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
     public class TryOptionLst
     {
         
-        private readonly ITestOutputHelper _log;
-        public TryOptionLst(ITestOutputHelper log) => _log = log;
-        
         [Fact]
         public void FailIsSingletonNone()
         {
             var ma = TryOptionFail<Lst<int>>(new Exception("fail"));
             var mb = ma.Sequence();
             var mc = List(TryOptionFail<int>(new Exception("fail")));
-
-            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
-            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
             
             Assert.True(mb == mc);
         }
@@ -40,9 +34,6 @@ namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
             var ma = TryOptionSucc(List(1, 2, 3));
             var mb = ma.Sequence();
             var mc = List(TryOptionSucc(1), TryOptionSucc(2), TryOptionSucc(3));
-            
-            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
-            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
 
             Assert.True(mb == mc);
         }

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
@@ -1,0 +1,50 @@
+using System;
+using Xunit;
+using Xunit.Abstractions;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class TryOptionLst
+    {
+        
+        private readonly ITestOutputHelper _log;
+        public TryOptionLst(ITestOutputHelper log) => _log = log;
+        
+        [Fact]
+        public void FailIsSingletonNone()
+        {
+            var ma = TryOptionFail<Lst<int>>(new Exception("fail"));
+            var mb = ma.Sequence();
+            var mc = List(TryOptionFail<int>(new Exception("fail")));
+
+            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
+            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
+            
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SuccEmptyIsEmpty()
+        {
+            var ma = TryOptionSucc<Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<TryOption<int>>();
+
+            Assert.True(mb == mc);
+        }
+
+        [Fact]
+        public void SuccNonEmptyLstIsLstSuccs()
+        {
+            var ma = TryOptionSucc(List(1, 2, 3));
+            var mb = ma.Sequence();
+            var mc = List(TryOptionSucc(1), TryOptionSucc(2), TryOptionSucc(3));
+            
+            _log.WriteLine(mb.Map(t => t.AsString()).ToFullString());
+            _log.WriteLine(mc.Map(t => t.AsString()).ToFullString());
+
+            Assert.True(mb == mc);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/ValidationSeq.cs
@@ -1,0 +1,40 @@
+using System;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
+{
+    public class ValidationSeqLst
+    {
+        [Fact]
+        public void FailIsSingletonFail()
+        {
+            var ma = Fail<Error, Lst<int>>(Error.New("alt"));
+            var mb = ma.Sequence();
+            var mc = List(Fail<Error, int>(new Exception("alt")));
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SuccessEmptyIsEmpty()
+        {
+            var ma = Success<Error, Lst<int>>(Empty);
+            var mb = ma.Sequence();
+            var mc = List<Validation<Error, int>>();
+
+            Assert.True(mb == mc);
+        }
+        
+        [Fact]
+        public void SuccessNonEmptyLstIsLstSuccesses()
+        {
+            var ma = Success<Error, Lst<int>>(List(1, 2, 3, 4));
+            var mb = ma.Sequence();
+            var mc = List(Success<Error, int>(1), Success<Error, int>(2), Success<Error, int>(3), Success<Error, int>(4));
+            
+            Assert.True(mb == mc);
+        }
+    }
+}


### PR DESCRIPTION
Encountered some problems:
 - cross product with `HashSet` fails in .NET Framework
 - some weirdness with `Stck` cross product
 - `Try` and `TryOption` structural equality does not work for some reason

I wanted to try fixing it but decided it's much more time-efficient if you have a look at it and I will write more tests. Plus, as an example with `Stck` not working (because of reverse iteration?), maybe it will apply for other implementations.

I added console logs for failing cases to assist in debugging.

#728