### PR TITLE
Upgrade benchmarks and samples projects to target .NET Core 3.1 LTS.

### DIFF
--- a/LanguageExt.Benchmarks/LanguageExt.Benchmarks.csproj
+++ b/LanguageExt.Benchmarks/LanguageExt.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Samples/RecordsNetCore/RecordsNetCore.csproj
+++ b/Samples/RecordsNetCore/RecordsNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since no production code depends on these projects directly, the added security of upgrading to LTS might not have measurable value. However, as  a low-priority pull request, this seemed like a simple, low-risk option for a first-time contribution to an open source project.