### PR TITLE
Identity traverse tests

### DIFF
--- a/LanguageExt.Core/Transformer/Traverse/Identity.cs
+++ b/LanguageExt.Core/Transformer/Traverse/Identity.cs
@@ -43,7 +43,7 @@ namespace LanguageExt
             return new Identity<HashSet<B>>(new HashSet<B>(res));            
         }
 
-        public static Identity<Identity<B>> Traverse<L, A, B>(this Identity<Identity<A>> ma, Func<A, B> f) =>
+        public static Identity<Identity<B>> Traverse<A, B>(this Identity<Identity<A>> ma, Func<A, B> f) =>
             new Identity<Identity<B>>(new Identity<B>(f(ma.Value.Value)));
         
         public static Identity<Lst<B>> Traverse<A, B>(this Lst<Identity<A>> ma, Func<A, B> f)
@@ -126,12 +126,12 @@ namespace LanguageExt
             return new Identity<Stck<B>>(new Stck<B>(res));            
         }
         
-        public static Identity<Try<B>> Traverse<L, A, B>(this Try<Identity<A>> ma, Func<A, B> f) =>
+        public static Identity<Try<B>> Traverse<A, B>(this Try<Identity<A>> ma, Func<A, B> f) =>
             ma.Match(
                 Succ: x => new Identity<Try<B>>(Try(f(x.Value))),
                 Fail: e => new Identity<Try<B>>(Try<B>(e)));
         
-        public static Identity<TryOption<B>> Traverse<L, A, B>(this TryOption<Identity<A>> ma, Func<A, B> f) =>
+        public static Identity<TryOption<B>> Traverse<A, B>(this TryOption<Identity<A>> ma, Func<A, B> f) =>
             ma.Match(
                 Some: x  => new Identity<TryOption<B>>(TryOption(f(x.Value))),
                 None: () => new Identity<TryOption<B>>(TryOption<B>(Option<B>.None)),

--- a/LanguageExt.Core/Transformer/Traverse/Identity.cs
+++ b/LanguageExt.Core/Transformer/Traverse/Identity.cs
@@ -31,7 +31,7 @@ namespace LanguageExt
                 Right: x => new Identity<EitherUnsafe<L, B>>(f(x.Value)),
                 Left: e => new Identity<EitherUnsafe<L, B>>(EitherUnsafe<L, B>.Left(e)));
 
