### PR TITLE
Add BiBind to Free Code-Gen

### DIFF
--- a/LanguageExt.CodeGen/FreeAttribute.cs
+++ b/LanguageExt.CodeGen/FreeAttribute.cs
@@ -16,4 +16,10 @@ namespace LanguageExt
     public class FreeAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    [Conditional("CodeGeneration")]
+    public sealed class FailAttribute : Attribute
+    {
+    }
 }

--- a/LanguageExt.CodeGen/FreeGenerator.cs
+++ b/LanguageExt.CodeGen/FreeGenerator.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using CodeGeneration.Roslyn;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using Microsoft.CodeAnalysis.CSharp;
-using System.ComponentModel;
-using System.Reflection.Metadata.Ecma335;
 
 namespace LanguageExt.CodeGen
 {
@@ -27,26 +24,28 @@ namespace LanguageExt.CodeGen
         {
             try
             {
-
                 if (context.ProcessingNode is InterfaceDeclarationSyntax applyTo)
                 {
                     if (applyTo.TypeParameterList.Parameters.Count > 1)
                     {
-                        CodeGenUtil.ReportError($"Free monads must have only one generic argument", "Free monad Code-Gen", context.ProcessingNode, progress);
+                        CodeGenUtil.ReportError($"Free monads must have only one generic argument",
+                            "Free monad Code-Gen", context.ProcessingNode, progress);
                         return Task.FromResult(List<MemberDeclarationSyntax>());
                     }
+
                     if (applyTo.TypeParameterList.Parameters.Count == 0)
                     {
-                        CodeGenUtil.ReportError($"Free monads must a generic argument", "Free monad Code-Gen", context.ProcessingNode, progress);
+                        CodeGenUtil.ReportError($"Free monads must a generic argument", "Free monad Code-Gen",
+                            context.ProcessingNode, progress);
                         return Task.FromResult(List<MemberDeclarationSyntax>());
                     }
 
                     var genA = applyTo.TypeParameterList.Parameters.First().ToString();
                     var genB = CodeGenUtil.NextGenName(genA);
                     var genC = CodeGenUtil.NextGenName(genB);
-                    
+
                     var thisType = ParseTypeName($"{applyTo.Identifier.Text}{applyTo.TypeParameterList}");
-                    
+
                     var typeA = MakeTypeName(applyTo.Identifier.Text, genA);
                     var typeB = MakeTypeName(applyTo.Identifier.Text, genB);
                     var mapFunc = ParseTypeName($"System.Func<{genA}, {genB}>");
@@ -61,74 +60,116 @@ namespace LanguageExt.CodeGen
                         // .Where(m => m.ParameterList.Parameters[0].Type.IsEquivalentTo(typeA))
                         // .Where(m => m.ParameterList.Parameters[1].Type.IsEquivalentTo(mapFunc))
                         .Any();
-                    
+
+
+                    var hasStaticBiMap = applyTo.Members
+                        .OfType<MethodDeclarationSyntax>()
+                        .Where(m => m.Identifier.Text == "BiMap")
+                        .Where(m => m.ParameterList.Parameters.Count == 3)
+                        .Where(m => m.Modifiers.Any(mo => mo.IsKind(SyntaxKind.StaticKeyword)))
+                        .Where(m => m.Modifiers.Any(mo => mo.IsKind(SyntaxKind.PublicKeyword)))
+                        .Any();
+
+                    var failType = applyTo.Members
+                        .OfType<MethodDeclarationSyntax>()
+                        .Where(HasFailAttr)
+                        .Where(m => m.ParameterList.Parameters.Count == 1)
+                        .Select(m => m.ParameterList.Parameters.First().Type)
+                        .FirstOrDefault();
+
                     var caseMethods = applyTo.Members
                         .OfType<MethodDeclarationSyntax>()
                         .Where(m => !m.Modifiers.Any(mo => mo.IsKind(SyntaxKind.StaticKeyword)))
-                        .Select(m => MakeFree(m, thisType))
+                        .Select(m => MakeFree(m, thisType, failType))
                         .ToArray();
-                    
-                    var firstPure = caseMethods.Where(HasPureAttr)
-                                               .Where(m => m.ParameterList.Parameters.Count == 1)
-                                               .Where(m => m.ReturnType.IsEquivalentTo(typeA))
-                                               .Where(m => m.ParameterList.Parameters.First().Type.ToString() == genA)
-                                               .FirstOrDefault();
+
+                    var firstPure = caseMethods
+                        .Where(HasPureAttr)
+                        .Where(m => m.ParameterList.Parameters.Count == 1)
+                        .Where(m => m.ReturnType.IsEquivalentTo(typeA))
+                        .Where(m => m.ParameterList.Parameters.First().Type.ToString() == genA)
+                        .FirstOrDefault();
+
+                    var firstFail = caseMethods
+                        .Where(HasFailAttr)
+                        .Where(m => m.ParameterList.Parameters.Count < 2)
+                        .Where(m => m.ReturnType.IsEquivalentTo(typeA))
+                        .FirstOrDefault();
+
+                    var failTypeCount = caseMethods
+                        .Where(HasFailAttr)
+                        .Count();
+
+                    if (failTypeCount > 1)
+                    {
+                        CodeGenUtil.ReportError(
+                            $"Type can't be made into a free monad because more than one member is marked with the 'Fail' attribute",
+                            "Free monad Code-Gen", context.ProcessingNode, progress);
+                        return Task.FromResult(List<MemberDeclarationSyntax>());
+                    }
 
                     if (firstPure == null)
                     {
-                        CodeGenUtil.ReportError($"Type can't be made into a free monad because no method in the interface has [Pure] attribute that takes a single argument of type '{genA}' and returns a '{genA}'", "Free monad Code-Gen", context.ProcessingNode, progress);
+                        CodeGenUtil.ReportError(
+                            $"Type can't be made into a free monad because no method in the interface has [Pure] attribute that takes a single argument of type '{genA}' and returns a '{genA}'",
+                            "Free monad Code-Gen", context.ProcessingNode, progress);
+                        return Task.FromResult(List<MemberDeclarationSyntax>());
+                    }
+
+                    if (firstFail != null && mapIsStatic && !hasStaticBiMap)
+                    {
+                        CodeGenUtil.ReportError(
+                            $"Type can't be made into a free monad because no static 'BiMap' method found",
+                            "Free monad Code-Gen", context.ProcessingNode, progress);
                         return Task.FromResult(List<MemberDeclarationSyntax>());
                     }
 
                     var caseRes = caseMethods
                         .Zip(Enumerable.Range(1, int.MaxValue), (m, i) => (m, i))
                         .Select(m => CodeGenUtil.MakeCaseType(
-                            context,
-                            progress,
-                            applyTo.Identifier,
-                            applyTo.Members,
-                            applyTo.TypeParameterList,
-                            applyTo.Modifiers,
-                            applyTo.ConstraintClauses,
-                            m.m.Identifier,
-                            m.m.TypeParameterList,
-                            m.m.ParameterList
+                            context: context,
+                            progress: progress,
+                            applyToIdentifier: applyTo.Identifier,
+                            applyToMembers: applyTo.Members,
+                            applyToTypeParams: applyTo.TypeParameterList,
+                            applyToModifiers: applyTo.Modifiers,
+                            applyToConstraints: applyTo.ConstraintClauses,
+                            caseIdentifier: m.m.Identifier,
+                            caseTypeParams: m.m.TypeParameterList,
+                            caseParams: m.m.ParameterList
                                 .Parameters
                                 .Select(p => (p.Identifier, p.Type, p.Modifiers, p.AttributeLists))
                                 .ToList(),
-                            BaseSpec.Interface,
+                            baseSpec: BaseSpec.Interface,
                             caseIsClass: true,
                             caseIsPartial: false,
                             includeWithAndLenses: false,
-                            m.i))
+                            tag: m.i))
                         .ToList();
 
                     var ok = caseRes.All(x => x.Success);
                     var cases = caseRes.Select(c => c.Type);
 
-                    var staticCtorClass = MakeStaticClass(
-                        applyTo.Identifier, 
-                        caseMethods,
-                        applyTo.TypeParameterList, 
-                        applyTo.ConstraintClauses,
-                        firstPure,
-                        mapIsStatic);
+                    var staticCtorClass = MakeStaticClass
+                    (
+                        applyToIdentifier: applyTo.Identifier,
+                        applyToMembers: caseMethods,
+                        applyToTypeParams: applyTo.TypeParameterList,
+                        applyToConstraints: applyTo.ConstraintClauses,
+                        pure: firstPure,
+                        fail: firstFail,
+                        failType: failType,
+                        mapIsStatic: mapIsStatic
+                    );
 
-                    if (ok)
-                    {
-                        return Task.FromResult(List<MemberDeclarationSyntax>().AddRange(cases).Add(staticCtorClass));
-                    }
-                    else
-                    {
-                        return Task.FromResult(List<MemberDeclarationSyntax>());
-                    }
-                }
-                else
-                {
-                    CodeGenUtil.ReportError($"Type can't be made into a free monad.  It must be an interface", "Free monad Code-Gen", context.ProcessingNode, progress);
-                    return Task.FromResult(List<MemberDeclarationSyntax>());
+                    return Task.FromResult(ok
+                        ? List<MemberDeclarationSyntax>().AddRange(cases).Add(staticCtorClass)
+                        : List<MemberDeclarationSyntax>());
                 }
 
+                CodeGenUtil.ReportError($"Type can't be made into a free monad.  It must be an interface",
+                    "Free monad Code-Gen", context.ProcessingNode, progress);
+                return Task.FromResult(List<MemberDeclarationSyntax>());
             }
             catch (Exception e)
             {
@@ -142,11 +183,19 @@ namespace LanguageExt.CodeGen
             }
         }
 
+        static bool IsPureAttr(AttributeSyntax s) => s.Name.ToString() == "Pure";
+        static bool IsFailAttr(AttributeSyntax s) => s.Name.ToString() == "Fail";
+
         static bool HasPureAttr(MethodDeclarationSyntax m) =>
-            m.AttributeLists != null &&
             m.AttributeLists
-                .SelectMany<AttributeListSyntax, AttributeSyntax>(a => a.Attributes)
-                .Any(a => a.Name.ToString() == "Pure");
+                .SelectMany(a => a.Attributes)
+                .Any(IsPureAttr);
+
+        static bool HasFailAttr(MethodDeclarationSyntax m) =>
+            m.AttributeLists
+                .SelectMany(a => a.Attributes)
+                .Any(IsFailAttr);
+
 
         static MemberDeclarationSyntax[] AddMonadDefaults(
             SyntaxToken applyToIdentifier,
@@ -157,11 +206,11 @@ namespace LanguageExt.CodeGen
             var genA = applyToTypeParams.Parameters.First().ToString();
             var genB = CodeGenUtil.NextGenName(genA);
             var genC = CodeGenUtil.NextGenName(genB);
-            
-            var typeA = MakeTypeName(applyToIdentifier.Text,genA);
+
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
             var liftedTypeA = MakeTypeName(applyToIdentifier.Text, typeA.ToString());
-            var typeB = MakeTypeName(applyToIdentifier.Text,genB);
-            var typeC = MakeTypeName(applyToIdentifier.Text,genC);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var typeC = MakeTypeName(applyToIdentifier.Text, genC);
             var bindFuncType = ParseTypeName($"System.Func<{genA}, {typeB}>");
             var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
             var projFuncType = ParseTypeName($"System.Func<{genA}, {genB}, {genC}>");
@@ -172,25 +221,13 @@ namespace LanguageExt.CodeGen
             var typeParamC = TypeParameter(Identifier(genC));
             var typeParamsA =
                 TypeParameterList(SeparatedList<TypeParameterSyntax>(new SyntaxNodeOrToken[] {typeParamA}));
-            
+
             var typeParamsAB = TypeParameterList(
                 SeparatedList<TypeParameterSyntax>(
-                    new SyntaxNodeOrToken[]
-                    {
-                        typeParamA,
-                        comma, 
-                        typeParamB
-                    }));
+                    new SyntaxNodeOrToken[] {typeParamA, comma, typeParamB}));
             var typeParamsABC = TypeParameterList(
                 SeparatedList<TypeParameterSyntax>(
-                    new SyntaxNodeOrToken[]
-                    {
-                        typeParamA,
-                        comma, 
-                        typeParamB,
-                        comma, 
-                        typeParamC
-                    }));
+                    new SyntaxNodeOrToken[] {typeParamA, comma, typeParamB, comma, typeParamC}));
             var pubStatMods = TokenList(new[] {Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)});
 
             var thisMA = Parameter(Identifier("ma"))
