### PR TITLE
Reintroduce code documentation for NuGet

### DIFF
--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -26,6 +26,7 @@
     <PackageLicenseUrl>https://github.com/louthy/language-ext/blob/master/LICENSE.md</PackageLicenseUrl>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <OutputType>library</OutputType>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <FileVersion>3.0.0.0</FileVersion>


### PR DESCRIPTION
As mentioned in a comment for [Issue 479 (No documentation in intellisense.)](https://github.com/louthy/language-ext/issues/479#issuecomment-616479332), Commit https://github.com/louthy/language-ext/commit/01bec9f47e962b88292c30083b776be0ab860bff#diff-a2eb26bcfe1e5d97500c75f6d3698b0dL27 reintroduced the absence of XML documentation comments in the NuGet package for LanguageExt.Core.
This PR reintroduces XML documentation.

Fixes #479