### PR TITLE
Change NumTypeExtensions.Sum to use Reduce instead of Fold

### DIFF
--- a/LanguageExt.Core/DataTypes/NumType/NumType.Extensions.cs
+++ b/LanguageExt.Core/DataTypes/NumType/NumType.Extensions.cs
@@ -8,12 +8,12 @@ namespace LanguageExt
         public static SELF Sum<SELF, NUM, A>(this IEnumerable<NumType<SELF, NUM, A>> self)
             where SELF : NumType<SELF, NUM, A>
             where NUM : struct, Num<A> =>
-            self.Fold(NumType<SELF, NUM, A>.FromInteger(0), (s, x) => s + x);
+            (SELF) self.Reduce((s, x) => s + x);
 
         public static SELF Sum<SELF, NUM, A, PRED>(this IEnumerable<NumType<SELF, NUM, A, PRED>> self)
             where SELF : NumType<SELF, NUM, A, PRED>
             where NUM : struct, Num<A>
             where PRED : struct, Pred<A> =>
-            self.Fold(NumType<SELF, NUM, A, PRED>.FromInteger(0), (s, x) => s + x);
+            (SELF) self.Reduce((s, x) => s + x);
     }
 }


### PR DESCRIPTION
Fixes #869; depending on the predicate of the NumType the original implementation could throw an exception (the seed value of "0" might violate the predicate condition).

@TysonMN turns out that other "Fold" overload already exists and is called "Reduce" :)

I was thinking about adding tests but I'm not sure if it's desirable for such a simple function (I found no original ones for this), let me know if you want any.