@@ -201,172 +238,199 @@ namespace LanguageExt.CodeGen
                 .WithModifiers(TokenList(Token(SyntaxKind.ThisKeyword)))
                 .WithType(liftedTypeA);
 
-            return new MemberDeclarationSyntax[]{
+            return new MemberDeclarationSyntax[]
+            {
                 MethodDeclaration(
-                    typeB,
-                    Identifier("Select"))
-                .WithModifiers(pubStatMods)
-                .WithTypeParameterList(typeParamsAB)
-                .WithParameterList(
-                    ParameterList(
-                        SeparatedList<ParameterSyntax>(
-                            new SyntaxNodeOrToken[]{
-                                thisMA,
-                                comma,
-                                Parameter(
-                                    Identifier("f"))
-                                .WithType(mapFuncType)})))
-                .WithExpressionBody(
-                    ArrowExpressionClause(
-                        InvocationExpression(
-                            IdentifierName("Map"))
-                        .WithArgumentList(
-                            ArgumentList(
-                                SeparatedList<ArgumentSyntax>(
-                                    new SyntaxNodeOrToken[]{
-                                        Argument(
-                                            IdentifierName("ma")),
-                                        comma,
-                                        Argument(
-                                            IdentifierName("f"))})))))
-                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
+                        typeB,
+                        Identifier("Select"))
+                    .WithModifiers(pubStatMods)
+                    .WithTypeParameterList(typeParamsAB)
+                    .WithParameterList(
+                        ParameterList(
+                            SeparatedList<ParameterSyntax>(
+                                new SyntaxNodeOrToken[]
+                                {
+                                    thisMA, comma, Parameter(Identifier("f"))
+                                        .WithType(mapFuncType)
+                                })))
+                    .WithExpressionBody(
+                        ArrowExpressionClause(
+                            InvocationExpression(
+                                    IdentifierName("Map"))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList<ArgumentSyntax>(
+                                            new SyntaxNodeOrToken[]
+                                            {
+                                                Argument(IdentifierName("ma")), comma, Argument(IdentifierName("f"))
+                                            })))))
+                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
                 MethodDeclaration(typeB, Identifier("SelectMany"))
-                .WithModifiers(pubStatMods)
-                .WithTypeParameterList(typeParamsAB)
-                .WithParameterList(
-                    ParameterList(
-                        SeparatedList<ParameterSyntax>(
-                            new SyntaxNodeOrToken[]{
-                                thisMA,
-                                comma,
-                                Parameter(Identifier("f")).WithType(bindFuncType)})))
-                .WithExpressionBody(
-                    ArrowExpressionClause(
-                        InvocationExpression(
-                            IdentifierName("Bind"))
-                        .WithArgumentList(
-                            ArgumentList(
-                                SeparatedList<ArgumentSyntax>(
-                                    new SyntaxNodeOrToken[]{
-                                        Argument(
-                                            IdentifierName("ma")),
-                                        comma,
-                                        Argument(
-                                            IdentifierName("f"))})))))
-                .WithSemicolonToken(
-                    Token(SyntaxKind.SemicolonToken)),
+                    .WithModifiers(pubStatMods)
+                    .WithTypeParameterList(typeParamsAB)
+                    .WithParameterList(
+                        ParameterList(
+                            SeparatedList<ParameterSyntax>(
+                                new SyntaxNodeOrToken[]
+                                {
+                                    thisMA, comma, Parameter(Identifier("f")).WithType(bindFuncType)
+                                })))
+                    .WithExpressionBody(
+                        ArrowExpressionClause(
+                            InvocationExpression(
+                                    IdentifierName("Bind"))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList<ArgumentSyntax>(
+                                            new SyntaxNodeOrToken[]
+                                            {
+                                                Argument(
+                                                    IdentifierName("ma")),
+                                                comma, Argument(
+                                                    IdentifierName("f"))
+                                            })))))
+                    .WithSemicolonToken(
+                        Token(SyntaxKind.SemicolonToken)),
                 MethodDeclaration(typeC, Identifier("SelectMany"))
-                .WithModifiers(pubStatMods)
-                .WithTypeParameterList(typeParamsABC)
-                .WithParameterList(
-                    ParameterList(
-                        SeparatedList<ParameterSyntax>(
-                            new SyntaxNodeOrToken[]{
-                                thisMA,
-                                comma,
-                                Parameter(Identifier("bind")).WithType(bindFuncType),
-                                comma,
-                                Parameter(Identifier("project")).WithType(projFuncType)})))
-                .WithExpressionBody(
-                    ArrowExpressionClause(
-                        InvocationExpression(
-                            IdentifierName("Bind"))
-                        .WithArgumentList(
-                            ArgumentList(
-                                SeparatedList<ArgumentSyntax>(
-                                    new SyntaxNodeOrToken[]{
-                                        Argument(
-                                            IdentifierName("ma")),
-                                        comma,
-                                        Argument(
-                                            SimpleLambdaExpression(
-                                                Parameter(
-                                                    Identifier("a")),
-                                                InvocationExpression(
-                                                    IdentifierName("Map"))
-                                                .WithArgumentList(
-                                                    ArgumentList(
-                                                        SeparatedList<ArgumentSyntax>(
-                                                            new SyntaxNodeOrToken[]{
-                                                                Argument(
-                                                                    InvocationExpression(
-                                                                        IdentifierName("bind"))
-                                                                    .WithArgumentList(
-                                                                        ArgumentList(
-                                                                            SingletonSeparatedList<ArgumentSyntax>(
-                                                                                Argument(
-                                                                                    IdentifierName("a")))))),
-                                                                comma,
-                                                                Argument(
-                                                                    SimpleLambdaExpression(
-                                                                        Parameter(
-                                                                            Identifier("b")),
-                                                                        InvocationExpression(
-                                                                            IdentifierName("project"))
-                                                                        .WithArgumentList(
-                                                                            ArgumentList(
-                                                                                SeparatedList<ArgumentSyntax>(
-                                                                                    new SyntaxNodeOrToken[]{
-                                                                                        Argument(
-                                                                                            IdentifierName("a")),
-                                                                                        comma,
-                                                                                        Argument(
-                                                                                            IdentifierName("b"))})))))})))))})))))
-                .WithSemicolonToken(
-                    Token(SyntaxKind.SemicolonToken)),
+                    .WithModifiers(pubStatMods)
+                    .WithTypeParameterList(typeParamsABC)
+                    .WithParameterList(
+                        ParameterList(
+                            SeparatedList<ParameterSyntax>(
+                                new SyntaxNodeOrToken[]
+                                {
+                                    thisMA, comma, Parameter(Identifier("bind")).WithType(bindFuncType), comma,
+                                    Parameter(Identifier("project")).WithType(projFuncType)
+                                })))
+                    .WithExpressionBody(
+                        ArrowExpressionClause(
+                            InvocationExpression(
+                                    IdentifierName("Bind"))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList<ArgumentSyntax>(
+                                            new SyntaxNodeOrToken[]
+                                            {
+                                                Argument(
+                                                    IdentifierName("ma")),
+                                                comma, Argument(
+                                                    SimpleLambdaExpression(
+                                                        Parameter(
+                                                            Identifier("a")),
+                                                        InvocationExpression(
+                                                                IdentifierName("Map"))
+                                                            .WithArgumentList(
+                                                                ArgumentList(
+                                                                    SeparatedList<ArgumentSyntax>(
+                                                                        new SyntaxNodeOrToken[]
+                                                                        {
+                                                                            Argument(
+                                                                                InvocationExpression(
+                                                                                        IdentifierName("bind"))
+                                                                                    .WithArgumentList(
+                                                                                        ArgumentList(
+                                                                                            SingletonSeparatedList(
+                                                                                                Argument(
+                                                                                                    IdentifierName(
+                                                                                                        "a")))))),
+                                                                            comma, Argument(
+                                                                                SimpleLambdaExpression(
+                                                                                    Parameter(
+                                                                                        Identifier("b")),
+                                                                                    InvocationExpression(
+                                                                                            IdentifierName("project"))
+                                                                                        .WithArgumentList(
+                                                                                            ArgumentList(
+                                                                                                SeparatedList<
+                                                                                                    ArgumentSyntax>(
+                                                                                                    new
+                                                                                                        SyntaxNodeOrToken
+                                                                                                        []
+                                                                                                        {
+                                                                                                            Argument(
+                                                                                                                IdentifierName(
+                                                                                                                    "a")),
+                                                                                                            comma,
+                                                                                                            Argument(
+                                                                                                                IdentifierName(
+                                                                                                                    "b"))
+                                                                                                        })))))
+                                                                        })))))
+                                            })))))
+                    .WithSemicolonToken(
+                        Token(SyntaxKind.SemicolonToken)),
                 MethodDeclaration(typeA, Identifier("Flatten"))
                     .WithModifiers(pubStatMods)
                     .WithTypeParameterList(typeParamsA)
-                .WithParameterList(ParameterList(SingletonSeparatedList<ParameterSyntax>(thisMMA)))
-                .WithExpressionBody(
-                    ArrowExpressionClause(
-                        InvocationExpression(
-                            IdentifierName("Bind"))
-                        .WithArgumentList(
-                            ArgumentList(
-                                SeparatedList<ArgumentSyntax>(
-                                    new SyntaxNodeOrToken[]{
-                                        Argument(
-                                            IdentifierName("mma")),
-                                        comma,
-                                        Argument(
-                                            MemberAccessExpression(
-                                                SyntaxKind.SimpleMemberAccessExpression,
-                                                MemberAccessExpression(
-                                                    SyntaxKind.SimpleMemberAccessExpression,
-                                                    IdentifierName("LanguageExt"),
-                                                    IdentifierName("Prelude")),
-                                                IdentifierName("identity")))})))))
-                .WithSemicolonToken(
-                    Token(SyntaxKind.SemicolonToken))
-                };
+                    .WithParameterList(ParameterList(SingletonSeparatedList(thisMMA)))
+                    .WithExpressionBody(
+                        ArrowExpressionClause(
+                            InvocationExpression(
+                                    IdentifierName("Bind"))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList<ArgumentSyntax>(
+                                            new SyntaxNodeOrToken[]
+                                            {
+                                                Argument(
+                                                    IdentifierName("mma")),
+                                                comma, Argument(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("LanguageExt"),
+                                                            IdentifierName("Prelude")),
+                                                        IdentifierName("identity")))
+                                            })))))
+                    .WithSemicolonToken(
+                        Token(SyntaxKind.SemicolonToken))
+            };
         }
 
