### PR TITLE
rename newline parser to LF

### DIFF
--- a/LanguageExt.Parsec/Parsers/Char.cs
+++ b/LanguageExt.Parsec/Parsers/Char.cs
@@ -20,13 +20,13 @@ namespace LanguageExt.Parsec
             spaces = skipMany(space).label("white space");
             control = satisfy(System.Char.IsControl).label("control");
             tab = satisfy(c => c == '\t').label("tab");
-            newline = satisfy(c => c == '\n').label("lf new-line");
+            LF = satisfy(c => c == '\n').label("lf new-line");
             CR = satisfy(c => c == '\r').label("cr carriage-return");
             CRLF = (from cr in ch('\r')
                     from nl in ch('\n')
                     select nl)
                    .label("crlf new-line");
-            endOfLine = either(newline, CRLF).label("new-line");
+            endOfLine = either(LF, CRLF).label("new-line");
             digit = satisfy(System.Char.IsDigit).label("digit");
             letter = satisfy(System.Char.IsLetter).label("letter");
             alphaNum = satisfy(System.Char.IsLetterOrDigit).label("letter or digit");
@@ -145,7 +145,7 @@ namespace LanguageExt.Parsec
         /// Parses a line-feed newline char (\n)
         /// Returns the parsed character.
         /// </summary>
-        public static readonly Parser<char> newline;
+        public static readonly Parser<char> LF;
 
         /// <summary>
         /// Parses a carriage-return char (\r)
@@ -155,13 +155,13 @@ namespace LanguageExt.Parsec
 
         /// <summary>
         /// Parses a carriage-return then line-feed
-        /// Returns the new-line.
+        /// Returns a LF character(\'\\n\').
         /// </summary>
         public static readonly Parser<char> CRLF;
 
         /// <summary>
-        /// Parses a CRLF (see 'crlf') or LF (see 'newline') end-of-line.
-        /// Returns a newline character(\'\\n\').
+        /// Parses a CRLF (see 'CRLF') or LF (see 'LF') end-of-line.
+        /// Returns a LF character(\'\\n\').
         /// </summary>
         public static readonly Parser<char> endOfLine;
 


### PR DESCRIPTION
I stumbled upon "newline" not working like e.g. https://docs.microsoft.com/en-us/dotnet/api/system.io.streamreader.readline which means eating CRLF and LF.

Seems the definition in LanguageExt is directly based on Haskell and I guess you see a value in this.
But I think some of those definitions are uncommon / unexpected from a .NET perspective. This might be a reason to change or rename this.

The commit here should avoid confusion for `newline` (`LF` is quite explicit).

I personally think `endOfLine` (which is what I should have used in the first place) isn't the best name for LF/CRLF. I personally would expect a parser equalivalent to regex `$` (which is `eof` in parsec). Maybe those should be renamed to more clear names, too?

Another part I find misleading is `space`. This should be named `whitespace`. Of course I could use `ch(' ')` but I expected `space` to be 0x20 only and there is e.g. `tab`...

But I'm ok with closing this if you think it really should be like before (at least consistent for Haskell) and of course changes might break user code.

