### PR TITLE
fix: AtomSeq<A> now is IEnumerable<A>

### DIFF
--- a/LanguageExt.Core/Concurrency/AtomSeq/AtomSeq.cs
+++ b/LanguageExt.Core/Concurrency/AtomSeq/AtomSeq.cs
@@ -24,8 +24,8 @@ namespace LanguageExt
         IComparable<AtomSeq<A>>, 
         IEquatable<AtomSeq<A>>, 
         IComparable<Seq<A>>, 
-        IEquatable<Seq<A>>, 
-        IEnumerable,
+        IEquatable<Seq<A>>,
+        IEnumerable<A>,
         IComparable
     {
         /// <summary>

--- a/LanguageExt.Tests/AtomTests.cs
+++ b/LanguageExt.Tests/AtomTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using LanguageExt;
 using static LanguageExt.Prelude;
 using Xunit;
@@ -32,5 +33,13 @@ namespace LanguageExt.Tests
             Debug.Assert(atom == Set(1, 2, 3, 4, 5));
         }
 
+        [Fact]
+        public void AtomSeqEnumeration()
+        {
+            var xs = Seq(1,2,3,4);
+            var atom = AtomSeq(xs);
+            
+            Assert.Equal(atom.Sum(), xs.Sum());
+        }
     }
 }


### PR DESCRIPTION
AtomSeq didn't implement generic IEnumerable<A>, test added.