### PR TITLE
Add missing Serializable attribute on abstract base class in union codegen

### DIFF
--- a/LanguageExt.CodeGen/UnionGenerator.cs
+++ b/LanguageExt.CodeGen/UnionGenerator.cs
@@ -862,6 +862,12 @@ namespace LanguageExt.CodeGen
                                 .ToList();
 
             return ClassDeclaration($"_{applyTo.Identifier}Base")
+                .WithAttributeLists(SingletonList<AttributeListSyntax>(
+                    AttributeList(
+                        SingletonSeparatedList<AttributeSyntax>(
+                            Attribute(
+                                QualifiedName(
+                                    IdentifierName("System"), IdentifierName("Serializable")))))))
                 .WithModifiers(applyTo.Modifiers)
                 .WithTypeParameterList(applyTo.TypeParameterList)
                 .WithConstraintClauses(applyTo.ConstraintClauses)


### PR DESCRIPTION
Serializing a union where an abstract class is used throws exception as the generated intermediate base class is not marked as `Serializable`.  This PR makes the codegen add the missing attribute