### PR TITLE
Should either(str, str) be nonconsuming?

### DIFF
--- a/LanguageExt.Parsec/Parsers/Char.cs
+++ b/LanguageExt.Parsec/Parsers/Char.cs
@@ -251,13 +251,13 @@ namespace LanguageExt.Parsec
         /// Parse a string
         /// </summary>
         public static Parser<string> str(string s) =>
-            asString(chain(Seq(s.Map(ch)))).label($"'{s}'");
+            asString(attempt(chain(Seq(s.Map(ch))))).label($"'{s}'");
 
         /// <summary>
         /// Parse a string case insensitive (char by char)
         /// <typeparam name="EQ">Eq<char> type-class</typeparam>
         /// </summary>
         public static Parser<string> str<EQ>(string s) where EQ: Eq<char>  =>
-            asString(chain(Seq(s.Map(ch<EQ>)))).label($"'{s}'");
+            asString(attempt(chain(Seq(s.Map(ch<EQ>))))).label($"'{s}'");
     }
 }

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -301,6 +301,22 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void EitherStringNonConsuming()
+        {
+            var parserStr = either(str("Hello"), str("How are you"));
+
+            Assert.Equal("How are you", parse(parserStr, "How are you").ToEither().IfLeft(identity));
+        }
+
+        [Fact]
+        public void EitherStringEqNonConsuming()
+        {
+            var parserStrEq = either(str<EqCharOrdinalIgnoreCase>("Hello"), str<EqCharOrdinalIgnoreCase>("How are you"));
+
+            Assert.Equal("how are you", parse(parserStrEq, "how are you").ToEither().IfLeft(identity));
+        }
+
+        [Fact]
         public void NaturalNumberComb()
         {
             var tok = makeTokenParser(Language.HaskellStyle);

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -317,6 +317,14 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void ChoiceStringNonConsuming()
+        {
+            var parserStr = choice(Seq("peach", "plum", "apple", "orange").Map(str));
+
+            Assert.Equal("plum", parse(parserStr, "plum").ToEither().IfLeft(identity));
+        }
+        
+        [Fact]
         public void NaturalNumberComb()
         {
             var tok = makeTokenParser(Language.HaskellStyle);


### PR DESCRIPTION
I stumbled upon a parser like this that failed (unexpectedly):

```
var twoThree= either(str("two"), str("three"));
Assert.Equal("three", parse(twoThree, "three").ToOption()); // currently fails
```

This is caused by `str` consuming "t" of "two" before trying to parse "three" (on "hree", which fails).

Technically everything is fine, I read the comment in Prim.cs and I use `attempt` to get around this. 

One "solution" could be that (by convention) a parser that has its own label should not consume parts.
