### PR TITLE
Remove allocation overhead for empty arrays (and enumerables) (#997)

### DIFF
--- a/LanguageExt.CodeGen/CodeGenUtil.cs
+++ b/LanguageExt.CodeGen/CodeGenUtil.cs
@@ -617,7 +617,7 @@ namespace LanguageExt.CodeGen
         {
             // Ugly, but fast
 
-            if (xs.Length == 0) return new A[0];
+            if (xs.Length == 0) return Array.Empty<A>();
             var nxs = new A[xs.Length * 2 - 1];
             for(int i = 0; i < nxs.Length; i++)
             {

--- a/LanguageExt.Core/Class Instances/Monad/MArray.cs
+++ b/LanguageExt.Core/Class Instances/Monad/MArray.cs
@@ -43,7 +43,7 @@ namespace LanguageExt.ClassInstances
 
         [Pure]
         public A[] Empty() =>
-            new A[0];
+            System.Array.Empty<A>();
 
         [Pure]
         public bool Equals(A[] x, A[] y) =>

--- a/LanguageExt.Core/Class Instances/Monad/MEnumerable.cs
+++ b/LanguageExt.Core/Class Instances/Monad/MEnumerable.cs
@@ -75,7 +75,7 @@ namespace LanguageExt.ClassInstances
 
         [Pure]
         public IEnumerable<A> Empty() =>
-            new A[0];
+            Enumerable.Empty<A>();
 
         [Pure]
         public bool Equals(IEnumerable<A> x, IEnumerable<A> y) =>

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -367,7 +367,7 @@ namespace LanguageExt
         [Pure]
         public Arr<A> InsertRange(int index, IEnumerable<A> items)
         {
-            items = items ?? new A[0];
+            items = items ?? Enumerable.Empty<A>();
             var arr = Value;
             if (index < 0 || index > arr.Length) throw new IndexOutOfRangeException(nameof(index));
 

--- a/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
@@ -482,7 +482,7 @@ namespace LanguageExt
         [Pure]
         public static IEnumerable<T> append<T>(params IEnumerable<T>[] lists) =>
             lists.Length == 0
-                ? new T[0]
+                ? Enumerable.Empty<T>()
                 : lists.Length == 1
                     ? lists[0]
                     : append(lists[0], lists.Skip(1));
@@ -1358,7 +1358,7 @@ namespace LanguageExt
             {
                 yield return lst.Skip(skip);
             }
-            yield return new T[0];
+            yield return Enumerable.Empty<T>();
         }
 
         /// <summary>

--- a/LanguageExt.Core/Immutable Collections/Prelude_Collections.cs
+++ b/LanguageExt.Core/Immutable Collections/Prelude_Collections.cs
@@ -654,7 +654,7 @@ namespace LanguageExt
         /// </summary>
         [Pure]
         public static Lst<PredList, T> List<PredList, T>() where PredList : struct, Pred<ListInfo> =>
-            new Lst<PredList, T>(new T[0]);
+            new Lst<PredList, T>(Enumerable.Empty<T>());
 
         /// <summary>
         /// Create an immutable list
@@ -688,7 +688,7 @@ namespace LanguageExt
         public static Lst<PredList, PredItem, T> List<PredList, PredItem, T>() 
             where PredItem : struct, Pred<T>
             where PredList : struct, Pred<ListInfo>  =>
-            new Lst<PredList, PredItem, T>(new T[0]);
+            new Lst<PredList, PredItem, T>(Enumerable.Empty<T>());
 
         /// <summary>
         /// Create an immutable list

--- a/LanguageExt.Core/Immutable Collections/TrieMap/TrieMap.cs
+++ b/LanguageExt.Core/Immutable Collections/TrieMap/TrieMap.cs
@@ -2365,7 +2365,7 @@ namespace LanguageExt
                     dataMap = Bit.Set(dataMap, Mask(pair2Index), true);
                     return new Entries(dataMap, 0, pair1Index < pair2Index
                         ? new[] { pair1, pair2 }
-                        : new[] { pair2, pair1 }, new Node[0]);
+                        : new[] { pair2, pair1 }, Array.Empty<Node>());
                 }
             }
         }

--- a/LanguageExt.Core/Immutable Collections/TrieSet/TrieSet.cs
+++ b/LanguageExt.Core/Immutable Collections/TrieSet/TrieSet.cs
@@ -703,7 +703,7 @@ namespace LanguageExt
                                         Mask(Bit.Get((uint)default(EqK).GetHashCode(subEntries.Items[0]), section)),
                                         0,
                                         Clone(subEntries.Items),
-                                        new Node[0]
+                                        System.Array.Empty<Node>()
                                         ));
                                 }
                                 else
@@ -1045,7 +1045,7 @@ namespace LanguageExt
                 }
 
                 var dataMap = Mask(Bit.Get(hash, section));
-                return (1, new Entries(dataMap, 0, new[] { change }, new Node[0]));
+                return (1, new Entries(dataMap, 0, new[] { change }, System.Array.Empty<Node>()));
             }
 
             public IEnumerator<K> GetEnumerator()