-        static MethodDeclarationSyntax MakeFree(MethodDeclarationSyntax m, TypeSyntax freeType)
+        static MethodDeclarationSyntax MakeFree(MethodDeclarationSyntax m, TypeSyntax freeType, TypeSyntax failType)
         {
-            bool isPure = m.AttributeLists != null && m.AttributeLists
-                           .SelectMany(a => a.Attributes)
-                           .Any(a => a.Name.ToString() == "Pure");
-
-            if (isPure)
+            if (HasPureAttr(m) || HasFailAttr(m))
             {
                 return m.WithReturnType(freeType);
             }
-            else
-            {
-                var type = QualifiedName(
-                    IdentifierName("System"),
-                    GenericName(
-                            Identifier("Func"))
-                        .WithTypeArgumentList(
-                            TypeArgumentList(
-                                SeparatedList<TypeSyntax>(
-                                    new SyntaxNodeOrToken[] {m.ReturnType, Token(SyntaxKind.CommaToken), freeType}))));
 
+            var nextType = QualifiedName(
+                IdentifierName("System"),
+                GenericName(
+                        Identifier("Func"))
+                    .WithTypeArgumentList(
+                        TypeArgumentList(
+                            SeparatedList<TypeSyntax>(
+                                new SyntaxNodeOrToken[] {m.ReturnType, Token(SyntaxKind.CommaToken), freeType}))));
+
+            if (failType == null)
+            {
                 return m.WithParameterList(m.ParameterList
-                                            .AddParameters(Parameter(Identifier("next")).WithType(type)))
-                        .WithReturnType(freeType);
+                        .AddParameters(
+                            Parameter(Identifier("next"))
+                                .WithType(nextType)))
+                    .WithReturnType(freeType);
             }
+
+            var failNextType = QualifiedName(
+                IdentifierName("System"),
+                GenericName(
+                        Identifier("Func"))
+                    .WithTypeArgumentList(
+                        TypeArgumentList(
+                            SeparatedList<TypeSyntax>(
+                                new SyntaxNodeOrToken[] {failType, Token(SyntaxKind.CommaToken), freeType}))));
+
+            return m.WithParameterList(m.ParameterList
+                    .AddParameters(
+                        Parameter(Identifier("next"))
+                            .WithType(nextType))
+                    .AddParameters(
+                        Parameter(Identifier("failNext"))
+                            .WithType(failNextType))
+                )
+                .WithReturnType(freeType);
         }
 
         static ClassDeclarationSyntax MakeStaticClass(
@@ -375,51 +439,108 @@ namespace LanguageExt.CodeGen
             TypeParameterListSyntax applyToTypeParams,
             SyntaxList<TypeParameterConstraintClauseSyntax> applyToConstraints,
             MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail,
+            TypeSyntax failType,
             bool mapIsStatic
-            )
+        )
         {
             var name = applyToIdentifier;
             var @class = ClassDeclaration(name)
-                            .WithModifiers(
-                                TokenList(new[] { Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.PartialKeyword) }));
+                .WithModifiers(
+                    TokenList(
+                        Token(SyntaxKind.PublicKeyword),
+                        Token(SyntaxKind.StaticKeyword),
+                        Token(SyntaxKind.PartialKeyword)));
 
             var returnType = ParseTypeName($"{applyToIdentifier}{applyToTypeParams}");
 
             var cases = applyToMembers
-                               .Select(m => MakeCaseCtorFunction(applyToIdentifier, applyToTypeParams, applyToConstraints, returnType, m, pure))
-                               .ToArray();
+                .Select(m => MakeCaseCtorFunction
+                (
+                    applyToIdentifier: applyToIdentifier,
+                    applyToTypeParams: applyToTypeParams,
+                    applyToConstraints: applyToConstraints,
+                    returnType: returnType,
+                    method: m,
+                    pure: pure,
+                    fail: fail
+                ))
+                .ToArray();
 
+            var bind = MakeBindFunction(applyToIdentifier, applyToMembers, applyToTypeParams, pure, fail, mapIsStatic);
 
-            var bind = MakeBindFunction(applyToIdentifier, applyToConstraints, applyToMembers, applyToTypeParams, pure, mapIsStatic);
             var map = mapIsStatic
-                ? MakeMapExtension(applyToIdentifier, applyToConstraints, applyToMembers, applyToTypeParams)
-                : MakeMapFunction(applyToIdentifier, applyToConstraints, applyToMembers, applyToTypeParams, pure);
+                ? MakeMapExtension
+                (
+                    applyToIdentifier: applyToIdentifier,
+                    applyToTypeParams: applyToTypeParams
+                )
+                : MakeMapFunction
+                (
+                    applyToIdentifier: applyToIdentifier,
+                    applyToMembers: applyToMembers,
+                    applyToTypeParams: applyToTypeParams,
+                    pure: pure,
+                    fail: fail
+                );
+
             var monad = AddMonadDefaults(applyToIdentifier, applyToMembers, applyToTypeParams, applyToConstraints);
-            
-            return @class.WithMembers(List(cases).Add(bind).Add(map).AddRange(monad));
+
+            if (fail == null)
+                return @class.WithMembers(List(cases).Add(bind).Add(map).AddRange(monad));
+
+            var biBind = MakeBiBindFunction
+            (
+                applyToIdentifier: applyToIdentifier,
+                applyToMembers: applyToMembers,
+                applyToTypeParams: applyToTypeParams,
+                pure: pure,
+                fail: fail,
+                failType: failType,
+                mapIsStatic: mapIsStatic
+            );
+
+            var bimap = mapIsStatic
+                ? MakeBiMapExtension
+                (
+                    applyToIdentifier: applyToIdentifier,
+                    applyToTypeParams: applyToTypeParams,
+                    failType: failType
+                )
+                : MakeBiMapFunction
+                (
+                    applyToIdentifier: applyToIdentifier,
+                    applyToMembers: applyToMembers,
+                    applyToTypeParams: applyToTypeParams,
+                    pure: pure,
+                    fail: fail,
+                    failType: failType
+                );
+
+            return @class.WithMembers(List(cases).Add(bind).Add(biBind).Add(map).Add(bimap).AddRange(monad));
         }
 
         static TypeSyntax MakeTypeName(string ident, string gen) =>
             ParseTypeName($"{ident}<{gen}>");
- 
+
         static MethodDeclarationSyntax MakeBindFunction(
-            SyntaxToken applyToIdentifier, 
-            SyntaxList<TypeParameterConstraintClauseSyntax> applyToConstraints,
+            SyntaxToken applyToIdentifier,
             MethodDeclarationSyntax[] applyToMembers,
             TypeParameterListSyntax applyToTypeParams,
             MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail,
             bool mapIsStatic)
         {
             var genA = applyToTypeParams.Parameters.First().ToString();
             var genB = CodeGenUtil.NextGenName(genA);
             var genC = CodeGenUtil.NextGenName(genB);
-            
-            var typeA = MakeTypeName(applyToIdentifier.Text,genA);
-            var typeB = MakeTypeName(applyToIdentifier.Text,genB);
-            var typeC = MakeTypeName(applyToIdentifier.Text,genC);
+
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var typeC = MakeTypeName(applyToIdentifier.Text, genC);
             var bindFunc = ParseTypeName($"System.Func<{genA}, {typeB}>");
 
-            var mapFunc = mapIsStatic
+            var mapNextFunc = mapIsStatic
                 ? InvocationExpression(
                     MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
@@ -441,116 +562,246 @@ namespace LanguageExt.CodeGen
                                                             IdentifierName("Next")))
                                                     .WithArgumentList(
                                                         ArgumentList(
-                                                            SingletonSeparatedList<ArgumentSyntax>(
+                                                            SingletonSeparatedList(
                                                                 Argument(
                                                                     IdentifierName("n")))))),
                                             Token(SyntaxKind.CommaToken), Argument(
                                                 ParenthesizedExpression(
                                                     IdentifierName("f")))
                                         }))),
-                        IdentifierName("Bind")))
+                        IdentifierName("Flatten")))
                 : InvocationExpression(IdentifierName("Flatten")).WithArgumentList(
                     ArgumentList(
-                        SingletonSeparatedList<ArgumentSyntax>(
+                        SingletonSeparatedList(
                             Argument(
-                    InvocationExpression(
-                            MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
                                 InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("v"),
-                                            IdentifierName("Next")))
+                                            InvocationExpression(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        IdentifierName("v"),
+                                                        IdentifierName("Next")))
+                                                .WithArgumentList(
+                                                    ArgumentList(
+                                                        SingletonSeparatedList(
+                                                            Argument(
+                                                                IdentifierName("n"))))),
+                                            IdentifierName("Map")))
                                     .WithArgumentList(
                                         ArgumentList(
-                                            SingletonSeparatedList<ArgumentSyntax>(
+                                            SingletonSeparatedList(
                                                 Argument(
-                                                    IdentifierName("n"))))),
-                                IdentifierName("Map")))
+                                                    IdentifierName("f")))))))));
+
+
+            // this is only used if we have a fail path
+            var mapFailFunc = mapIsStatic
+                ? InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    typeA,
+                                    IdentifierName("Map")))
+                            .WithArgumentList(
+                                ArgumentList(
+                                    SeparatedList<ArgumentSyntax>(
+                                        new SyntaxNodeOrToken[]
+                                        {
+                                            Argument(
+                                                InvocationExpression(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName("FailNext")))
+                                                    .WithArgumentList(
+                                                        ArgumentList(
+                                                            SingletonSeparatedList(
+                                                                Argument(
+                                                                    IdentifierName("fn")))))),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                ParenthesizedExpression(
+                                                    IdentifierName("f")))
+                                        }))),
+                        IdentifierName("Flatten")))
+                : InvocationExpression(IdentifierName("Flatten")).WithArgumentList(
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                InvocationExpression(
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            InvocationExpression(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        IdentifierName("v"),
+                                                        IdentifierName("FailNext")))
+                                                .WithArgumentList(
+                                                    ArgumentList(
+                                                        SingletonSeparatedList(
+                                                            Argument(
+                                                                IdentifierName("fn"))))),
+                                            IdentifierName("Map")))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SingletonSeparatedList(
+                                                Argument(
+                                                    IdentifierName("f")))))))));
+
+            var pureFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        ParseTypeName($"{pure.Identifier.Text}<{genA}>"),
+                        SingleVariableDesignation(Identifier("v"))),
+                    InvocationExpression(IdentifierName("f"))
                         .WithArgumentList(
                             ArgumentList(
-                                SingletonSeparatedList<ArgumentSyntax>(
+                                SingletonSeparatedList(
                                     Argument(
-                                        IdentifierName("f")))))))));
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            IdentifierName("v"),
+                                            IdentifierName(CodeGenUtil.MakeFirstCharUpper(pure.ParameterList.Parameters
+                                                .First().Identifier.Text)))))))),
+                Token(SyntaxKind.CommaToken)
+            };
 
-            var pureFunc =
-                    new SyntaxNodeOrToken[]
-                    {
-                        SwitchExpressionArm(
-                            DeclarationPattern(
-                                ParseTypeName($"{pure.Identifier.Text}<{genA}>"),
-                                SingleVariableDesignation(Identifier("v"))),
-                            InvocationExpression(IdentifierName("f"))
-                                .WithArgumentList(
-                                    ArgumentList(
-                                        SingletonSeparatedList<ArgumentSyntax>(
+            // this will only be used if we have a fail path
+            var failFunc = fail != null
+                ? new SyntaxNodeOrToken[]
+                {
+                    SwitchExpressionArm(
+                        DeclarationPattern(
+                            MakeTypeName(fail.Identifier.Text, genA),
+                            SingleVariableDesignation(Identifier("v"))),
+                        ObjectCreationExpression(MakeTypeName(fail.Identifier.Text, genB))
+                            .WithArgumentList(
+                                fail.ParameterList.Parameters.Count == 0
+                                    ? ArgumentList()
+                                    : ArgumentList(
+                                        SingletonSeparatedList(
                                             Argument(
                                                 MemberAccessExpression(
                                                     SyntaxKind.SimpleMemberAccessExpression,
                                                     IdentifierName("v"),
-                                                    IdentifierName(CodeGenUtil.MakeFirstCharUpper(pure.ParameterList.Parameters.First().Identifier.Text)))))))),
-                        Token(SyntaxKind.CommaToken)
-                    };
+                                                    IdentifierName(
+                                                        CodeGenUtil.MakeFirstCharUpper(fail.ParameterList
+                                                            .Parameters.First().Identifier.Text)))))))),
+                    Token(SyntaxKind.CommaToken)
+                }
+                : null;
+
 
             var termimalFuncs = applyToMembers
