### PR TITLE
make all UnitsOfMeasure types implement IComparable

### DIFF
--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Accel.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Accel.cs
@@ -14,7 +14,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct Accel :
         IComparable<Accel>,
-        IEquatable<Accel>
+        IEquatable<Accel>,
+        IComparable
     {
         readonly double Value;
 
@@ -39,6 +40,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) => 
+            obj is null ? 1
+            : obj is Accel other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Accel)}");
 
         public int CompareTo(Accel other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Area.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Area.cs
@@ -14,7 +14,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct Area :
         IComparable<Area>,
-        IEquatable<Area>
+        IEquatable<Area>,
+        IComparable
     {
         readonly double Value;
 
@@ -39,6 +40,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) => 
+            obj is null ? 1
+            : obj is Area other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Area)}");
 
         public int CompareTo(Area other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Length.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Length.cs
@@ -14,7 +14,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct Length :
         IComparable<Length>,
-        IEquatable<Length>
+        IEquatable<Length>,
+        IComparable
     {
         readonly double Value;
 
@@ -39,6 +40,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) => 
+            obj is null ? 1
+            : obj is Length other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Length)}");
 
         public int CompareTo(Length other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Mass.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Mass.cs
@@ -2,7 +2,10 @@ using System;
 
 namespace LanguageExt.UnitsOfMeasure
 {
-    public struct Mass : IComparable<Mass>, IEquatable<Mass>
+    public struct Mass : 
+        IComparable<Mass>, 
+        IEquatable<Mass>, 
+        IComparable
     {
         readonly double Value;
 
@@ -11,6 +14,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override string ToString() =>
             Kilograms + " kg";
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is Mass other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Mass)}");
 
         public int CompareTo(Mass other) =>
             Kilograms.CompareTo(other.Kilograms);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Temperature.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Temperature.cs
@@ -6,7 +6,8 @@ namespace LanguageExt.UnitsOfMeasure
 {
     public struct Temperature :
         IComparable<Temperature>,
-        IEquatable<Temperature>
+        IEquatable<Temperature>,
+        IComparable
     {
         internal enum UnitType
         {
@@ -102,6 +103,11 @@ namespace LanguageExt.UnitsOfMeasure
               : rhs.Type == UnitType.F ? Math.Abs(rhs.Value - Value) < epsilon
               : throw new NotSupportedException(Type.ToString())
           : throw new NotSupportedException(Type.ToString());
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is Temperature other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Temperature)}");
 
         public int CompareTo(Temperature rhs) =>
             Type == UnitType.K ?

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Time.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Time.cs
@@ -14,7 +14,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct Time :
         IComparable<Time>,
-        IEquatable<Time>
+        IEquatable<Time>,
+        IComparable
     {
         readonly double Value;
 
@@ -39,6 +40,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is Time other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Time)}");
 
         public int CompareTo(Time other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/TimeSq.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/TimeSq.cs
@@ -8,7 +8,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct TimeSq :
         IComparable<TimeSq>,
-        IEquatable<TimeSq>
+        IEquatable<TimeSq>,
+        IComparable
     {
         readonly double Value;
 
@@ -33,6 +34,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is TimeSq other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(TimeSq)}");
 
         public int CompareTo(TimeSq other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/Velocity.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/Velocity.cs
@@ -14,7 +14,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct Velocity :
         IComparable<Velocity>,
-        IEquatable<Velocity>
+        IEquatable<Velocity>,
+        IComparable
     {
         readonly double Value;
 
@@ -39,6 +40,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is Velocity other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(Velocity)}");
 
         public int CompareTo(Velocity other) =>
             Value.CompareTo(other.Value);

--- a/LanguageExt.Core/DataTypes/UnitsOfMeasure/VelocitySq.cs
+++ b/LanguageExt.Core/DataTypes/UnitsOfMeasure/VelocitySq.cs
@@ -9,7 +9,8 @@ namespace LanguageExt.UnitsOfMeasure
     /// </summary>
     public struct VelocitySq :
         IComparable<VelocitySq>,
-        IEquatable<VelocitySq>
+        IEquatable<VelocitySq>,
+        IComparable
     {
         readonly double Value;
 
@@ -34,6 +35,11 @@ namespace LanguageExt.UnitsOfMeasure
 
         public override int GetHashCode() =>
             Value.GetHashCode();
+
+        public int CompareTo(object obj) =>
+            obj is null ? 1
+            : obj is VelocitySq other ? CompareTo(other)
+            : throw new ArgumentException($"must be of type {nameof(VelocitySq)}");
 
         public int CompareTo(VelocitySq other) =>
             Value.CompareTo(other.Value);


### PR DESCRIPTION
This is a suggestion.

Currently those types only implement `IComparable<T>` which is a good thing in theory because of type-safety.
But there is still code out there that uses `IComparable`.

Example: [`Assert.InRange(result, min, max)`](https://github.com/xunit/assert.xunit/blob/main/RangeAsserts.cs#L26-L30) in xunit.

I started a [discussion there](https://github.com/xunit/xunit/discussions/2176), to maybe add support for `IComparable<T>`-only types but I'm not sure what's the best way to solve this more generally. At least dotnet core itself still implements the untyped variant for e.g. [`int32`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/Int32.cs).

In LanguageExt there are already a lot of types (like `Option`) that implement `IComparable`...