@@ -1077,7 +1077,7 @@ namespace LanguageExt
                 {
                     var node = Merge(key1, key2, pair1Hash, pair2Hash, nextLevel);
                     var nodeMap = Mask(pair1Index);
-                    return new Entries(0, nodeMap, new K[0], new[] { node });
+                    return new Entries(0, nodeMap, System.Array.Empty<K>(), new[] { node });
                 }
                 else
                 {
@@ -1085,7 +1085,7 @@ namespace LanguageExt
                     dataMap = Bit.Set(dataMap, Mask(pair2Index), true);
                     return new Entries(dataMap, 0, pair1Index < pair2Index
                         ? new[] { key1, key2 }
-                        : new[] { key2, key1 }, new Node[0]);
+                        : new[] { key2, key1 }, System.Array.Empty<Node>());
                 }
             }
         }

--- a/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
@@ -611,8 +611,8 @@ namespace LanguageExt
         [Pure, MethodImpl(Opt.Default)]
         public A[] ToArray() =>
             IsSucc
-                ? new A[] {Value}
-                : new A[0];
+                ? new A[] { Value }
+                : System.Array.Empty<A>();
 
         [Pure, MethodImpl(Opt.Default)]
         public Option<A> ToOption() =>

--- a/LanguageExt.Core/Monads/Alternative Value Monads/Some/Some.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Some/Some.cs
@@ -72,7 +72,7 @@ namespace LanguageExt
         public IEnumerable<A> AsEnumerable() =>
             initialised
                 ? new[] { value }
-                : new A[0];
+                : Enumerable.Empty<A>();
 
         [Pure]
         public IEnumerator<A> GetEnumerator() =>

--- a/LanguageExt.Core/Type Classes/BiFoldable/BiFoldable.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/BiFoldable/BiFoldable.Prelude.cs
@@ -78,7 +78,7 @@ namespace LanguageExt
         [Pure]
         public static IEnumerable<C> collect<FOLD, F, A, B, C>(F foldable, Func<A, C> fa, Func<B, C> fb)
             where FOLD : struct, BiFoldable<F, A, B> =>
-            biFoldBack<FOLD, F, A, B, IEnumerable<C>>(foldable, new C[0].AsEnumerable(), (s, x) => fa(x).Cons(s), (s, x) => fb(x).Cons(s));
+            biFoldBack<FOLD, F, A, B, IEnumerable<C>>(foldable, Enumerable.Empty<C>(), (s, x) => fa(x).Cons(s), (s, x) => fb(x).Cons(s));
 
         /// <summary>
         /// Does the element occur in the structure?

--- a/LanguageExt.Core/Type Classes/BiFoldableAsync/BiFoldableAsync.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/BiFoldableAsync/BiFoldableAsync.Prelude.cs
@@ -196,7 +196,7 @@ namespace LanguageExt
         [Pure]
         public static Task<IEnumerable<C>> collectAsync<FOLD, F, A, B, C>(F foldable, Func<A, C> fa, Func<B, C> fb)
             where FOLD : struct, BiFoldableAsync<F, A, B> =>
-            biFoldBackAsync<FOLD, F, A, B, IEnumerable<C>>(foldable, new C[0].AsEnumerable(), (s, x) => fa(x).Cons(s), (s, x) => fb(x).Cons(s));
+            biFoldBackAsync<FOLD, F, A, B, IEnumerable<C>>(foldable, Enumerable.Empty<C>(), (s, x) => fa(x).Cons(s), (s, x) => fb(x).Cons(s));
 
         /// <summary>
         /// Does the element occur in the structure?

--- a/LanguageExt.Core/Type Classes/Choice/Choice.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/Choice/Choice.Prelude.cs
@@ -36,9 +36,9 @@ namespace LanguageExt
         public static Arr<B> toArray<CHOICE, CH, A, B>(CH ma)
             where CHOICE : struct, Choice<CH, A, B> =>
             default(CHOICE).Match(ma,
-                Left: x => new B[0],
+                Left: x => System.Array.Empty<B>(),
                 Right: y => new B[1] { y },
-                Bottom: () => new B[0]);
+                Bottom: () => System.Array.Empty<B>());
 
         /// <summary>
         /// Convert the Option to an immutable list of zero or one items

--- a/LanguageExt.Core/Type Classes/ChoiceUnsafe/ChoiceUnsafe.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/ChoiceUnsafe/ChoiceUnsafe.Prelude.cs
@@ -36,9 +36,9 @@ namespace LanguageExt
         public static Arr<B> toArray<CHOICE, CH, A, B>(CH ma)
             where CHOICE : struct, ChoiceUnsafe<CH, A, B> =>
             default(CHOICE).MatchUnsafe(ma,
-                Left: x => new B[0],
+                Left: x => System.Array.Empty<B>(),
                 Right: y => new B[1] { y },
-                Bottom: () => new B[0]);
+                Bottom: () => System.Array.Empty<B>());
 
         /// <summary>
         /// Convert the Option to an immutable list of zero or one items

