### PR TITLE
Eq.ToEqualityComparer (Ord.ToComparer)

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Prelude_Collections.cs
+++ b/LanguageExt.Core/Immutable Collections/Prelude_Collections.cs
@@ -114,35 +114,35 @@ namespace LanguageExt
         /// </summary>
         [Pure]
         public static IEnumerable<A> Sort<OrdA, A>(this IEnumerable<A> xs) where OrdA : struct, Ord<A> =>
-            xs.OrderBy(identity, default(OrdA).ToComparable());
+            xs.OrderBy(identity, default(OrdA).ToComparer());
 
         /// <summary>
         /// Provide a sorted Seq
         /// </summary>
         [Pure]
         public static Seq<A> Sort<OrdA, A>(this Seq<A> xs) where OrdA : struct, Ord<A> =>
-            xs.OrderBy(identity, default(OrdA).ToComparable()).ToSeq();
+            xs.OrderBy(identity, default(OrdA).ToComparer()).ToSeq();
 
         /// <summary>
         /// Provide a sorted Lst
         /// </summary>
         [Pure]
         public static Lst<A> Sort<OrdA, A>(this Lst<A> xs) where OrdA : struct, Ord<A> =>
-            xs.OrderBy(identity, default(OrdA).ToComparable()).Freeze();
+            xs.OrderBy(identity, default(OrdA).ToComparer()).Freeze();
 
         /// <summary>
         /// Provide a sorted Arr
         /// </summary>
         [Pure]
         public static Arr<A> Sort<OrdA, A>(this Arr<A> xs) where OrdA : struct, Ord<A> =>
-            xs.OrderBy(identity, default(OrdA).ToComparable()).ToArr();
+            xs.OrderBy(identity, default(OrdA).ToComparer()).ToArr();
 
         /// <summary>
         /// Provide a sorted array
         /// </summary>
         [Pure]
         public static A[] Sort<OrdA, A>(this A[] xs) where OrdA : struct, Ord<A> =>
-            xs.OrderBy(identity, default(OrdA).ToComparable()).ToArray();
+            xs.OrderBy(identity, default(OrdA).ToComparer()).ToArray();
 
         /// <summary>
         /// Lazy sequence of natural numbers up to Int32.MaxValue

--- a/LanguageExt.Core/Type Classes/Eq/Eq.cs
+++ b/LanguageExt.Core/Type Classes/Eq/Eq.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.Contracts;
+﻿using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using LanguageExt.Attributes;
 
 namespace LanguageExt.TypeClasses
@@ -20,5 +21,25 @@ namespace LanguageExt.TypeClasses
         /// <returns>True if x and y are equal</returns>
         [Pure]
         bool Equals(A x, A y);
+    }
+
+    public static class EqExt
+    {
+        class EqEqualityComparer<A> : IEqualityComparer<A>
+        {
+            readonly Eq<A> eq;
+
+            public EqEqualityComparer(Eq<A> eq) =>
+                this.eq = eq;
+
+            public bool Equals(A x, A y) =>
+                eq.Equals(x, y);
+
+            public int GetHashCode(A obj) =>
+                eq.GetHashCode(obj);
+        }
+
+        public static IEqualityComparer<A> ToEqualityComparer<A>(this Eq<A> self) =>
+            new EqEqualityComparer<A>(self);
     }
 }

--- a/LanguageExt.Core/Type Classes/Ord/Ord.cs
+++ b/LanguageExt.Core/Type Classes/Ord/Ord.cs
@@ -22,7 +22,7 @@ namespace LanguageExt.TypeClasses
         [Pure]
         int Compare(A x, A y);
     }
-        
+
     public static class OrdExt
     {
         class OrdComparer<A> : IComparer<A>
@@ -36,7 +36,7 @@ namespace LanguageExt.TypeClasses
                 ord.Compare(x, y);
         }
 
