### PR TITLE
Bugfixes: SeqLazy.Equals sometimes wrong, Set.Case returned wrong data/type

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Seq/SeqLazy.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/SeqLazy.cs
@@ -511,9 +511,9 @@ namespace LanguageExt
             {
                 hash = FNV32.Hash<HashableDefault<A>, A>(data, start, count, hash);
             }
-            if (seq.Count > 0)
+            if (seq.Count - seqStart > 0)
             {
-                hash = FNV32.Hash<HashableDefault<A>, A>(seq.Data, 0, seq.Count, hash);
+                hash = FNV32.Hash<HashableDefault<A>, A>(seq.Data, seqStart, seq.Count - seqStart, hash);
             }
             return hash;
         }

--- a/LanguageExt.Core/Immutable Collections/Set/Set.Ord.cs
+++ b/LanguageExt.Core/Immutable Collections/Set/Set.Ord.cs
@@ -87,7 +87,7 @@ namespace LanguageExt
         public object Case =>
             IsEmpty
                 ? null
-                : Seq1(Value).Case;
+                : toSeq(Value).Case;
 
         /// <summary>
         /// Add an item to the set

--- a/LanguageExt.Core/Immutable Collections/Set/Set.cs
+++ b/LanguageExt.Core/Immutable Collections/Set/Set.cs
@@ -116,7 +116,7 @@ namespace LanguageExt
         public object Case =>
             IsEmpty
                 ? null
-                : Seq1(Value).Case;
+                : toSeq(Value).Case;
 
         /// <summary>
         /// Add an item to the set

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -555,5 +555,23 @@ namespace LanguageExt.Tests
             Assert.True(xs[11] == 11);
             Assert.True(xs[12] == 12);
         }
+
+        [Fact]
+        void SeqHashCodeRegression()
+        {
+            // GetHashCode is internally used to compare Seq values => has to be equal irrespective of creation method 
+
+            var originalStrictTail = Seq(2, 3);
+            var lazyTailSeq = Set(1, 2, 3).Tail().ToSeq();
+            var lazySeqTail = Set(1, 2, 3).ToSeq().Tail;
+            var lazyPattern = Set(1, 2, 3).Case is (int _, Seq<int> tail) ? tail : throw new ("invalid");
+            
+            Assert.Equal(originalStrictTail.GetHashCode(), lazyTailSeq.GetHashCode());
+            Assert.Equal(originalStrictTail, lazyTailSeq);
+            Assert.Equal(originalStrictTail.GetHashCode(), lazySeqTail.GetHashCode());
+            Assert.Equal(originalStrictTail, lazySeqTail);
+            Assert.Equal(originalStrictTail.GetHashCode(), lazyPattern.GetHashCode());
+            Assert.Equal(originalStrictTail, lazyPattern);
+        }
     }
 }

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -26,7 +26,7 @@ namespace LanguageExt.Tests
             Assert.True(set.Contains("thREE"));
         }
 
-  
+
         [Fact]
         public void EqualsTest()
         {
@@ -456,6 +456,23 @@ namespace LanguageExt.Tests
             Assert.True(m.FindExactOrSuccessor(13) == 13);
             Assert.True(m.FindExactOrSuccessor(14) == 15);
             Assert.True(m.FindExactOrSuccessor(15) == 15);
+        }
+
+        [Fact]
+        public void CaseTest()
+        {
+            // seq1 tests here just for reference
+            { Assert.True(Seq<int>().Case is not var (_, _) and not {} ); }
+            { Assert.True(Seq1<int>(1).Case is not var (_, _) and 1); }
+            { Assert.True(Seq<int>(1, 2).Case is (1, Seq<int> xs) && xs == Seq1(2)); }
+
+            { Assert.True(Set<int>().Case is not var (_, _) and not {} ); }
+            { Assert.True(Set<int>(1).Case is not var (_, _) and 1); }
+            { Assert.True(Set<int>(1, 2).Case is (1, Seq<int> xs) && xs == Seq1(2)); }
+
+            { Assert.True(Set<OrdInt, int>().Case is not var (_, _) and not {} ); }
+            { Assert.True(Set<OrdInt, int>(1).Case is not var (_, _) and 1); }
+            { Assert.True(Set<OrdInt, int>(1, 2).Case is (1, Seq<int> xs) && xs == Seq1(2)); }
         }
     }
 }


### PR DESCRIPTION
Two bug fixes:
* `Set.Case` returned wrong type (not `var x or var (x,xs)`)
* `SeqLazy` had broken `GetHashCode()` which could result in wrong Equality (two `Seq` could be equal with `Equals` returning false).