### PR TITLE
add str<EQ> parser

### DIFF
--- a/LanguageExt.Core/ClassInstances/Eq/EqChar.cs
+++ b/LanguageExt.Core/ClassInstances/Eq/EqChar.cs
@@ -1,5 +1,6 @@
 ﻿using LanguageExt.TypeClasses;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Threading.Tasks;
 using static LanguageExt.Prelude;
 
@@ -38,6 +39,45 @@ namespace LanguageExt.ClassInstances
 
         [Pure]
         public Task<int> GetHashCodeAsync(char x) => 
+            GetHashCode(x).AsTask();
+    }
+
+    /// <summary>
+    /// Char equality (ordinal, ignore case)
+    /// </summary>
+    public struct EqCharOrdinalIgnoreCase : Eq<char>
+    {
+        public static readonly EqCharOrdinalIgnoreCase Inst = default(EqCharOrdinalIgnoreCase);
+
+        /// <summary>
+        /// Equality test
+        /// </summary>
+        /// <param name="a">The left hand side of the equality operation</param>
+        /// <param name="b">The right hand side of the equality operation</param>
+        /// <returns>True if a and b are equal</returns>
+        [Pure]
+        public bool Equals(char a, char b)
+        {
+            if (a >= 'a' && a <= 'z') a = (char)(a - 0x20);
+            if (b >= 'a' && b <= 'z') b = (char)(b - 0x20);
+            return a == b;
+        }
+
+        /// <summary>
+        /// Get hash code of the value
+        /// </summary>
+        /// <param name="x">Value to get the hash code of</param>
+        /// <returns>The hash code of x</returns>
+        [Pure]
+        public int GetHashCode(char x) =>
+            default(HashableCharOrdinalIgnoreCase).GetHashCode(x);
+
+        [Pure]
+        public Task<bool> EqualsAsync(char x, char y) =>
+            Equals(x, y).AsTask();
+
+        [Pure]
+        public Task<int> GetHashCodeAsync(char x) =>
             GetHashCode(x).AsTask();
     }
 }

--- a/LanguageExt.Core/ClassInstances/Hashable/HashableChar.cs
+++ b/LanguageExt.Core/ClassInstances/Hashable/HashableChar.cs
@@ -23,4 +23,23 @@ namespace LanguageExt.ClassInstances
         public Task<int> GetHashCodeAsync(char x) =>
             GetHashCode(x).AsTask();
     }
+
+    /// <summary>
+    /// Char hash (ordinal, ignore case)
+    /// </summary>
+    public struct HashableCharOrdinalIgnoreCase : Hashable<char>
+    {
+        /// <summary>
+        /// Get hash code of the value
+        /// </summary>
+        /// <param name="x">Value to get the hash code of</param>
+        /// <returns>The hash code of x</returns>
+        [Pure]
+        public int GetHashCode(char x) =>
+            (x >= 'a' && x <= 'z') ? x - 0x20 : x;
+
+        [Pure]
+        public Task<int> GetHashCodeAsync(char x) =>
+            GetHashCode(x).AsTask();
+    }
 }

--- a/LanguageExt.Parsec/Parsers/Char.cs
+++ b/LanguageExt.Parsec/Parsers/Char.cs
@@ -6,6 +6,7 @@ using static LanguageExt.Prelude;
 using static LanguageExt.Parsec.ParserResult;
 using static LanguageExt.Parsec.Internal;
 using static LanguageExt.Parsec.Prim;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt.Parsec
 {
@@ -46,6 +47,14 @@ namespace LanguageExt.Parsec
         /// <returns>The parsed character</returns>
         public static Parser<char> ch(char c) =>
             satisfy(x => x == c).label($"'{c}'");
+
+        /// <summary>
+        /// ch(c) parses a single character c
+        /// </summary>
+        /// <typeparam name="EQ">Eq<char> type-class</typeparam>
+        /// <returns>The parsed character</returns>
+        public static Parser<char> ch<EQ>(char c) where EQ : Eq<char> =>
+            satisfy(x => default(EQ).Equals(x, c)).label($"'{c}'");
 
         /// <summary>
         /// The parser satisfy(pred) succeeds for any character for which the
@@ -233,5 +242,12 @@ namespace LanguageExt.Parsec
         /// </summary>
         public static Parser<string> str(string s) =>
             asString(chain(Seq(s.Map(ch)))).label($"'{s}'");
+
+        /// <summary>
+        /// Parse a string case insensitive (char by char)
+        /// <typeparam name="EQ">Eq<char> type-class</typeparam>
+        /// </summary>
+        public static Parser<string> str<EQ>(string s) where EQ: Eq<char>  =>
+            asString(chain(Seq(s.Map(ch<EQ>)))).label($"'{s}'");
     }
 }

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -291,7 +291,6 @@ namespace LanguageExt.Tests
         public void StringOrdinalIgnoreCase()
         {
             var p = str<EqCharOrdinalIgnoreCase>("Hello");
-            var r = parse(p, "hello");
 
             Assert.Equal("hello", parse(p, "hello").ToOption());
             Assert.Equal("Hello", parse(p, "Hello").ToOption());

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -14,6 +14,7 @@ using static LanguageExt.Parsec.Char;
 using static LanguageExt.Parsec.Expr;
 using static LanguageExt.Parsec.Token;
 using LanguageExt.UnitsOfMeasure;
+using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests
 {
@@ -284,6 +285,20 @@ namespace LanguageExt.Tests
             var r = parse(p, "no match");
 
             Assert.True(r.IsFaulted);
+        }
+
+        [Fact]
+        public void StringOrdinalIgnoreCase()
+        {
+            var p = str<EqCharOrdinalIgnoreCase>("Hello");
+            var r = parse(p, "hello");
+
+            Assert.Equal("hello", parse(p, "hello").ToOption());
+            Assert.Equal("Hello", parse(p, "Hello").ToOption());
+            Assert.Equal("HELLO" , parse(p, "HELLO").ToOption());
+            Assert.Equal("hELLO", parse(p, "hELLO").ToOption());
+            Assert.True(parse(p, "olleH").IsFaulted);
+            Assert.True(parse(p, "Héllo").IsFaulted);
         }
 
         [Fact]

--- a/LanguageExt.Tests/TypeClassEQ.cs
+++ b/LanguageExt.Tests/TypeClassEQ.cs
@@ -28,6 +28,20 @@ namespace LanguageExt.Tests
             Assert.False(IsEqualGeneral<EqString, string>("not", "same"));
         }
 
+        [Fact]
+        public void EqStringOrdinalIgnoreCase()
+        {
+            Assert.True(IsEqualGeneral<EqStringOrdinalIgnoreCase, string>("Test", "test"));
+            Assert.False(IsEqualGeneral<EqStringOrdinalIgnoreCase, string>("Test", "Tést"));
+        }
+
+        [Fact]
+        public void EqCharOrdinalIgnoreCase()
+        {
+            Assert.True(IsEqualGeneral<EqCharOrdinalIgnoreCase, char>('T', 't'));
+            Assert.False(IsEqualGeneral<EqCharOrdinalIgnoreCase, char>('e', 'é'));
+        }
+
         public bool IsEqualGeneral<EQ, A>(A x, A y) where EQ : struct, Eq<A> => 
             equals<EQ, A>(x, y);
 


### PR DESCRIPTION
Generic version of a parse I often use to validate e.g. filenames (case insensitive).

This variant parsers char by char and therefore needs an Eq<char> comparer. Therefore I added EqCharOrdinalIgnoreCase, too.