-               .Where(m => m != pure && m.AttributeLists != null && m.AttributeLists.SelectMany(a => a.Attributes).Any(a => a.Name.ToString() == "Pure"))
-               .SelectMany(m => 
-                   new SyntaxNodeOrToken[]
-                   {
-                       SwitchExpressionArm(
-                           DeclarationPattern(
-                               ParseTypeName($"{m.Identifier.Text}<{genA}>"),
-                               SingleVariableDesignation(Identifier("v"))),
-                               ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
-                              .WithArgumentList(
-                                   ArgumentList(
-                                       SeparatedList<ArgumentSyntax>(
-                                           m.ParameterList
-                                            .Parameters
-                                            .Select(p =>  
-                                               Argument(
-                                                   MemberAccessExpression(
-                                                       SyntaxKind.SimpleMemberAccessExpression,
-                                                       IdentifierName("v"),
-                                                       IdentifierName(CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
-                       Token(SyntaxKind.CommaToken)
-                   });
-
-
-            var freeFuncs = applyToMembers
-                .Where(m => m.AttributeLists == null || !m.AttributeLists.SelectMany(a => a.Attributes).Any(a => a.Name.ToString() == "Pure"))
-                .SelectMany(m => 
+                .Where(m => m != pure)
+                .Where(m => m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
                     new SyntaxNodeOrToken[]
                     {
                         SwitchExpressionArm(
                             DeclarationPattern(
                                 ParseTypeName($"{m.Identifier.Text}<{genA}>"),
                                 SingleVariableDesignation(Identifier("v"))),
-                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
                                 .WithArgumentList(
                                     ArgumentList(
-                                        SeparatedList<ArgumentSyntax>(
-                                            Enumerable.Concat(
+                                        SeparatedList(
+                                            m.ParameterList
+                                                .Parameters
+                                                .Select(p =>
+                                                    Argument(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName(
+                                                                CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
+                        Token(SyntaxKind.CommaToken)
+                    });
+
+
+            var freeFuncs = fail != null
+                ? applyToMembers
+                    .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                    .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsFailAttr))
+                    .SelectMany(m =>
+                        new SyntaxNodeOrToken[]
+                        {
+                            SwitchExpressionArm(
+                                DeclarationPattern(
+                                    ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                    SingleVariableDesignation(Identifier("v"))),
+                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList<ArgumentSyntax>(
                                                 m.ParameterList
                                                     .Parameters
-                                                    .Take(m.ParameterList.Parameters.Count - 1)
+                                                    .Take(m.ParameterList.Parameters.Count - 2)
                                                     .SelectMany(p =>
-                                                        new SyntaxNodeOrToken[]{
+                                                        new SyntaxNodeOrToken[]
+                                                        {
                                                             Argument(
                                                                 MemberAccessExpression(
                                                                     SyntaxKind.SimpleMemberAccessExpression,
                                                                     IdentifierName("v"),
-                                                                    IdentifierName(CodeGenUtil.MakeFirstCharUpper(p.Identifier.Text)))),
-                                                            Token(SyntaxKind.CommaToken) 
-                                                        }),
-                                                new SyntaxNodeOrToken [1] {
-                                                    Argument(SimpleLambdaExpression(Parameter(Identifier("n")), mapFunc))
-                                                }))))),
-                        Token(SyntaxKind.CommaToken)
-                    });
+                                                                    IdentifierName(
+                                                                        CodeGenUtil.MakeFirstCharUpper(p.Identifier
+                                                                            .Text)))),
+                                                            Token(SyntaxKind.CommaToken)
+                                                        })
+                                                    .Concat(new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                            mapNextFunc)),
+                                                        Token(SyntaxKind.CommaToken), Argument(SimpleLambdaExpression(
+                                                            Parameter(Identifier("fn")),
+                                                            mapFailFunc))
+                                                    }))))),
+                            Token(SyntaxKind.CommaToken)
+                        })
+                : applyToMembers
+                    .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                    .SelectMany(m =>
+                        new SyntaxNodeOrToken[]
+                        {
+                            SwitchExpressionArm(
+                                DeclarationPattern(
+                                    ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                    SingleVariableDesignation(Identifier("v"))),
+                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList<ArgumentSyntax>(
+                                                m.ParameterList
+                                                    .Parameters
+                                                    .Take(m.ParameterList.Parameters.Count - 1)
+                                                    .SelectMany(p =>
+                                                        new SyntaxNodeOrToken[]
+                                                        {
+                                                            Argument(
+                                                                MemberAccessExpression(
+                                                                    SyntaxKind.SimpleMemberAccessExpression,
+                                                                    IdentifierName("v"),
+                                                                    IdentifierName(
+                                                                        CodeGenUtil.MakeFirstCharUpper(p.Identifier
+                                                                            .Text)))),
+                                                            Token(SyntaxKind.CommaToken)
+                                                        })
+                                                    .Concat(new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                            mapNextFunc))
+                                                    }))))),
+                            Token(SyntaxKind.CommaToken)
+                        });
 
             var tokens = new List<SyntaxNodeOrToken>();
             tokens.AddRange(pureFunc);
+            if (failFunc != null)
+                tokens.AddRange(failFunc);
             tokens.AddRange(termimalFuncs);
             tokens.AddRange(freeFuncs);
             tokens.Add(
@@ -558,10 +809,10 @@ namespace LanguageExt.CodeGen
                     DiscardPattern(),
                     ThrowExpression(
                         ObjectCreationExpression(
-                            QualifiedName(
-                                IdentifierName("System"),
-                                IdentifierName("NotSupportedException")))
-                        .WithArgumentList(ArgumentList()))));
+                                QualifiedName(
+                                    IdentifierName("System"),
+                                    IdentifierName("NotSupportedException")))
+                            .WithArgumentList(ArgumentList()))));
 
             return MethodDeclaration(typeB, Identifier("Bind"))
                 .WithModifiers(
@@ -601,185 +852,266 @@ namespace LanguageExt.CodeGen
                 .NormalizeWhitespace();
         }
 
-        static MethodDeclarationSyntax MakeMapExtension(
-            SyntaxToken applyToIdentifier, 
-            SyntaxList<TypeParameterConstraintClauseSyntax> applyToConstraints,
+        static MethodDeclarationSyntax MakeBiBindFunction(
+            SyntaxToken applyToIdentifier,
             MethodDeclarationSyntax[] applyToMembers,
-            TypeParameterListSyntax applyToTypeParams)
+            TypeParameterListSyntax applyToTypeParams,
+            MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail,
+            TypeSyntax failType,
+            bool mapIsStatic)
         {
             var genA = applyToTypeParams.Parameters.First().ToString();
             var genB = CodeGenUtil.NextGenName(genA);
-            var typeA = MakeTypeName(applyToIdentifier.Text,genA);
-            var typeB = MakeTypeName(applyToIdentifier.Text,genB);
-            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
+            var genC = CodeGenUtil.NextGenName(genB);
 
-            return MethodDeclaration(
-                    typeB,
-                    Identifier("Map"))
-                        .WithModifiers(
-                            TokenList(
-                                new[] {Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)}))
-                        .WithTypeParameterList(
-                            TypeParameterList(
-                                SeparatedList<TypeParameterSyntax>(
-                                    new SyntaxNodeOrToken[]
-                                    {
-                                        TypeParameter(
-                                            Identifier(genA)),
-                                        Token(SyntaxKind.CommaToken), TypeParameter(
-                                            Identifier(genB))
-                                    })))
-                        .WithParameterList(
-                            ParameterList(
-                                SeparatedList<ParameterSyntax>(
-                                    new SyntaxNodeOrToken[]
-                                    {
-                                        Parameter(
-                                                Identifier("ma"))
-                                            .WithModifiers(
-                                                TokenList(
-                                                    Token(SyntaxKind.ThisKeyword)))
-                                            .WithType(typeA),
-                                        Token(SyntaxKind.CommaToken), Parameter(Identifier("f")).WithType(mapFuncType)
-                                    })))
-                        .WithExpressionBody(
-                            ArrowExpressionClause(
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var typeC = MakeTypeName(applyToIdentifier.Text, genC);
+            var bindFunc = ParseTypeName($"System.Func<{genA}, {typeB}>");
+            var bindFailFuncType = failType != null
+                ? ParseTypeName($"System.Func<{failType}, {typeB}>")
+                : ParseTypeName($"System.Func<{typeB}>");
+            
+            var pureTypeA = MakeTypeName(pure.Identifier.Text, genA);
+            var failTypeA = MakeTypeName(fail.Identifier.Text, genA);
+
+            var mapFunc = mapIsStatic
+                ? InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    typeA,
+                                    IdentifierName("BiMap")))
+                            .WithArgumentList(
+                                ArgumentList(
+                                    SeparatedList<ArgumentSyntax>(
+                                        new SyntaxNodeOrToken[]
+                                        {
+                                            Argument(
+                                                InvocationExpression(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName("Next")))
+                                                    .WithArgumentList(
+                                                        ArgumentList(
+                                                            SingletonSeparatedList(
+                                                                Argument(
+                                                                    IdentifierName("n")))))),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                ParenthesizedExpression(
+                                                    IdentifierName("Succ"))),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                ParenthesizedExpression(
+                                                    IdentifierName("Fail")))
+                                        }))),
+                        IdentifierName("Flatten")))
+                : InvocationExpression(IdentifierName("Flatten")).WithArgumentList(
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
                                 InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            typeA,
-                                            IdentifierName("Map")))
+                                            InvocationExpression(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        IdentifierName("v"),
+                                                        IdentifierName("Next")))
+                                                .WithArgumentList(
+                                                    ArgumentList(
+                                                        SingletonSeparatedList(
+                                                            Argument(
+                                                                IdentifierName("n"))))),
+                                            IdentifierName("BiMap")))
                                     .WithArgumentList(
                                         ArgumentList(
                                             SeparatedList<ArgumentSyntax>(
                                                 new SyntaxNodeOrToken[]
                                                 {
-                                                    Argument(
-                                                        IdentifierName("ma")),
-                                                    Token(SyntaxKind.CommaToken), Argument(
-                                                        IdentifierName("f"))
-                                                })))))
-                        .WithSemicolonToken(
-                            Token(SyntaxKind.SemicolonToken));
-        }
+                                                    Argument(IdentifierName("Succ")), Token(SyntaxKind.CommaToken),
+                                                    Argument(IdentifierName("Fail"))
+                                                }
+                                            )))))));
 
