### PR TITLE
Add Changed events for Ref, AtomHashMap and AtomSeq

### DIFF
--- a/LanguageExt.Core/Concurrency/AtomHashMap/AtomHashMap.Eq.cs
+++ b/LanguageExt.Core/Concurrency/AtomHashMap/AtomHashMap.Eq.cs
@@ -29,6 +29,8 @@ namespace LanguageExt
     {
         internal volatile TrieMap<EqK, K, V> Items;
 
+        public event AtomChangedEvent<HashMap<EqK, K, V>>? Change;
+
         /// <summary>
         /// Creates a new atom-hashmap
         /// </summary>
@@ -116,6 +118,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -147,6 +150,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -175,6 +179,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItem(key, swap((V)ovalue));
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -229,6 +234,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -264,6 +270,7 @@ namespace LanguageExt
                 var nitems = oitems.Filter(pred);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -296,6 +303,7 @@ namespace LanguageExt
                 var nitems = oitems.Filter(pred);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -321,6 +329,7 @@ namespace LanguageExt
                 var nitems = oitems.Map(f);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -354,6 +363,7 @@ namespace LanguageExt
                 var nitems = oitems.Add(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -384,6 +394,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -410,6 +421,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -438,6 +450,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, Some, None);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -466,6 +479,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, Some, None);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -493,6 +507,7 @@ namespace LanguageExt
                 var nitems = oitems.AddRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -524,6 +539,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -554,6 +570,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -582,6 +599,7 @@ namespace LanguageExt
                 var nitems = Items.AddOrUpdateRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -609,6 +627,7 @@ namespace LanguageExt
                 var nitems = Items.AddOrUpdateRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -636,6 +655,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -696,6 +716,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return value;
                 }
                 else