-        public static IComparer<A> ToComparable<A>(this Ord<A> self) =>
+        public static IComparer<A> ToComparer<A>(this Ord<A> self) =>
             new OrdComparer<A>(self);
     }
 }

--- a/LanguageExt.Core/Type Classes/Ord/Ord.cs
+++ b/LanguageExt.Core/Type Classes/Ord/Ord.cs
@@ -36,6 +36,10 @@ namespace LanguageExt.TypeClasses
                 ord.Compare(x, y);
         }
 
+        [System.Obsolete("'ToComparable' has been renamed to 'ToComparer', please use that instead")]
+        public static IComparer<A> ToComparable<A>(this Ord<A> self) =>
+            new OrdComparer<A>(self);
+
         public static IComparer<A> ToComparer<A>(this Ord<A> self) =>
             new OrdComparer<A>(self);
     }

--- a/LanguageExt.Tests/TypeClassEQ.cs
+++ b/LanguageExt.Tests/TypeClassEQ.cs
@@ -45,5 +45,13 @@ namespace LanguageExt.Tests
         public bool IsEqualGeneral<EQ, A>(A x, A y) where EQ : struct, Eq<A> => 
             equals<EQ, A>(x, y);
 
+        [Fact]
+        public void EqualityComparer()
+        {
+            var items = Prelude.Seq("a", "A", "b");
+            var distinct = items.Distinct(default(EqStringOrdinalIgnoreCase).ToEqualityComparer());
+            
+            Assert.Equal(Prelude.Seq("a", "b"), distinct);
+        }
     }
 }

--- a/LanguageExt.Tests/TypeClassORD.cs
+++ b/LanguageExt.Tests/TypeClassORD.cs
@@ -109,12 +109,14 @@ namespace LanguageExt.Tests
         public void OrderBy()
         {
             var items = Prelude.Seq("2", "1", "10");
+
+            Assert.False(typeof(System.Collections.Generic.IComparer<string>).IsAssignableFrom(typeof(Ord<string>)), "would break Record Compare system (=> ToComparable())");
             
-            Assert.Equal(Prelude.Seq("1", "10", "2"), items.OrderBy(Prelude.identity,  default(OrdDefault<string>).ToComparable()));
-            Assert.Equal(Prelude.Seq("1", "2", "10"), items.OrderBy(System.Convert.ToInt32,  default(OrdDefault<int>).ToComparable()));
+            Assert.Equal(Prelude.Seq("1", "10", "2"), items.OrderBy(Prelude.identity, default(OrdDefault<string>).ToComparer()));
+            Assert.Equal(Prelude.Seq("1", "2", "10"), items.OrderBy(System.Convert.ToInt32, default(OrdDefault<int>).ToComparer()));
             
-            Assert.Equal(Prelude.Seq("2", "10", "1"), items.OrderBy(Prelude.identity,  default(OrdDesc<OrdDefault<string>, string>).ToComparable()));
-            Assert.Equal(Prelude.Seq("10", "2", "1"), items.OrderBy(System.Convert.ToInt32,  default(OrdDesc<OrdDefault<int>, int>).ToComparable()));
+            Assert.Equal(Prelude.Seq("2", "10", "1"), items.OrderBy(Prelude.identity, default(OrdDesc<OrdDefault<string>, string>).ToComparer()));
+            Assert.Equal(Prelude.Seq("10", "2", "1"), items.OrderBy(System.Convert.ToInt32, default(OrdDesc<OrdDefault<int>, int>).ToComparer()));
         }
     }
 }


### PR DESCRIPTION
This is an addition to #720. I think it's less important than `IComparer` but still has some use when dealing with non-LanguageExt code (like LINQ extensions, System.Interactive ...).

I've seen that you changed #720 to avoid a record problem and I added a small assertion in that ord test to make that more explicit (avoiding that it get's changed back easily).

I renamed `Ord.ToComparable` to `Ord.ToComparer` because I think the latter is more correct to align this to *Comparable vs. *Comparer and *Equatable vs. *EqualityComparer. 