-        static MethodDeclarationSyntax MakeMapFunction(
-            SyntaxToken applyToIdentifier, 
-            SyntaxList<TypeParameterConstraintClauseSyntax> applyToConstraints,
-            MethodDeclarationSyntax[] applyToMembers,
-            TypeParameterListSyntax applyToTypeParams,
-            MethodDeclarationSyntax pure)
-        {
-            var genA = applyToTypeParams.Parameters.First().ToString();
-            var genB = CodeGenUtil.NextGenName(genA);
-            var genC = CodeGenUtil.NextGenName(genB);
-            
-            var typeA = MakeTypeName(applyToIdentifier.Text,genA);
-            var typeB = MakeTypeName(applyToIdentifier.Text,genB);
-            var typeC = MakeTypeName(applyToIdentifier.Text,genC);
-            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
-            var pureTypeA = MakeTypeName(pure.Identifier.Text, genA);
-            var pureTypeB = MakeTypeName(pure.Identifier.Text, genB);
 
-            var mapFunc = InvocationExpression(
-                MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    InvocationExpression(
-                         MemberAccessExpression(
-                             SyntaxKind.SimpleMemberAccessExpression,
-                             IdentifierName("v"),
-                             IdentifierName("Next")))
-                        .WithArgumentList(ArgumentList(SingletonSeparatedList<ArgumentSyntax>(Argument(IdentifierName("n"))))),
-                    IdentifierName("Map")))
-                .WithArgumentList(
-                    ArgumentList(
-                        SingletonSeparatedList<ArgumentSyntax>(
-                            Argument(
-                                IdentifierName("f")))));
-
-            var pureFunc =
-                    new SyntaxNodeOrToken[]
-                    {
-                        SwitchExpressionArm(
-                            DeclarationPattern(
-                                pureTypeA,
-                                SingleVariableDesignation(Identifier("v"))),
-                            ObjectCreationExpression(pureTypeB)
-                                .WithArgumentList(
-                                    ArgumentList(
-                                        SingletonSeparatedList<ArgumentSyntax>(
+            var mapFailFunc = mapIsStatic
+                ? InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    typeA,
+                                    IdentifierName("BiMap")))
+                            .WithArgumentList(
+                                ArgumentList(
+                                    SeparatedList<ArgumentSyntax>(
+                                        new SyntaxNodeOrToken[]
+                                        {
                                             Argument(
-                                                InvocationExpression(IdentifierName("f"))
+                                                InvocationExpression(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName("FailNext")))
                                                     .WithArgumentList(
                                                         ArgumentList(
-                                                            SingletonSeparatedList<ArgumentSyntax>(
+                                                            SingletonSeparatedList(
                                                                 Argument(
-                                                                    MemberAccessExpression(
-                                                                        SyntaxKind.SimpleMemberAccessExpression,
-                                                                        IdentifierName("v"),
-                                                                        IdentifierName(CodeGenUtil.MakeFirstCharUpper(pure.ParameterList.Parameters.First().Identifier.Text)))))))))))),
-                        Token(SyntaxKind.CommaToken)
-                    };
+                                                                    IdentifierName("fn")))))),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                ParenthesizedExpression(
+                                                    IdentifierName("Succ"))),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                ParenthesizedExpression(
+                                                    IdentifierName("Fail")))
+                                        }))),
+                        IdentifierName("Flatten")))
+                : InvocationExpression(IdentifierName("Flatten")).WithArgumentList(
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                InvocationExpression(
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            InvocationExpression(
+                                                    MemberAccessExpression(
+                                                        SyntaxKind.SimpleMemberAccessExpression,
+                                                        IdentifierName("v"),
+                                                        IdentifierName("FailNext")))
+                                                .WithArgumentList(
+                                                    ArgumentList(
+                                                        SingletonSeparatedList(
+                                                            Argument(
+                                                                IdentifierName("fn"))))),
+                                            IdentifierName("BiMap")))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList<ArgumentSyntax>(
+                                                new SyntaxNodeOrToken[]
+                                                {
+                                                    Argument(IdentifierName("Succ")), Token(SyntaxKind.CommaToken),
+                                                    Argument(IdentifierName("Fail"))
+                                                }
+                                            )))))));
+
+            var pureFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        pureTypeA,
+                        SingleVariableDesignation(Identifier("v"))),
+                    InvocationExpression(IdentifierName("Succ"))
+                        .WithArgumentList(
+                            ArgumentList(
+                                SingletonSeparatedList(
+                                    Argument(
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            IdentifierName("v"),
+                                            IdentifierName(CodeGenUtil.MakeFirstCharUpper(pure.ParameterList.Parameters
+                                                .First().Identifier.Text)))))))),
+                Token(SyntaxKind.CommaToken)
+            };
+
+            var failFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        failTypeA,
+                        SingleVariableDesignation(Identifier("v"))),
+                    InvocationExpression(IdentifierName("Fail"))
+                        .WithArgumentList(
+                            fail.ParameterList.Parameters.Count == 0
+                                ? ArgumentList()
+                                : ArgumentList(
+                                    SingletonSeparatedList(
+                                        Argument(
+                                            MemberAccessExpression(
+                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                IdentifierName("v"),
+                                                IdentifierName(CodeGenUtil.MakeFirstCharUpper(fail.ParameterList
+                                                    .Parameters
+                                                    .First().Identifier.Text)))))))),
+                Token(SyntaxKind.CommaToken)
+            };
 
             var termimalFuncs = applyToMembers
