### PR TITLE
Not a bug, just two tests (was: `Map` with target net5.0 and unicode)

### DIFF
--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Nito.AsyncEx" Version="[5.0.0,)" />
     <PackageReference Include="System.Net.Http" Version="[4.3.3,)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[15.6.0-preview-20171211-02,)" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.14.3" />
     <PackageReference Include="System.ValueTuple" Version="[4.5.0,)" />
     <PackageReference Include="xunit" Version="[2.4.1,)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[2.4.1,)">

--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0</TargetFrameworks>
     <FileVersion>3.0.0.0</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <LangVersion>8.0</LangVersion>

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -564,6 +564,13 @@ namespace LanguageExt.Tests
             Assert.True(m.FindExactOrSuccessor(15) == (15, 15));
         }
 
+        [Fact]
+        public void MapWithUnicodeChars()
+        {
+            var x = Map((";", 6), ("H", 5), ("", 4), ("\u0005", -4));
+            Assert.Equal(4, x.Count);
+        }
+        
         // Exponential test - takes too long to run
         //[Fact]
         //public void Issue_454()

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -3,7 +3,9 @@ using static LanguageExt.Prelude;
 using static LanguageExt.Map;
 using Xunit;
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using FsCheck.Xunit;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests
@@ -571,6 +573,15 @@ namespace LanguageExt.Tests
             Assert.Equal(4, x.Count);
         }
         
+        [Property]
+        public void MapRandomDict(IDictionary<string, int> dict)
+        {
+            dict.Remove("\u0000"); // this value fails on all targets
+            var x = toMap(dict);
+            Assert.Equal(dict.Count, x.Count);
+            Assert.Equal(dict.Keys.OrderBy(identity), x.Keys.OrderBy(identity));
+        }
+
         // Exponential test - takes too long to run
         //[Fact]
         //public void Issue_454()

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -569,15 +569,18 @@ namespace LanguageExt.Tests
         [Fact]
         public void MapWithUnicodeChars()
         {
-            var x = Map((";", 6), ("H", 5), ("", 4), ("\u0005", -4));
-            Assert.Equal(4, x.Count);
+            // fails from net5.0 on when default OrdString is used instead of OrdStringOrdinal 
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
+            var x = Map<OrdStringOrdinal, string, int>(("", 4), ("\u0005", -4));
+            Assert.Equal(2, x.Count);
         }
         
         [Property]
         public void MapRandomDict(IDictionary<string, int> dict)
         {
-            dict.Remove("\u0000"); // this value fails on all targets
-            var x = toMap(dict);
+            // fails from net5.0 on when default OrdString is used instead of OrdStringOrdinal 
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
+            var x = toMap<OrdStringOrdinal, string, int>(dict);
             Assert.Equal(dict.Count, x.Count);
             Assert.Equal(dict.Keys.OrderBy(identity), x.Keys.OrderBy(identity));
         }


### PR DESCRIPTION
I think there is a bug somewhere in `Map` for net5.0.
Everything is fine for netcoreapp3.1.

Note: I found this using property based testing and can recommend this (especially for generic code like LanguageExt). Second commit is request to add `FsCheck.Xunit` to enable this kind of tests.