--- a/LanguageExt.Core/Type Classes/FoldableAsync/FoldableAsync.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/FoldableAsync/FoldableAsync.Prelude.cs
@@ -122,7 +122,7 @@ namespace LanguageExt
         /// <returns>Sequence of As that represent the value(s) in the structure</returns>
         [Pure]
         public static Task<IEnumerable<B>> collectAsync<FOLD, F, A, B>(F self, Func<A, B> f) where FOLD : FoldableAsync<F, A> =>
-            default(FOLD).FoldBack(self, new B[0].AsEnumerable(), (s, x) => f(x).Cons(s))(unit);
+            default(FOLD).FoldBack(self, Enumerable.Empty<B>(), (s, x) => f(x).Cons(s))(unit);
 
         /// <summary>
         /// Get the first item in a foldable structure

--- a/LanguageExt.Core/Type Classes/Optional/Optional.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/Optional/Optional.Prelude.cs
@@ -91,7 +91,7 @@ namespace LanguageExt
             where OPT : struct, Optional<OA, A> =>
             default(OPT).Match(ma,
                 Some: x => new A[1] { x },
-                None: () => new A[0]);
+                None: () => System.Array.Empty<A>());
 
         /// <summary>
         /// Convert the Option to an immutable list of zero or one items

--- a/LanguageExt.Core/Type Classes/OptionalUnsafe/OptionalUnsafe.Prelude.cs
+++ b/LanguageExt.Core/Type Classes/OptionalUnsafe/OptionalUnsafe.Prelude.cs
@@ -92,7 +92,7 @@ namespace LanguageExt
             where OPT : struct, OptionalUnsafe<OA, A> =>
             default(OPT).MatchUnsafe(ma,
                 Some: x => new A[1] { x },
-                None: () => new A[0]);
+                None: () => System.Array.Empty<A>());
 
         /// <summary>
         /// Convert the Option to an immutable list of zero or one items

--- a/LanguageExt.Core/Utility/EnumerableOptimal.cs
+++ b/LanguageExt.Core/Utility/EnumerableOptimal.cs
@@ -17,18 +17,18 @@ namespace LanguageExt
 
         internal static IEnumerable<B> BindFast<A, B>(this IEnumerable<A> ma, Func<A, IEnumerable<B>> f) =>
             ma == null
-                ? (IEnumerable<B>)(new B[0])
+                ? System.Linq.Enumerable.Empty<B>()
                 : new BindEnum<A, B>(ma, f);
 
         internal static IEnumerable<B> BindFast<A, B>(this IEnumerable<A> ma, Func<A, Lst<B>> f) =>
             ma == null
-                ? (IEnumerable<B>)(new B[0])
+                ? System.Linq.Enumerable.Empty<B>()
                 : new BindEnum<A, B>(ma, a => f(a).AsEnumerable());
 
         internal static IEnumerable<B> BindFast<PredList, A, B>(this IEnumerable<A> ma, Func<A, Lst<PredList, B>> f)
             where PredList : struct, Pred<ListInfo> =>
             ma == null
-                ? (IEnumerable<B>)(new B[0])
+                ? System.Linq.Enumerable.Empty<B>()
                 : new BindEnum<A, B>(ma, a => f(a).AsEnumerable());
 
         internal static IEnumerable<B> BindFast<PredList, PredItemA, PredItemB, A, B>(this IEnumerable<A> ma, Func<A, Lst<PredList, PredItemB, B>> f)
@@ -36,12 +36,12 @@ namespace LanguageExt
             where PredItemA : struct, Pred<A>
             where PredItemB : struct, Pred<B> =>
             ma == null
-                ? (IEnumerable<B>)(new B[0])
+                ? System.Linq.Enumerable.Empty<B>()
                 : new BindEnum<A, B>(ma, a => f(a).AsEnumerable());
 
         internal static IEnumerable<B> BindFast<A, B>(this IEnumerable<A> ma, Func<A, Seq<B>> f) =>
             ma == null
-                ? (IEnumerable<B>)(new B[0])
+                ? System.Linq.Enumerable.Empty<B>()
                 : new BindEnum<A, B>(ma, a => f(a).AsEnumerable());
 
         internal class ConcatEnum<A> : IEnumerable<A>

--- a/LanguageExt.Parsec/PStringIO.cs
+++ b/LanguageExt.Parsec/PStringIO.cs
@@ -48,7 +48,7 @@ namespace LanguageExt.Parsec
             $"{typeof(T).Name}({Index}, {EndIndex})";
 
         public static PString<T> Zero(Func<T, Pos> tokenPos) =>
-            new PString<T>(new T[0], 0, 0, None, tokenPos);
+            new PString<T>(System.Array.Empty<T>(), 0, 0, None, tokenPos);
 
         public PString<U> Cast<U>() where U : T =>
             new PString<U>(Value.Cast<U>().ToArray(), Index, EndIndex, UserState, u => TokenPos((T)u));


### PR DESCRIPTION
This fixes issue #997 and a few other places that I considered performance critical.
Would be interesting to actually benchmark this.