-               .Where(m => m != pure && m.AttributeLists != null && m.AttributeLists.SelectMany(a => a.Attributes).Any(a => a.Name.ToString() == "Pure"))
-               .SelectMany(m => 
-                   new SyntaxNodeOrToken[]
-                   {
-                       SwitchExpressionArm(
-                           DeclarationPattern(
-                               ParseTypeName($"{m.Identifier.Text}<{genA}>"),
-                               SingleVariableDesignation(Identifier("v"))),
-                               ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
-                              .WithArgumentList(
-                                   ArgumentList(
-                                       SeparatedList<ArgumentSyntax>(
-                                           m.ParameterList
-                                            .Parameters
-                                            .Select(p =>  
-                                               Argument(
-                                                   MemberAccessExpression(
-                                                       SyntaxKind.SimpleMemberAccessExpression,
-                                                       IdentifierName("v"),
-                                                       IdentifierName(CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
-                       Token(SyntaxKind.CommaToken)
-                   });
-
-
-            var freeFuncs = applyToMembers
-                .Where(m => m.AttributeLists == null || !m.AttributeLists.SelectMany(a => a.Attributes).Any(a => a.Name.ToString() == "Pure"))
-                .SelectMany(m => 
+                .Where(m => m != pure)
+                .Where(m => m != fail)
+                .Where(m => m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
                     new SyntaxNodeOrToken[]
                     {
                         SwitchExpressionArm(
                             DeclarationPattern(
                                 ParseTypeName($"{m.Identifier.Text}<{genA}>"),
                                 SingleVariableDesignation(Identifier("v"))),
-                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList(
+                                            m.ParameterList
+                                                .Parameters
+                                                .Select(p =>
+                                                    Argument(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName(
+                                                                CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
+                        Token(SyntaxKind.CommaToken)
+                    });
+
+
+            var freeFuncs = applyToMembers
+                .Where(m => m != fail)
+                .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
+                    new SyntaxNodeOrToken[]
+                    {
+                        SwitchExpressionArm(
+                            DeclarationPattern(
+                                ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                SingleVariableDesignation(Identifier("v"))),
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
                                 .WithArgumentList(
                                     ArgumentList(
                                         SeparatedList<ArgumentSyntax>(
-                                            Enumerable.Concat(
-                                                m.ParameterList
-                                                    .Parameters
-                                                    .Take(m.ParameterList.Parameters.Count - 1)
-                                                    .SelectMany(p =>
-                                                        new SyntaxNodeOrToken[]{
-                                                            Argument(
-                                                                MemberAccessExpression(
-                                                                    SyntaxKind.SimpleMemberAccessExpression,
-                                                                    IdentifierName("v"),
-                                                                    IdentifierName(CodeGenUtil.MakeFirstCharUpper(p.Identifier.Text)))),
-                                                            Token(SyntaxKind.CommaToken) 
-                                                        }),
-                                                new SyntaxNodeOrToken [1] {
-                                                    Argument(SimpleLambdaExpression(Parameter(Identifier("n")), mapFunc))
-                                                }))))),
+                                            m.ParameterList
+                                                .Parameters
+                                                .Take(m.ParameterList.Parameters.Count - 2)
+                                                .SelectMany(p =>
+                                                    new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(
+                                                            MemberAccessExpression(
+                                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                                IdentifierName("v"),
+                                                                IdentifierName(
+                                                                    CodeGenUtil.MakeFirstCharUpper(
+                                                                        p.Identifier.Text)))),
+                                                        Token(SyntaxKind.CommaToken)
+                                                    })
+                                                .Concat(new SyntaxNodeOrToken[]
+                                                {
+                                                    Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                        mapFunc)),
+                                                    Token(SyntaxKind.CommaToken), Argument(SimpleLambdaExpression(
+                                                        Parameter(Identifier("fn")),
+                                                        mapFailFunc))
+                                                })
+                                        )))),
                         Token(SyntaxKind.CommaToken)
                     });
 
             var tokens = new List<SyntaxNodeOrToken>();
             tokens.AddRange(pureFunc);
+            tokens.AddRange(failFunc);
             tokens.AddRange(termimalFuncs);
             tokens.AddRange(freeFuncs);
             tokens.Add(
@@ -787,14 +1119,336 @@ namespace LanguageExt.CodeGen
                     DiscardPattern(),
                     ThrowExpression(
                         ObjectCreationExpression(
-                            QualifiedName(
-                                IdentifierName("System"),
-                                IdentifierName("NotSupportedException")))
-                        .WithArgumentList(ArgumentList()))));
+                                QualifiedName(
+                                    IdentifierName("System"),
+                                    IdentifierName("NotSupportedException")))
+                            .WithArgumentList(ArgumentList()))));
+
+            return MethodDeclaration(typeB, Identifier("BiBind"))
+                .WithModifiers(
+                    TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                .WithTypeParameterList(
+                    TypeParameterList(
+                        SeparatedList<TypeParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                TypeParameter(
+                                    Identifier(genA)),
+                                Token(SyntaxKind.CommaToken), TypeParameter(
+                                    Identifier(genB))
+                            })))
+                .WithParameterList(
+                    ParameterList(
+                        SeparatedList<ParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Parameter(
+                                        Identifier("ma"))
+                                    .WithModifiers(
+                                        TokenList(
+                                            Token(SyntaxKind.ThisKeyword)))
+                                    .WithType(typeA),
+                                Token(SyntaxKind.CommaToken), Parameter(
+                                        Identifier("Succ"))
+                                    .WithType(bindFunc),
+                                Token(SyntaxKind.CommaToken), Parameter(
+                                        Identifier("Fail"))
+                                    .WithType(bindFailFuncType)
+                            })))
+                .WithExpressionBody(
+                    ArrowExpressionClause(
+                        SwitchExpression(
+                                IdentifierName("ma"))
+                            .WithArms(SeparatedList<SwitchExpressionArmSyntax>(tokens))))
+                .WithSemicolonToken(
+                    Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace();
+        }
+
+        static MethodDeclarationSyntax MakeMapExtension(
+            SyntaxToken applyToIdentifier,
+            TypeParameterListSyntax applyToTypeParams)
+        {
+            var genA = applyToTypeParams.Parameters.First().ToString();
+            var genB = CodeGenUtil.NextGenName(genA);
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
+
+            return MethodDeclaration(
+                    typeB,
+                    Identifier("Map"))
+                .WithModifiers(
+                    TokenList(
+                        new[] {Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)}))
+                .WithTypeParameterList(
+                    TypeParameterList(
+                        SeparatedList<TypeParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                TypeParameter(
+                                    Identifier(genA)),
+                                Token(SyntaxKind.CommaToken), TypeParameter(
+                                    Identifier(genB))
+                            })))
+                .WithParameterList(
+                    ParameterList(
+                        SeparatedList<ParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Parameter(
+                                        Identifier("ma"))
+                                    .WithModifiers(
+                                        TokenList(
+                                            Token(SyntaxKind.ThisKeyword)))
+                                    .WithType(typeA),
+                                Token(SyntaxKind.CommaToken), Parameter(Identifier("f")).WithType(mapFuncType)
+                            })))
+                .WithExpressionBody(
+                    ArrowExpressionClause(
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    typeA,
+                                    IdentifierName("Map")))
+                            .WithArgumentList(
+                                ArgumentList(
+                                    SeparatedList<ArgumentSyntax>(
+                                        new SyntaxNodeOrToken[]
+                                        {
+                                            Argument(
+                                                IdentifierName("ma")),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                IdentifierName("f"))
+                                        })))))
+                .WithSemicolonToken(
+                    Token(SyntaxKind.SemicolonToken));
+        }
+
+        static MethodDeclarationSyntax MakeMapFunction(
+            SyntaxToken applyToIdentifier,
+            MethodDeclarationSyntax[] applyToMembers,
+            TypeParameterListSyntax applyToTypeParams,
+            MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail)
+        {
+            var genA = applyToTypeParams.Parameters.First().ToString();
+            var genB = CodeGenUtil.NextGenName(genA);
+            var genC = CodeGenUtil.NextGenName(genB);
+
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var typeC = MakeTypeName(applyToIdentifier.Text, genC);
+            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
+            var pureTypeA = MakeTypeName(pure.Identifier.Text, genA);
+            var pureTypeB = MakeTypeName(pure.Identifier.Text, genB);
+
+            var mapNextFunc = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("v"),
+                                    IdentifierName("Next")))
+                            .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("n"))))),
+                        IdentifierName("Map")))
+                .WithArgumentList(
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                IdentifierName("f")))));
+
+            // this will only be used if we have a fail path
+            var mapFailFunc = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("v"),
+                                    IdentifierName("FailNext")))
+                            .WithArgumentList(ArgumentList(SingletonSeparatedList(Argument(IdentifierName("fn"))))),
+                        IdentifierName("Map")))
+                .WithArgumentList(
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(
+                                IdentifierName("f")))));
+
+            var pureFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        pureTypeA,
+                        SingleVariableDesignation(Identifier("v"))),
+                    ObjectCreationExpression(pureTypeB)
+                        .WithArgumentList(
+                            ArgumentList(
+                                SingletonSeparatedList(
+                                    Argument(
+                                        InvocationExpression(IdentifierName("f"))
+                                            .WithArgumentList(
+                                                ArgumentList(
+                                                    SingletonSeparatedList(
+                                                        Argument(
+                                                            MemberAccessExpression(
+                                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                                IdentifierName("v"),
+                                                                IdentifierName(
+                                                                    CodeGenUtil.MakeFirstCharUpper(pure.ParameterList
+                                                                        .Parameters.First().Identifier.Text)))))))))))),
+                Token(SyntaxKind.CommaToken)
+            };
+
+            // this will only be used if we have a fail path
+            var failFunc = fail != null
+                ? new SyntaxNodeOrToken[]
+                {
+                    SwitchExpressionArm(
+                        DeclarationPattern(
+                            MakeTypeName(fail.Identifier.Text, genA),
+                            SingleVariableDesignation(Identifier("v"))),
+                        ObjectCreationExpression(MakeTypeName(fail.Identifier.Text, genB))
+                            .WithArgumentList(
+                                fail.ParameterList.Parameters.Count == 0
+                                    ? ArgumentList()
+                                    : ArgumentList(
+                                        SingletonSeparatedList(
+                                            Argument(
+                                                MemberAccessExpression(
+                                                    SyntaxKind.SimpleMemberAccessExpression,
+                                                    IdentifierName("v"),
+                                                    IdentifierName(
+                                                        CodeGenUtil.MakeFirstCharUpper(fail.ParameterList
+                                                            .Parameters.First().Identifier.Text)))))))),
+                    Token(SyntaxKind.CommaToken)
+                }
+                : null;
+
+            var termimalFuncs = applyToMembers
+                .Where(m => m != pure)
+                .Where(m => m != fail)
+                .Where(m => m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
+                    new SyntaxNodeOrToken[]
+                    {
+                        SwitchExpressionArm(
+                            DeclarationPattern(
+                                ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                SingleVariableDesignation(Identifier("v"))),
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList(
+                                            m.ParameterList
+                                                .Parameters
+                                                .Select(p =>
+                                                    Argument(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName(
+                                                                CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
+                        Token(SyntaxKind.CommaToken)
+                    });
+
+
+            var freeFuncs = fail != null
+                ? applyToMembers
+                    .Where(m => m != fail)
+                    .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                    .SelectMany(m =>
+                        new SyntaxNodeOrToken[]
+                        {
+                            SwitchExpressionArm(
+                                DeclarationPattern(
+                                    ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                    SingleVariableDesignation(Identifier("v"))),
+                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList<ArgumentSyntax>(
+                                                m.ParameterList
+                                                    .Parameters
+                                                    .Take(m.ParameterList.Parameters.Count - 2)
+                                                    .SelectMany(p =>
+                                                        new SyntaxNodeOrToken[]
+                                                        {
+                                                            Argument(
+                                                                MemberAccessExpression(
+                                                                    SyntaxKind.SimpleMemberAccessExpression,
+                                                                    IdentifierName("v"),
+                                                                    IdentifierName(
+                                                                        CodeGenUtil.MakeFirstCharUpper(
+                                                                            p.Identifier.Text)))),
+                                                            Token(SyntaxKind.CommaToken)
+                                                        })
+                                                    .Concat(new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                            mapNextFunc)),
+                                                        Token(SyntaxKind.CommaToken), Argument(SimpleLambdaExpression(
+                                                            Parameter(Identifier("fn")),
+                                                            mapFailFunc))
+                                                    }))))),
+                            Token(SyntaxKind.CommaToken)
+                        })
+                : applyToMembers
+                    .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                    .SelectMany(m =>
+                        new SyntaxNodeOrToken[]
+                        {
+                            SwitchExpressionArm(
+                                DeclarationPattern(
+                                    ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                    SingleVariableDesignation(Identifier("v"))),
+                                ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                    .WithArgumentList(
+                                        ArgumentList(
+                                            SeparatedList<ArgumentSyntax>(
+                                                m.ParameterList
+                                                    .Parameters
+                                                    .Take(m.ParameterList.Parameters.Count - 1)
+                                                    .SelectMany(p =>
+                                                        new SyntaxNodeOrToken[]
+                                                        {
+                                                            Argument(
+                                                                MemberAccessExpression(
+                                                                    SyntaxKind.SimpleMemberAccessExpression,
+                                                                    IdentifierName("v"),
+                                                                    IdentifierName(
+                                                                        CodeGenUtil.MakeFirstCharUpper(
+                                                                            p.Identifier.Text)))),
+                                                            Token(SyntaxKind.CommaToken)
+                                                        })
+                                                    .Concat(new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                            mapNextFunc))
+                                                    }))))),
+                            Token(SyntaxKind.CommaToken)
+                        });
+
+            var tokens = new List<SyntaxNodeOrToken>();
+            tokens.AddRange(pureFunc);
+            if (failFunc != null)
+                tokens.AddRange(failFunc);
+            tokens.AddRange(termimalFuncs);
+            tokens.AddRange(freeFuncs);
+            tokens.Add(
+                SwitchExpressionArm(
+                    DiscardPattern(),
+                    ThrowExpression(
+                        ObjectCreationExpression(
+                                QualifiedName(
+                                    IdentifierName("System"),
+                                    IdentifierName("NotSupportedException")))
+                            .WithArgumentList(ArgumentList()))));
 
             return MethodDeclaration(typeB, Identifier("Map"))
                 .WithModifiers(
-                    TokenList(new[] {Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)}))
+                    TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
                 .WithTypeParameterList(
                     TypeParameterList(
                         SeparatedList<TypeParameterSyntax>(
@@ -828,21 +1482,328 @@ namespace LanguageExt.CodeGen
                 .WithSemicolonToken(
                     Token(SyntaxKind.SemicolonToken))
                 .NormalizeWhitespace();
-        }        
+        }
+
+
+        static MethodDeclarationSyntax MakeBiMapExtension(
+            SyntaxToken applyToIdentifier,
+            TypeParameterListSyntax applyToTypeParams,
+            TypeSyntax failType)
+        {
+            var genA = applyToTypeParams.Parameters.First().ToString();
+            var genB = CodeGenUtil.NextGenName(genA);
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
+            var mapFailFuncType = ParseTypeName($"System.Func<{failType}, {genB}>");
+
+            return MethodDeclaration(
+                    typeB,
+                    Identifier("BiMap"))
+                .WithModifiers(
+                    TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
+                .WithTypeParameterList(
+                    TypeParameterList(
+                        SeparatedList<TypeParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                TypeParameter(
+                                    Identifier(genA)),
+                                Token(SyntaxKind.CommaToken), TypeParameter(
+                                    Identifier(genB))
+                            })))
+                .WithParameterList(
+                    ParameterList(
+                        SeparatedList<ParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Parameter(
+                                        Identifier("ma"))
+                                    .WithModifiers(
+                                        TokenList(
+                                            Token(SyntaxKind.ThisKeyword)))
+                                    .WithType(typeA),
+                                Token(SyntaxKind.CommaToken), Parameter(Identifier("Succ")).WithType(mapFuncType),
+                                Token(SyntaxKind.CommaToken), Parameter(Identifier("Fail")).WithType(mapFailFuncType)
+                            })))
+                .WithExpressionBody(
+                    ArrowExpressionClause(
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    typeA,
+                                    IdentifierName("BiMap")))
+                            .WithArgumentList(
+                                ArgumentList(
+                                    SeparatedList<ArgumentSyntax>(
+                                        new SyntaxNodeOrToken[]
+                                        {
+                                            Argument(
+                                                IdentifierName("ma")),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                IdentifierName("Succ")),
+                                            Token(SyntaxKind.CommaToken), Argument(
+                                                IdentifierName("Fail"))
+                                        })))))
+                .WithSemicolonToken(
+                    Token(SyntaxKind.SemicolonToken));
+        }
+
+
+        static MethodDeclarationSyntax MakeBiMapFunction(
+            SyntaxToken applyToIdentifier,
+            MethodDeclarationSyntax[] applyToMembers,
+            TypeParameterListSyntax applyToTypeParams,
+            MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail,
+            TypeSyntax failType)
+        {
+            var genA = applyToTypeParams.Parameters.First().ToString();
+            var genB = CodeGenUtil.NextGenName(genA);
+            var genC = CodeGenUtil.NextGenName(genB);
+
+            var typeA = MakeTypeName(applyToIdentifier.Text, genA);
+            var typeB = MakeTypeName(applyToIdentifier.Text, genB);
+            var typeC = MakeTypeName(applyToIdentifier.Text, genC);
+            var mapFuncType = ParseTypeName($"System.Func<{genA}, {genB}>");
+            var mapFailFuncType = failType != null
+                ? ParseTypeName($"System.Func<{failType}, {genB}>")
+                : ParseTypeName($"System.Func<{genB}>");
+            var pureTypeA = MakeTypeName(pure.Identifier.Text, genA);
+            var pureTypeB = MakeTypeName(pure.Identifier.Text, genB);
+            var failTypeA = MakeTypeName(fail.Identifier.Text, genA);
+
+
+            var mapNextFunc = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("v"),
+                                    IdentifierName("Next")))
+                            .WithArgumentList(
+                                ArgumentList(SingletonSeparatedList(Argument(IdentifierName("n"))))),
+                        IdentifierName("BiMap")))
+                .WithArgumentList(
+                    ArgumentList(
+                        SeparatedList<ArgumentSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Argument(IdentifierName("Succ")), Token(SyntaxKind.CommaToken),
+                                Argument(IdentifierName("Fail"))
+                            }
+                        )));
+
+            var mapFailFunc = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("v"),
+                                    IdentifierName("FailNext")))
+                            .WithArgumentList(
+                                ArgumentList(SingletonSeparatedList(Argument(IdentifierName("fn"))))),
+                        IdentifierName("BiMap")))
+                .WithArgumentList(
+                    ArgumentList(
+                        SeparatedList<ArgumentSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Argument(IdentifierName("Succ")), Token(SyntaxKind.CommaToken),
+                                Argument(IdentifierName("Fail"))
+                            }
+                        )));
+
+            var pureSuccFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        pureTypeA,
+                        SingleVariableDesignation(Identifier("v"))),
+                    ObjectCreationExpression(pureTypeB)
+                        .WithArgumentList(
+                            ArgumentList(
+                                SingletonSeparatedList(
+                                    Argument(
+                                        InvocationExpression(IdentifierName("Succ"))
+                                            .WithArgumentList(
+                                                ArgumentList(
+                                                    SingletonSeparatedList(
+                                                        Argument(
+                                                            MemberAccessExpression(
+                                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                                IdentifierName("v"),
+                                                                IdentifierName(
+                                                                    CodeGenUtil.MakeFirstCharUpper(pure.ParameterList
+                                                                        .Parameters.First().Identifier.Text)))))))))))),
+                Token(SyntaxKind.CommaToken)
+            };
+
+            var pureFailFunc = new SyntaxNodeOrToken[]
+            {
+                SwitchExpressionArm(
+                    DeclarationPattern(
+                        failTypeA,
+                        SingleVariableDesignation(Identifier("v"))),
+                    ObjectCreationExpression(pureTypeB)
+                        .WithArgumentList(
+                            ArgumentList(
+                                SingletonSeparatedList(
+                                    Argument(
+                                        InvocationExpression(IdentifierName("Fail"))
+                                            .WithArgumentList(
+                                                fail.ParameterList.Parameters.Count == 0
+                                                    ? ArgumentList()
+                                                    : ArgumentList(
+                                                        SingletonSeparatedList(
+                                                            Argument(
+                                                                MemberAccessExpression(
+                                                                    SyntaxKind.SimpleMemberAccessExpression,
+                                                                    IdentifierName("v"),
+                                                                    IdentifierName(
+                                                                        CodeGenUtil.MakeFirstCharUpper(fail
+                                                                            .ParameterList
+                                                                            .Parameters.First().Identifier
+                                                                            .Text)))))))))))),
+                Token(SyntaxKind.CommaToken)
+            };
+
+
+            var termimalFuncs = applyToMembers
+                .Where(m => m != pure)
+                .Where(m => m != fail)
+                .Where(m => m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
+                    new SyntaxNodeOrToken[]
+                    {
+                        SwitchExpressionArm(
+                            DeclarationPattern(
+                                ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                SingleVariableDesignation(Identifier("v"))),
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList(
+                                            m.ParameterList
+                                                .Parameters
+                                                .Select(p =>
+                                                    Argument(
+                                                        MemberAccessExpression(
+                                                            SyntaxKind.SimpleMemberAccessExpression,
+                                                            IdentifierName("v"),
+                                                            IdentifierName(
+                                                                CodeGenUtil.MakeFirstCharUpper(p.Identifier))))))))),
+                        Token(SyntaxKind.CommaToken)
+                    });
+
+
+            var freeFuncs = applyToMembers
+                .Where(m => m != pure)
+                .Where(m => m != fail)
+                .Where(m => !m.AttributeLists.SelectMany(a => a.Attributes).Any(IsPureAttr))
+                .SelectMany(m =>
+                    new SyntaxNodeOrToken[]
+                    {
+                        SwitchExpressionArm(
+                            DeclarationPattern(
+                                ParseTypeName($"{m.Identifier.Text}<{genA}>"),
+                                SingleVariableDesignation(Identifier("v"))),
+                            ObjectCreationExpression(MakeTypeName(m.Identifier.Text, genB))
+                                .WithArgumentList(
+                                    ArgumentList(
+                                        SeparatedList<ArgumentSyntax>(
+                                            m.ParameterList
+                                                .Parameters
+                                                .Take(m.ParameterList.Parameters.Count - 2)
+                                                .SelectMany(p =>
+                                                    new SyntaxNodeOrToken[]
+                                                    {
+                                                        Argument(
+                                                            MemberAccessExpression(
+                                                                SyntaxKind.SimpleMemberAccessExpression,
+                                                                IdentifierName("v"),
+                                                                IdentifierName(
+                                                                    CodeGenUtil.MakeFirstCharUpper(
+                                                                        p.Identifier.Text)))),
+                                                        Token(SyntaxKind.CommaToken)
+                                                    })
+                                                .Concat(new SyntaxNodeOrToken[]
+                                                {
+                                                    Argument(SimpleLambdaExpression(Parameter(Identifier("n")),
+                                                        mapNextFunc)),
+                                                    Token(SyntaxKind.CommaToken), Argument(SimpleLambdaExpression(
+                                                        Parameter(Identifier("fn")),
+                                                        mapFailFunc))
+                                                })
+                                        )))),
+                        Token(SyntaxKind.CommaToken)
+                    });
+
+            var tokens = new List<SyntaxNodeOrToken>();
+            tokens.AddRange(pureSuccFunc);
+            tokens.AddRange(pureFailFunc);
+            tokens.AddRange(termimalFuncs);
+            tokens.AddRange(freeFuncs);
+            tokens.Add(
+                SwitchExpressionArm(
+                    DiscardPattern(),
+                    ThrowExpression(
+                        ObjectCreationExpression(
+                                QualifiedName(
+                                    IdentifierName("System"),
+                                    IdentifierName("NotSupportedException")))
+                            .WithArgumentList(ArgumentList()))));
+
+            return MethodDeclaration(typeB, Identifier("BiMap"))
+                .WithModifiers(
+                    TokenList(new[] {Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)}))
+                .WithTypeParameterList(
+                    TypeParameterList(
+                        SeparatedList<TypeParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                TypeParameter(
+                                    Identifier(genA)),
+                                Token(SyntaxKind.CommaToken), TypeParameter(
+                                    Identifier(genB))
+                            })))
+                .WithParameterList(
+                    ParameterList(
+                        SeparatedList<ParameterSyntax>(
+                            new SyntaxNodeOrToken[]
+                            {
+                                Parameter(Identifier("ma"))
+                                    .WithModifiers(
+                                        TokenList(
+                                            Token(SyntaxKind.ThisKeyword)))
+                                    .WithType(typeA),
+                                Token(SyntaxKind.CommaToken), Parameter(Identifier("Succ"))
+                                    .WithType(mapFuncType),
+                                Token(SyntaxKind.CommaToken), Parameter(Identifier("Fail"))
+                                    .WithType(mapFailFuncType)
+                            })))
+                .WithExpressionBody(
+                    ArrowExpressionClause(
+                        SwitchExpression(
+                                IdentifierName("ma"))
+                            .WithArms(SeparatedList<SwitchExpressionArmSyntax>(tokens))))
+                .WithSemicolonToken(
+                    Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace();
+        }
 
         static MemberDeclarationSyntax MakeCaseCtorFunction(
             SyntaxToken applyToIdentifier,
             TypeParameterListSyntax applyToTypeParams,
             SyntaxList<TypeParameterConstraintClauseSyntax> applyToConstraints,
-            TypeSyntax returnType, 
+            TypeSyntax returnType,
             MethodDeclarationSyntax method,
-            MethodDeclarationSyntax pure)
+            MethodDeclarationSyntax pure,
+            MethodDeclarationSyntax fail)
         {
-            bool isPure = method.AttributeLists
-                                .SelectMany(a => a.Attributes)
-                                .Any(a => a.Name.ToString() == "Pure");
-
-            if (isPure)
+            if (HasPureAttr(method) || HasFailAttr(method))
             {
                 var typeParamList = applyToTypeParams;
                 if (method.TypeParameterList != null)
@@ -863,14 +1824,9 @@ namespace LanguageExt.CodeGen
 
                 var @case = MethodDeclaration(returnType, method.Identifier)
                     .WithModifiers(
-                        TokenList(
-                            new[]{
-                                Token(SyntaxKind.PublicKeyword),
-                                Token(SyntaxKind.StaticKeyword)}))
+                        TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
                     .WithParameterList(
-                        isPure
-                            ? method.ParameterList
-                            : method.ParameterList.WithParameters(method.ParameterList.Parameters.RemoveAt(method.ParameterList.Parameters.Count - 1)))
+                        method.ParameterList)
                     .WithConstraintClauses(applyToConstraints)
                     .WithExpressionBody(
                         ArrowExpressionClause(
@@ -881,18 +1837,28 @@ namespace LanguageExt.CodeGen
                     .WithSemicolonToken(
                         Token(SyntaxKind.SemicolonToken));
 
-                if(typeParamList != null)
+                if (typeParamList != null)
                 {
                     @case = @case.WithTypeParameterList(typeParamList);
                 }
+
                 return @case;
             }
             else
             {
-                var nextType = ((GenericNameSyntax)((QualifiedNameSyntax)method.ParameterList.Parameters.Last().Type).Right)
-                                    .TypeArgumentList
-                                    .Arguments
-                                    .First();
+                var skip = fail != null
+                    ? 1
+                    : 0;
+
+                var nextType = ((GenericNameSyntax)((QualifiedNameSyntax)method.ParameterList.Parameters
+                            .Reverse()
+                            .Skip(skip)
+                            .First()
+                            .Type)
+                        .Right)
+                    .TypeArgumentList
+                    .Arguments
+                    .First();
 
                 var thisType = ParseTypeName($"{method.Identifier.Text}<{nextType}>");
                 returnType = ParseTypeName($"{applyToIdentifier}<{nextType}>");
@@ -902,20 +1868,45 @@ namespace LanguageExt.CodeGen
                     .Select(p => (SyntaxNodeOrToken)Argument(IdentifierName(p.Identifier.Text)))
                     .ToArray();
 
-                paramIdents[paramIdents.Length - 1] = Argument(IdentifierName(pure.Identifier.Text));
+                //var nextType = QualifiedName(
+                //    IdentifierName("System"),
+                //    GenericName(
+                //            Identifier("Func"))
+                //        .WithTypeArgumentList(
+                //            TypeArgumentList(
+                //                SeparatedList<TypeSyntax>(
+                //                    new SyntaxNodeOrToken[] { m.ReturnType, Token(SyntaxKind.CommaToken), freeType }))));
+
+                if (fail != null)
+                {
+                    paramIdents[paramIdents.Length - 1] = Argument(GenericName(fail.Identifier.Text)
+                        .WithTypeArgumentList(
+                            TypeArgumentList(SeparatedList<TypeSyntax>(
+                                new SyntaxNodeOrToken[] {nextType}))));
+                    paramIdents[paramIdents.Length - 2] = Argument(IdentifierName(pure.Identifier.Text));
+                }
+                else
+                {
+                    paramIdents[paramIdents.Length - 1] = Argument(IdentifierName(pure.Identifier.Text));
+                }
 
                 var args = CodeGenUtil.Interleave(
                     paramIdents,
                     Token(SyntaxKind.CommaToken));
 
+                var parameters = fail != null
+                    ? method.ParameterList.Parameters
+                        .RemoveAt(method.ParameterList.Parameters.Count - 1)
+                        .RemoveAt(method.ParameterList.Parameters.Count - 2)
+                    : method.ParameterList.Parameters
+                        .RemoveAt(method.ParameterList.Parameters.Count - 1);
+
+
                 var @case = MethodDeclaration(returnType, method.Identifier)
                     .WithModifiers(
-                        TokenList(
-                            new[]{
-                                Token(SyntaxKind.PublicKeyword),
-                                Token(SyntaxKind.StaticKeyword)}))
+                        TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)))
                     .WithParameterList(
-                        method.ParameterList.WithParameters(method.ParameterList.Parameters.RemoveAt(method.ParameterList.Parameters.Count - 1)))
+                        method.ParameterList.WithParameters(parameters))
                     .WithConstraintClauses(applyToConstraints)
                     .WithExpressionBody(
                         ArrowExpressionClause(
@@ -925,8 +1916,8 @@ namespace LanguageExt.CodeGen
                                         SeparatedList<ArgumentSyntax>(args)))))
                     .WithSemicolonToken(
                         Token(SyntaxKind.SemicolonToken));