@@ -725,6 +746,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -757,6 +779,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -786,6 +809,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -811,6 +835,7 @@ namespace LanguageExt
                 var nitems = Items.SetItem(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -839,6 +864,7 @@ namespace LanguageExt
                 var nitems = Items.SetItem(key, Some);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -869,6 +895,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -902,6 +929,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -968,6 +996,7 @@ namespace LanguageExt
                 var nitems = Items.Clear();
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -993,6 +1022,7 @@ namespace LanguageExt
                 var nitems = Items.AddRange(spairs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1018,6 +1048,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItems(sitems);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1043,6 +1074,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItems(sitems);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1072,6 +1104,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1101,6 +1134,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1135,6 +1169,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1163,6 +1198,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1322,6 +1358,7 @@ namespace LanguageExt
                 var nitems = oitems.Append(rhs.Items);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1341,6 +1378,7 @@ namespace LanguageExt
                 var nitems = oitems.Append(rhs.Value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1360,6 +1398,7 @@ namespace LanguageExt
                 var nitems = oitems.Subtract(rhs.Items);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1379,6 +1418,7 @@ namespace LanguageExt
                 var nitems = oitems.Subtract(rhs.Value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1473,6 +1513,7 @@ namespace LanguageExt
                 var nitems = oitems.Intersect(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1495,6 +1536,7 @@ namespace LanguageExt
                 var nitems = oitems.Intersect(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1532,6 +1574,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1555,6 +1598,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1577,6 +1621,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(rhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1600,6 +1645,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else
@@ -1625,6 +1671,7 @@ namespace LanguageExt
                 var nitems = oitems.Union(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<EqK, K, V>(nitems));
                     return default;
                 }
                 else

--- a/LanguageExt.Core/Concurrency/AtomHashMap/AtomHashMap.cs
+++ b/LanguageExt.Core/Concurrency/AtomHashMap/AtomHashMap.cs
@@ -28,6 +28,8 @@ namespace LanguageExt
     {
         internal volatile TrieMap<EqDefault<K>, K, V> Items;
 
+        public event AtomChangedEvent<HashMap<K, V>>? Change;
+
         /// <summary>
         /// Creates a new atom-hashmap
         /// </summary>
@@ -115,6 +117,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -143,6 +146,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItem(key, swap((V)ovalue));
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -197,6 +201,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -232,6 +237,7 @@ namespace LanguageExt
                 var nitems = oitems.Filter(pred);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -265,6 +271,7 @@ namespace LanguageExt
                 var nitems = oitems.Filter(pred);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -290,6 +297,7 @@ namespace LanguageExt
                 var nitems = oitems.Map(f);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -323,6 +331,7 @@ namespace LanguageExt
                 var nitems = oitems.Add(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -353,6 +362,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -379,6 +389,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -407,6 +418,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, Some, None);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -435,6 +447,7 @@ namespace LanguageExt
                 var nitems = oitems.AddOrUpdate(key, Some, None);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -462,6 +475,7 @@ namespace LanguageExt
                 var nitems = oitems.AddRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -493,6 +507,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -524,6 +539,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -552,6 +568,7 @@ namespace LanguageExt
                 var nitems = Items.AddOrUpdateRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -579,6 +596,7 @@ namespace LanguageExt
                 var nitems = Items.AddOrUpdateRange(srange);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -606,6 +624,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -666,6 +685,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return value;
                 }
                 else
@@ -695,6 +715,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -727,6 +748,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -756,6 +778,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return nvalue;
                 }
                 else
@@ -781,6 +804,7 @@ namespace LanguageExt
                 var nitems = Items.SetItem(key, value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -809,6 +833,7 @@ namespace LanguageExt
                 var nitems = Items.SetItem(key, Some);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -839,6 +864,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -872,6 +898,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -938,6 +965,7 @@ namespace LanguageExt
                 var nitems = Items.Clear();
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -963,6 +991,7 @@ namespace LanguageExt
                 var nitems = Items.AddRange(spairs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -988,6 +1017,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItems(sitems);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1013,6 +1043,7 @@ namespace LanguageExt
                 var nitems = oitems.SetItems(sitems);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1042,6 +1073,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1071,6 +1103,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1105,6 +1138,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1133,6 +1167,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1292,6 +1327,7 @@ namespace LanguageExt
                 var nitems = oitems.Append(rhs.Items);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1311,6 +1347,7 @@ namespace LanguageExt
                 var nitems = oitems.Append(rhs.Value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1330,6 +1367,7 @@ namespace LanguageExt
                 var nitems = oitems.Subtract(rhs.Items);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1349,6 +1387,7 @@ namespace LanguageExt
                 var nitems = oitems.Subtract(rhs.Value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1443,6 +1482,7 @@ namespace LanguageExt
                 var nitems = oitems.Intersect(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1465,6 +1505,7 @@ namespace LanguageExt
                 var nitems = oitems.Intersect(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1502,6 +1543,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1525,6 +1567,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1547,6 +1590,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(rhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1570,6 +1614,7 @@ namespace LanguageExt
                 var nitems = oitems.Except(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else
@@ -1595,6 +1640,7 @@ namespace LanguageExt
                 var nitems = oitems.Union(srhs);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref this.Items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new HashMap<K, V>(nitems));
                     return default;
                 }
                 else

--- a/LanguageExt.Core/Concurrency/AtomSeq/AtomSeq.cs
+++ b/LanguageExt.Core/Concurrency/AtomSeq/AtomSeq.cs
@@ -33,6 +33,8 @@ namespace LanguageExt
         /// </summary>
         public static readonly Seq<A> Empty = new Seq<A>(SeqEmptyInternal<A>.Default);
 
+        public event AtomChangedEvent<Seq<A>>? Change;
+
         /// <summary>
         /// Internal representation of the sequence (SeqStrict|SeqLazy|SeqEmptyInternal)
         /// </summary>
@@ -114,6 +116,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -145,6 +148,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -171,6 +175,7 @@ namespace LanguageExt
                 var nitems = oitems.Add(value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -416,6 +421,7 @@ namespace LanguageExt
 
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -437,6 +443,7 @@ namespace LanguageExt
                 var nitems = oitems.Cons(value);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -813,6 +820,7 @@ namespace LanguageExt
                 var nitems = new SeqLazy<A>(oitems.Map(f));
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -873,6 +881,7 @@ namespace LanguageExt
                 var nitems = new Seq<A>(oitems).Bind(f);
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems.Value, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -947,6 +956,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -1050,6 +1060,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -1256,6 +1267,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -1283,6 +1295,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -1315,6 +1328,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else
@@ -1348,6 +1362,7 @@ namespace LanguageExt
                 }
                 if (ReferenceEquals(Interlocked.CompareExchange(ref items, nitems, oitems), oitems))
                 {
+                    this.Change?.Invoke(new Seq<A>(nitems));
                     return default;
                 }
                 else

--- a/LanguageExt.Core/Concurrency/STM/RefChangedEvent.cs
+++ b/LanguageExt.Core/Concurrency/STM/RefChangedEvent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace LanguageExt
+{
+    /// <summary>
+    /// Announces Ref change events
+    /// </summary>
+    /// <remarks>
+    /// See the [concurrency section](https://github.com/louthy/language-ext/wiki/Concurrency) of the wiki for more info.
+    /// </remarks>
+    public delegate void RefChangedEvent<in A>(A value);
+}

--- a/LanguageExt.Core/Concurrency/STM/STM.cs
+++ b/LanguageExt.Core/Concurrency/STM/STM.cs
@@ -21,6 +21,11 @@ namespace LanguageExt
         static readonly AtomHashMap<EqLong, long, RefState> state = AtomHashMap<EqLong, long, RefState>();
         static readonly AsyncLocal<Transaction> transaction = new AsyncLocal<Transaction>();
 
+        internal static event AtomChangedEvent<HashMap<EqLong, long, object>> Change;
+
+        static STM()
+            => state.Change += v => Change?.Invoke(v.Map(s => s.UntypedValue));
+
         /// <summary>
         /// Generates a new reference that can be used within a sync transaction
         /// </summary>

--- a/LanguageExt.Tests/AtomHashMapEqTests.cs
+++ b/LanguageExt.Tests/AtomHashMapEqTests.cs
@@ -1,0 +1,427 @@
+﻿using static LanguageExt.Prelude;
+using Xunit;
+using LanguageExt.ClassInstances;
+
+namespace LanguageExt.Tests
+{
+    public class AtomHashMapEqTests
+    {
+        [Fact]
+        public void SwapInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Swap(m => m.Add("biz", 99));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SwapKeyInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SwapKey("foo", i => i + 1);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SwapKeyOptionalInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SwapKey("foo", i => None);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FilterInPlaceInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FilterInPlace(i => i % 2 == 0);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FilterInPlaceWithKeyInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FilterInPlace((k, i) => k[0] == 'b' && i % 2 == 0);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void MapInPlaceInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.MapInPlace(i => i * 3);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Add("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TryAddInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TryAdd("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddOrUpdateInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddOrUpdate("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TryAddRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TryAddRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddOrUpdateRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddOrUpdateRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void RemoveInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Remove("bar");
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void RemoveRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.RemoveRange(Seq("bar", "biz"));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrAddInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrAdd("biz", () => 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrAddConstantInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrAdd("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrMaybeAddInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrMaybeAdd("biz", () => Some(7));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrMaybeAddConstantInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrMaybeAdd("biz", Some(7));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SetItemsInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SetItems(Seq(("foo", 80), ("bar", 17)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemsInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItems(Seq(("foo", 80), ("bar", 17)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SetItemFuncInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SetItem("foo", i => i * 2);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItem("foo", 80);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemFuncInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            HashMap<TString, string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItem("foo", i => i * 2);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ClearInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Clear();
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AppendInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            var toAppend = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Append(toAppend);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AppendAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            var toAppend = AtomHashMap<TString, string, int>(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Append(toAppend);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SubtractInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toSubtract = HashMap<TString, string, int>(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Subtract(toSubtract);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SubtractAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toSubtract = HashMap<TString, string, int>(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Subtract(toSubtract);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void IntersectInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toIntersect = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Intersect(toIntersect);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void IntersectAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toIntersect = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Intersect(toIntersect);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ExceptInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toExcept = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Except(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ExceptKeysInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toExcept = Seq("biz", "baz");
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Except(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SymmetricExceptInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            var toExcept = AtomHashMap<TString, string, int>(("foo", 3), ("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.SymmetricExcept(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void UnionInvokesChange()
+        {
+            var hashMap = AtomHashMap<TString, string, int>(("foo", 3), ("bar", 42));
+            var toUnion = AtomHashMap<TString, string, int>(("foo", 3), ("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Union(toUnion);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+    }
+}

--- a/LanguageExt.Tests/AtomHashMapTests.cs
+++ b/LanguageExt.Tests/AtomHashMapTests.cs
@@ -1,0 +1,426 @@
+﻿using static LanguageExt.Prelude;
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public class AtomHashMapTests
+    {
+        [Fact]
+        public void SwapInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Swap(m => m.Add("biz", 99));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SwapKeyInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SwapKey("foo", i => i + 1);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SwapKeyOptionalInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SwapKey("foo", i => None);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FilterInPlaceInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FilterInPlace(i => i % 2 == 0);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FilterInPlaceWithKeyInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FilterInPlace((k, i) => k[0] == 'b' && i % 2 == 0);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void MapInPlaceInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.MapInPlace(i => i * 3);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Add("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TryAddInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TryAdd("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddOrUpdateInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddOrUpdate("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TryAddRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TryAddRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AddOrUpdateRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.AddOrUpdateRange(Seq(("biz", 7), ("baz", 9)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void RemoveInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.Remove("bar");
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void RemoveRangeInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.RemoveRange(Seq("bar", "biz"));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrAddInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrAdd("biz", () => 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrAddConstantInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrAdd("biz", 7);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrMaybeAddInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrMaybeAdd("biz", () => Some(7));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void FindOrMaybeAddConstantInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.FindOrMaybeAdd("biz", Some(7));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SetItemsInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SetItems(Seq(("foo", 80), ("bar", 17)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemsInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItems(Seq(("foo", 80), ("bar", 17)));
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SetItemFuncInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.SetItem("foo", i => i * 2);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItem("foo", 80);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void TrySetItemFuncInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            HashMap<string, int> state = default;
+            hashMap.Change += v => state = v;
+
+            hashMap.TrySetItem("foo", i => i * 2);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ClearInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Clear();
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AppendInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            var toAppend = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Append(toAppend);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void AppendAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            var toAppend = AtomHashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Append(toAppend);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SubtractInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toSubtract = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Subtract(toSubtract);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SubtractAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toSubtract = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Subtract(toSubtract);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void IntersectInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toIntersect = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Intersect(toIntersect);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void IntersectAtomInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toIntersect = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Intersect(toIntersect);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ExceptInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toExcept = HashMap(("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Except(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void ExceptKeysInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42), ("biz", 7), ("baz", 9));
+            var toExcept = Seq("biz", "baz");
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Except(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void SymmetricExceptInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            var toExcept = AtomHashMap(("foo", 3), ("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.SymmetricExcept(toExcept);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+
+        [Fact]
+        public void UnionInvokesChange()
+        {
+            var hashMap = AtomHashMap(("foo", 3), ("bar", 42));
+            var toUnion = AtomHashMap(("foo", 3), ("biz", 7), ("baz", 9));
+            var state = hashMap.ToHashMap();
+            hashMap.Change += v => state = v;
+
+            hashMap.Union(toUnion);
+
+            Assert.Equal(hashMap.ToHashMap(), state);
+        }
+    }
+}

--- a/LanguageExt.Tests/AtomSeqTests.cs
+++ b/LanguageExt.Tests/AtomSeqTests.cs
@@ -1,0 +1,129 @@
+﻿using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests
+{
+    public class AtomSeqTests
+    {
+        [Fact]
+        public void SwapInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.Swap(s => 0.Cons(s));
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void AddInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            var toConcat = Seq(6, 7, 8);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.Concat(toConcat);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void MapInPlaceInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.MapInPlace(i => i * 2);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void BindInPlaceInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.BindInPlace<int>(i => Range(0, i).ToSeq());
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void FilterInPlaceInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.FilterInPlace(i => i % 2 == 0);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void IntersperseInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.Intersperse(9);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void SkipInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.Skip(2);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void TakeInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.Take(2);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void TakeWhileInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.TakeWhile(i => i < 3);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+
+        [Fact]
+        public void TakeWhileIndexInvokesChange()
+        {
+            var seq = AtomSeq(1, 2, 3, 4, 5);
+            Seq<int> state = default;
+            seq.Change += v => state = v;
+
+            seq.TakeWhile((i, ix) => ix < 3);
+
+            Assert.Equal(seq.ToSeq(), state);
+        }
+    }
+}

--- a/LanguageExt.Tests/RefTest.cs
+++ b/LanguageExt.Tests/RefTest.cs
@@ -58,6 +58,37 @@ namespace LanguageExt.Tests
         }
 
         [Fact]
+        public void BankBalanceChangeTest()
+        {
+            var accountA = Account.New(200);
+            var accountB = Account.New(0);
+
+            var stateA = Option<Account>.None;
+            var stateB = Option<Account>.None;
+            var changedA = 0;
+            var changedB = 0;
+            accountA.Change += v => { stateA = v; changedA++; };
+            accountB.Change += v => { stateB = v; changedB++; };
+
+            atomic(() =>
+            {
+                accountA.Value = accountA.Value.AddBalance(-50);
+                accountB.Value = accountB.Value.AddBalance(50);
+                accountA.Value = accountA.Value.AddBalance(-5);
+                accountB.Value = accountB.Value.AddBalance(5);
+
+                Assert.Equal(None, stateA);
+                Assert.Equal(None, stateB);
+            });
+
+            Assert.Equal(Some(accountA.Value), stateA);
+            Assert.Equal(Some(accountB.Value), stateB);
+            Assert.Equal(1, changedA);
+            Assert.Equal(1, changedB);
+        }
+
+
+        [Fact]
         public void CommuteTest()
         {
             const int count = 1000;


### PR DESCRIPTION
`Atom<A>` has a `Changed` event that is very useful for reactive code.
I've added the same kind of event for `Ref<A>`, `AtomHashMap<TEq, K, V>`, `AtomHashMap<K, V>` and `AtomSeq<A>`.

This PR was previously discussed in https://github.com/louthy/language-ext/issues/923.