### PR TITLE
added flatten functions for the seq variant of the Validation monad #698

### DIFF
--- a/LanguageExt.Core/DataTypes/Validation/ValidationSeq.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/Validation/ValidationSeq.Extensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics.Contracts;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt
+{
+    public static class ValidationSeqExtensions
+    {
+        /// <summary>
+        /// Flatten the nested Validation type
+        /// </summary>
+        [Pure]
+        public static Validation<FAIL, SUCCESS> Flatten<FAIL, SUCCESS>(this Validation<FAIL, Validation<FAIL, SUCCESS>> self) =>
+            self.Bind(identity);
+    }
+}

--- a/LanguageExt.Core/DataTypes/Validation/ValidationSeq.Prelude.cs
+++ b/LanguageExt.Core/DataTypes/Validation/ValidationSeq.Prelude.cs
@@ -1,0 +1,14 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace LanguageExt
+{
+    public static partial class Prelude
+    {
+        /// <summary>
+        /// Flatten the nested Validation type
+        /// </summary>
+        [Pure]
+        public static Validation<FAIL, SUCCESS> flatten<FAIL, SUCCESS>(this Validation<FAIL, Validation<FAIL, SUCCESS>> self) =>
+            self.Flatten();
+    }
+}


### PR DESCRIPTION
Fixes #698 

I had suggested in that issue adding both the missing `Flatten` methods as well as the missing `Sequence` methods, but I feel like adding the missing `Flatten` methods is enough for now.