-                
-                return @case;                
+
+                return @case;
             }
         }
     }

--- a/Samples/TestBed/TestCodeGen.cs
+++ b/Samples/TestBed/TestCodeGen.cs
@@ -27,13 +27,6 @@ namespace TestBed
         Unit WriteAllText(string path, string text);
     }
 
-    [Free]
-    public interface Try<A>
-    {
-        [Pure] A Succ(A value);
-        [Fail] A NiceTry(Exception e);
-    }
-
     public static partial class FreeIO
     {
         public static FreeIO<T> Flatten2<T>(this FreeIO<FreeIO<T>> ma) => ma switch
@@ -42,13 +35,13 @@ namespace TestBed
             Fail<FreeIO<T>> v => new Fail<T>(v.Error),
             ReadAllText<FreeIO<T>> v => new ReadAllText<T>(v.Path, n => Flatten(v.Next(n)), fn => Flatten(v.FailNext(fn))),
             WriteAllText<FreeIO<T>> v => new WriteAllText<T>(v.Path, v.Text, n => Flatten(v.Next(n)), fn => Flatten(v.FailNext(fn))),
-            _ => throw new NotSupportedException()
+            _ => throw new System.NotSupportedException()
         };
     }
 
     public static class FreeIOTest
     {
-        public static async Task Test1()
+        public async static Task Test1()
         {
             var dsl = from t in FreeIO.ReadAllText("I:\\temp\\test.txt")
                       from _ in FreeIO.WriteAllText("I:\\temp\\test2.txt", t)
@@ -92,19 +85,13 @@ namespace TestBed
     public interface Maybe<A>
     {
         [Pure] A Just(A value);
-        [Fail] A Nothing();
+        [Pure] A Nothing();
 
-        //public static Maybe<B> Map<B>(Maybe<A> ma, Func<A, B> f) => ma switch
-        //{
-        //    Just<A>(var x) => Maybe.Just(f(x)),
-        //    _ => Maybe.Nothing<B>()
-        //};
-
-        //public static Maybe<B> BiMap<B>(Maybe<A> ma, Func<A, B> succ, Func<B> none) => ma switch
-        //{
-        //    Just<A>(var x) => Maybe.Just(succ(x)),
-        //    _ => Maybe.Just(none())
-        //};
+        public static Maybe<B> Map<B>(Maybe<A> ma, Func<A, B> f) => ma switch
+        {
+            Just<A>(var x) => Maybe.Just(f(x)),
+            _ => Maybe.Nothing<B>()
+        };
     }
 
     public static class MaybeFreeTest
@@ -169,7 +156,7 @@ namespace TestBed
         }
         public Person ReadFromDB() => new Person("Spider", "Man");
         public int Zero => 0;
-    } 
+    }
 
     public static class TestSubs
     {
@@ -177,7 +164,7 @@ namespace TestBed
         {
             var comp = from ze in Subsystem.Zero
                        from ls in Subsystem.ReadAllLines("c:/test.txt")
-                       from _  in Subsystem.WriteAllLines("c:/test-copy.txt", ls)
+                       from _ in Subsystem.WriteAllLines("c:/test-copy.txt", ls)
                        select ls.Count;
 
             var res = comp.Run(new RealIO()).IfFail(0);
@@ -197,11 +184,11 @@ namespace TestBed
     //}
 
 
-    [RWS(WriterMonoid: typeof(MSeq<string>), 
-         Env:          typeof(IO), 
-         State:        typeof(Person), 
-         Constructor:  "Pure", 
-         Fail:         "Error" )]
+    [RWS(WriterMonoid: typeof(MSeq<string>),
+         Env: typeof(IO),
+         State: typeof(Person),
+         Constructor: "Pure",
+         Fail: "Error")]
     public partial struct Subsys<T>
     {
     }
@@ -315,5 +302,3 @@ namespace TestBed
         public readonly string Surname;
     }
 }