-        public static Identity<HashSet<B>> Traverse<L, A, B>(this HashSet<Identity<A>> ma, Func<A, B> f)
+        public static Identity<HashSet<B>> Traverse<A, B>(this HashSet<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = 0;
@@ -46,7 +46,7 @@ namespace LanguageExt
         public static Identity<Identity<B>> Traverse<L, A, B>(this Identity<Identity<A>> ma, Func<A, B> f) =>
             new Identity<Identity<B>>(new Identity<B>(f(ma.Value.Value)));
         
-        public static Identity<Lst<B>> Traverse<L, A, B>(this Lst<Identity<A>> ma, Func<A, B> f)
+        public static Identity<Lst<B>> Traverse<A, B>(this Lst<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = 0;
@@ -68,7 +68,7 @@ namespace LanguageExt
                 Some: x => new Identity<OptionUnsafe<B>>(f(x.Value)),
                 None: () => new Identity<OptionUnsafe<B>>(OptionUnsafe<B>.None));
         
-        public static Identity<Que<B>> Traverse<L, A, B>(this Que<Identity<A>> ma, Func<A, B> f)
+        public static Identity<Que<B>> Traverse<A, B>(this Que<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = 0;
@@ -80,7 +80,7 @@ namespace LanguageExt
             return new Identity<Que<B>>(new Que<B>(res));            
         }
         
-        public static Identity<Seq<B>> Traverse<L, A, B>(this Seq<Identity<A>> ma, Func<A, B> f)
+        public static Identity<Seq<B>> Traverse<A, B>(this Seq<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = 0;
@@ -92,7 +92,7 @@ namespace LanguageExt
             return new Identity<Seq<B>>(Seq.FromArray(res));            
         }
         
-        public static Identity<IEnumerable<B>> Traverse<L, A, B>(this IEnumerable<Identity<A>> ma, Func<A, B> f)
+        public static Identity<IEnumerable<B>> Traverse<A, B>(this IEnumerable<Identity<A>> ma, Func<A, B> f)
         {
             var res = new List<B>();
             foreach (var xs in ma)
@@ -102,7 +102,7 @@ namespace LanguageExt
             return new Identity<IEnumerable<B>>(Seq.FromArray(res.ToArray()));            
         }
         
-        public static Identity<Set<B>> Traverse<L, A, B>(this Set<Identity<A>> ma, Func<A, B> f)
+        public static Identity<Set<B>> Traverse<A, B>(this Set<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = 0;
@@ -114,7 +114,7 @@ namespace LanguageExt
             return new Identity<Set<B>>(new Set<B>(res));            
         }
         
-        public static Identity<Stck<B>> Traverse<L, A, B>(this Stck<Identity<A>> ma, Func<A, B> f)
+        public static Identity<Stck<B>> Traverse<A, B>(this Stck<Identity<A>> ma, Func<A, B> f)
         {
             var res = new B[ma.Count];
             var ix = ma.Count - 1;

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Arr.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class ArrIdentity
+    {
+        [Fact]
+        public void EmptyArrayIsSuccess()
+        {
+            Arr<Identity<int>> ma = Empty;
+
+            var mb = ma.Traverse(identity);
+            
+            Assert.Equal(Id(Arr<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void ArrOfIdentitiesIsIdentityOfArr()
+        {
+            var ma = Array(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Array(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/HashSet.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class HashSet
+    {
+        [Fact]
+        public void EmptyHashSetIsSuccess()
+        {
+            HashSet<Identity<int>> ma = Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(HashSet<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void HashSetOfIdentitiesIsSuccess()
+        {
+            var ma = HashSet(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(HashSet(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/IEnumerable.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class IEnumerable
+    {
+        [Fact]
+        public void EmptyIEnumerableIsEmpty()
+        {
+            var ma = Enumerable.Empty<Identity<int>>();
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Enumerable.Empty<int>()), mb);
+        }
+
+        [Fact]
+        public void EnumerableOfIdentitiesIsIdentityOfEnumerable()
+        {
+            var ma = List(Id(1), Id(3), Id(5)).AsEnumerable();
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(List(1, 3, 5).AsEnumerable()), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Lst.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class Lst
+    {
+        [Fact]
+        public void EmptyLstIsEmpty()
+        {
+            var ma = Lst<Identity<int>>.Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Lst<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void LstOfIdentitiesIsIdentityOfLst()
+        {
+            var ma = List(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(List(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Que.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class Que
+    {
+        [Fact]
+        public void EmptyQueIsEmpty()
+        {
+            var ma = Que<Identity<int>>.Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Que<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void QueOfIdentitiesIsIdentityOfQue()
+        {
+            var ma = Queue(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Queue(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Seq.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class Seq
+    {
+        [Fact]
+        public void EmptySeqIsEmpty()
+        {
+            var ma = Seq<Identity<int>>.Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Seq<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void SeqOfIdentitiesIsIdentityOfSeq()
+        {
+            var ma = Seq(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Seq(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Set.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class Set
+    {
+        [Fact]
+        public void EmptySetIsEmpty()
+        {
+            var ma = Set<Identity<int>>.Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Set<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void SetOfIdentitiesIsIdentityOfSet()
+        {
+            var ma = Set(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Set(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Stck.cs
@@ -1,0 +1,28 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
+{
+    public class Stck
+    {
+        [Fact]
+        public void EmptyStckIsEmpty()
+        {
+            var ma = Stck<Identity<int>>.Empty;
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Stck<int>.Empty), mb);
+        }
+
+        [Fact]
+        public void StckOfIdentitiesIsIdentityOfStck()
+        {
+            var ma = Stack(Id(1), Id(3), Id(5));
+
+            var mb = ma.Traverse(identity);
+
+            Assert.Equal(Id(Stack(1, 3, 5)), mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Either.cs
@@ -1,0 +1,33 @@
+﻿using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class Either
+    {
+        [Fact]
+        public void LeftIsIdentityLeft()
+        {
+            var ma = Left<Error, Identity<int>>(Error.New("An Error"));
+            
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Left<Error, int>(Error.New("An Error")));
+            
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void RightIsIdentityRight()
+        {
+            var ma = Right<Error, Identity<int>>(Id(42));
+            
+            var mb = ma.Traverse(identity);
+            
+            var mc = Id(Right<Error, int>(42));
+            
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/EitherUnsafe.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using LanguageExt.Common;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class EitherUnsafe
+    {
+        [Fact]
+        public void LeftUnsafeIsIdentityLeftUnsafe()
+        {
+            var ma = LeftUnsafe<Error, Identity<int>>(Error.New("An Error"));
+            
+            var mb = ma.Traverse(identity);
+            
+            var mc = Id(LeftUnsafe<Error, int>(Error.New("An Error")));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void RightUnsafeIsIdentityRightUnsafe()
+        {
+            var ma = RightUnsafe<Error, Identity<int>>(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(RightUnsafe<Error, int>(42));
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Identity.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class Identity
+    {
+        [Fact]
+        public void IdentityIdentityIsIdentityIdentity()
+        {
+            var ma = Id(Id(42));
+            
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Id(42));
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Option.cs
@@ -1,0 +1,32 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class Option
+    {
+        [Fact]
+        public void SomeIdentityIsIdentitySome()
+        {
+            var ma = Some(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Some(42));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void NoneIdentityIsIdentityNone()
+        {
+            var ma = Option<Identity<int>>.None;
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Option<int>.None);
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/OptionUnsafe.cs
@@ -1,0 +1,32 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class OptionUnsafe
+    {
+        [Fact]
+        public void SomeIdentityIsIdentitySome()
+        {
+            var ma = SomeUnsafe(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(SomeUnsafe(42));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void NoneIdentityIsIdentityNone()
+        {
+            var ma = OptionUnsafe<Identity<int>>.None;
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(OptionUnsafe<int>.None);
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Try.cs
@@ -1,0 +1,32 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class Try
+    {
+        [Fact]
+        public void TrySuccIdentityIsIdentityTrySucc()
+        {
+            var ma = TrySucc(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(TrySucc(42));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void TryFailIdentityIsIdentityTryFail()
+        {
+            var ma = TryFail<Identity<int>>(new System.Exception("Failed"));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(TryFail<int>(new System.Exception("Failed")));
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/TryOption.cs
@@ -1,0 +1,32 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class TryOption
+    {
+        [Fact]
+        public void IdentityFailisFailIdentity()
+        {
+            var ma = TryOptionFail<Identity<int>>(new System.Exception("An Error"));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(TryOptionFail<int>(new System.Exception("An Error")));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void IdentitySuccIsSuccIdentity()
+        {
+            var ma = TryOptionSucc(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(TryOptionSucc(42));
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/ValidationSeq.cs
@@ -1,0 +1,33 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+using LanguageExt.Common;
+
+namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
+{
+    public class ValidationSeq
+    {
+        [Fact]
+        public void ValidationFailIsIdentityFail()
+        {
+            var ma = Fail<Error, Identity<int>>(Error.New("An Error"));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Fail<Error, int>(Error.New("An Error")));
+
+            Assert.Equal(mc, mb);
+        }
+
+        [Fact]
+        public void ValidationSuccIsIdentitySuccess()
+        {
+            var ma = Success<Error, Identity<int>>(Id(42));
+
+            var mb = ma.Traverse(identity);
+
+            var mc = Id(Success<Error, int>(42));
+
+            Assert.Equal(mc, mb);
+        }
+    }
+}


### PR DESCRIPTION
As mentioned in #728 - Identity traverse tests.

Looks like `Sequence` isn't defined for `Identity<A>` so all the tests use `.Traverse(identity)`

Removed some extra generic parameters in Identity.cs which confused C# a bit.