-
-

--- a/Samples/TestBed/TestCodeGen.cs
+++ b/Samples/TestBed/TestCodeGen.cs
@@ -22,26 +22,33 @@ namespace TestBed
     public interface FreeIO<T>
     {
         [Pure] T Pure(T value);
-        [Pure] T Fail(Error error);
+        [Fail] T Fail(Error error);
         string ReadAllText(string path);
         Unit WriteAllText(string path, string text);
+    }
+
+    [Free]
+    public interface Try<A>
+    {
+        [Pure] A Succ(A value);
+        [Fail] A NiceTry(Exception e);
     }
 
     public static partial class FreeIO
     {
         public static FreeIO<T> Flatten2<T>(this FreeIO<FreeIO<T>> ma) => ma switch
         {
-            Pure<FreeIO<T>> v => v.Value, 
+            Pure<FreeIO<T>> v => v.Value,
             Fail<FreeIO<T>> v => new Fail<T>(v.Error),
-            ReadAllText<FreeIO<T>> v => new ReadAllText<T>(v.Path, n => Flatten(v.Next(n))),
-            WriteAllText<FreeIO<T>> v => new WriteAllText<T>(v.Path, v.Text, n => Flatten(v.Next(n))),
-            _ => throw new System.NotSupportedException()
+            ReadAllText<FreeIO<T>> v => new ReadAllText<T>(v.Path, n => Flatten(v.Next(n)), fn => Flatten(v.FailNext(fn))),
+            WriteAllText<FreeIO<T>> v => new WriteAllText<T>(v.Path, v.Text, n => Flatten(v.Next(n)), fn => Flatten(v.FailNext(fn))),
+            _ => throw new NotSupportedException()
         };
     }
 
     public static class FreeIOTest
     {
-        public async static Task Test1()
+        public static async Task Test1()
         {
             var dsl = from t in FreeIO.ReadAllText("I:\\temp\\test.txt")
                       from _ in FreeIO.WriteAllText("I:\\temp\\test2.txt", t)
@@ -49,20 +56,20 @@ namespace TestBed
 
 
             var res1 = Interpret(dsl);
-            
+
             var res2 = await InterpretAsync(dsl);
         }
 
         public static Either<Error, A> Interpret<A>(FreeIO<A> ma) => ma switch
         {
-            Pure<A> (var value)                            => value,
-            Fail<A> (var error)                            => error,  
-            ReadAllText<A> (var path, var next)            => Interpret(next(Read(path))),
-            WriteAllText<A> (var path, var text, var next) => Interpret(next(Write(path, text))),
-            _                                              => throw new NotSupportedException()
+            Pure<A>(var value) => value,
+            Fail<A>(var error) => error,
+            ReadAllText<A>(var path, var next, var failNext) => Interpret(next(Read(path))),
+            WriteAllText<A>(var path, var text, var next, var failNext) => Interpret(next(Write(path, text))),
+            _ => throw new NotSupportedException()
         };
 
-        static string Read(string path) => 
+        static string Read(string path) =>
             File.ReadAllText(path);
 
         static Unit Write(string path, string text)
@@ -73,11 +80,11 @@ namespace TestBed
 
         public static async Task<A> InterpretAsync<A>(FreeIO<A> ma) => ma switch
         {
-            Pure<A> (var value)                            => value,
-            Fail<A> (var error)                            => await Task.FromException<A>(error),  
-            ReadAllText<A> (var path, var next)            => await InterpretAsync(next(await File.ReadAllTextAsync(path))),
-            WriteAllText<A> (var path, var text, var next) => await InterpretAsync(next(await File.WriteAllTextAsync(path, text).ToUnit())),
-            _                                              => throw new NotSupportedException()
+            Pure<A>(var value) => value,
+            Fail<A>(var error) => await Task.FromException<A>(error),
+            ReadAllText<A>(var path, var next, var failNext) => await InterpretAsync(next(await File.ReadAllTextAsync(path))),
+            WriteAllText<A>(var path, var text, var next, var failNext) => await InterpretAsync(next(await File.WriteAllTextAsync(path, text).ToUnit())),
+            _ => throw new NotSupportedException()
         };
     }
 
@@ -85,13 +92,19 @@ namespace TestBed
     public interface Maybe<A>
     {
         [Pure] A Just(A value);
-        [Pure] A Nothing();
+        [Fail] A Nothing();
 
-        public static Maybe<B> Map<B>(Maybe<A> ma, Func<A, B> f) => ma switch
-        {
-            Just<A>(var x) => Maybe.Just(f(x)),
-            _              => Maybe.Nothing<B>()
-        };
+        //public static Maybe<B> Map<B>(Maybe<A> ma, Func<A, B> f) => ma switch
+        //{
+        //    Just<A>(var x) => Maybe.Just(f(x)),
+        //    _ => Maybe.Nothing<B>()
+        //};
+
+        //public static Maybe<B> BiMap<B>(Maybe<A> ma, Func<A, B> succ, Func<B> none) => ma switch
+        //{
+        //    Just<A>(var x) => Maybe.Just(succ(x)),
+        //    _ => Maybe.Just(none())
+        //};
     }
 
     public static class MaybeFreeTest
@@ -112,13 +125,13 @@ namespace TestBed
                 from b in mb
                 from _ in mn
                 select a + b;
-            
+
             var r3 = mr switch
             {
-                Just<int> (var x) => $"Value is {x}",
-                _                 => "No value"
+                Just<int>(var x) => $"Value is {x}",
+                _ => "No value"
             };
-            
+
             Console.WriteLine(mr);
             Console.WriteLine(mnn);
         }


### PR DESCRIPTION
Resolves #757 
The idea is to have the Free code-gen handle the success path as well as the fail path by adding code-gen'd `BiMap` and BiBind implementations.
This adds a `FailNext` field in addition to the `Next` field on the non-terminal nodes of the Free.
The Free's `BiBind` and `BiMap` implementations then use this extra field.
It is up to the end-user-built `Interpreter` to make a choice between the two paths based on the outcome of the action.
While implementing it become apparent that it would be nice if the user could decorate which `Free` state represented the shortcutting-fail path so an extra `Fail` attribute was added.

With usage as follows:
```
[Free]
public interface Maybe<A>
{
    [Pure] A Just(A value);
    [Fail] A Nothing();
}
```

```
[Free]
public interface Try<A>
{
    [Pure] A Succ(A value);
    [Fail] A Fail(Exception e);
}
```

```
[Free]
public interface FreeIO<T>
{
    [Pure] T Pure(T value);
    [Fail] T Fail(Error error);
    string ReadAllText(string path);
    Unit WriteAllText(string path, string text);
}
```

If at least one state is decorated with a `Fail` attribute then `BiMap` and `BiBind` will be created for the generated `Free`.

What do you think about this approach in general? The 'FailNext' field? And also the specific 'Fail' attribute?

Apologies for the formatting changes and the removal of some redundant code. I got a bit carried away in the process.
