### PR TITLE
Fixes #1065 - Schedule Run methods now do not capture free variables

### DIFF
--- a/LanguageExt.Tests/ScheduleTest/AffTests.cs
+++ b/LanguageExt.Tests/ScheduleTest/AffTests.cs
@@ -1,8 +1,13 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using LanguageExt.Common;
+using LanguageExt.Sys;
 using LanguageExt.Sys.Test;
+using LanguageExt.Sys.Traits;
 using Xunit;
 using static LanguageExt.Prelude;
 
@@ -56,11 +61,12 @@ public static class AffTests
     public static async Task RetryTest1()
     {
         var counter = 0;
-        var effect = AffMaybe<int>(async () =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New("Failed");
-        });
+        var effect = AffMaybe<int>(
+            async () =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New("Failed");
+            });
         var result = await effect.Retry(TestSchedule()).Run();
         counter.Should().Be(6);
         result.Case.Should().Be(Error.New("Failed"));
@@ -70,11 +76,12 @@ public static class AffTests
     public static async Task RetryTest2()
     {
         var counter = 0;
-        var effect = AffMaybe<Runtime, int>(async _ =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New("Failed");
-        });
+        var effect = AffMaybe<Runtime, int>(
+            async _ =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New("Failed");
+            });
         var result = await effect.Retry(TestSchedule()).Run(Runtime.New());
         counter.Should().Be(6);
         result.Case.Should().Be(Error.New("Failed"));
@@ -104,11 +111,12 @@ public static class AffTests
     public static async Task RetryWhileTest1()
     {
         var counter = 0;
-        var effect = AffMaybe<int>(async () =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New(counter.ToString());
-        });
+        var effect = AffMaybe<int>(
+            async () =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New(counter.ToString());
+            });
         var result = await effect.RetryWhile(TestSchedule(), static e => (int)parseInt(e.Message) < 3).Run();
         counter.Should().Be(3);
         result.Case.Should().Be(Error.New("3"));
@@ -118,11 +126,12 @@ public static class AffTests
     public static async Task RetryWhileTest2()
     {
         var counter = 0;
-        var effect = AffMaybe<Runtime, int>(async _ =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New(counter.ToString());
-        });
+        var effect = AffMaybe<Runtime, int>(
+            async _ =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New(counter.ToString());
+            });
         var result = await effect.RetryWhile(TestSchedule(), static e => (int)parseInt(e.Message) < 3)
             .Run(Runtime.New());
         counter.Should().Be(3);
@@ -153,11 +162,12 @@ public static class AffTests
     public static async Task RetryUntilTest1()
     {
         var counter = 0;
-        var effect = AffMaybe<int>(async () =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New(counter.ToString());
-        });
+        var effect = AffMaybe<int>(
+            async () =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New(counter.ToString());
+            });
         var result = await effect.RetryUntil(static e => (int)parseInt(e.Message) == 10).Run();
         counter.Should().Be(10);
         result.Case.Should().Be(Error.New("10"));
@@ -167,11 +177,12 @@ public static class AffTests
     public static async Task RetryUntilTest2()
     {
         var counter = 0;
-        var effect = AffMaybe<Runtime, int>(async _ =>
-        {
-            await (++counter).AsValueTask();
-            return Error.New(counter.ToString());
-        });
+        var effect = AffMaybe<Runtime, int>(
+            async _ =>
+            {
+                await (++counter).AsValueTask();
+                return Error.New(counter.ToString());
+            });
         var result = await effect.RetryUntil(static e => (int)parseInt(e.Message) == 10).Run(Runtime.New());
         counter.Should().Be(10);
         result.Case.Should().Be(Error.New("10"));
@@ -251,5 +262,60 @@ public static class AffTests
         counter.Should().Be(1);
         result.IsSucc.Should().BeTrue();
         result.Case.Should().Be(1);
+    }
+    
+    [Fact(DisplayName = "Schedule Run against Aff<T> should not capture state")]
+    public static async Task ShouldNotCaptureState1Test()
+    {
+        var content = Encoding.ASCII.GetBytes("test\0test\0test\0");
+        var memStream = new MemoryStream(100);
+        memStream.Write(content, 0, content.Length);
+        memStream.Seek(0, SeekOrigin.Begin);
+
+        Eff<Unit> AddToBuffer(ICollection<string> buffer, string value) =>
+            Eff(() => { buffer.Add(value); return unit; });
+
+        Aff<Unit> CreateEffect(ICollection<string> buffer) =>
+            repeat(
+                from ln in (
+                    from data in Aff(() => memStream.ReadByte().AsValueTask())
+                    from _ in guard(data != -1, Errors.Cancelled)
+                    select data).FoldUntil(string.Empty, (s, ch) => s + (char)ch, ch => ch == '\0')
+                from _0 in AddToBuffer(buffer,ln)
+                select unit)
+            | @catch(exception => AddToBuffer(buffer,exception.Message));
+
+        var buffer = new List<string>();
+        var effect = CreateEffect(buffer);
+
+        await effect.RunUnit();
+
+        buffer.Should().Equal("test\0", "test\0", "test\0", "cancelled");
+    }
+
+    [Fact(DisplayName = "Schedule Run against Aff<RT,T> should not capture state")]
+    public static async Task ShouldNotCaptureState2Test()
+    {
+        var content = Encoding.ASCII.GetBytes("test\0test\0test\0");
+        var memStream = new MemoryStream(100);
+        memStream.Write(content, 0, content.Length);
+        memStream.Seek(0, SeekOrigin.Begin);
+
+        Aff<RT, Unit> CreateEffect<RT>() where RT : struct, HasConsole<RT> =>
+            repeat(
+                from ln in (
+                    from data in Aff(() => memStream.ReadByte().AsValueTask())
+                    from _ in guard(data != -1, Errors.Cancelled)
+                    select data).FoldUntil(string.Empty, (s, ch) => s + (char)ch, ch => ch == '\0')
+                from _0 in Console<RT>.writeLine(ln)
+                select unit)
+            | @catch(exception => Console<RT>.writeLine(exception.Message));
+
+        var runtime = Runtime.New();
+        var effect = CreateEffect<Runtime>();
+
+        await effect.RunUnit(runtime);
+
+        runtime.Env.Console.Should().Equal("test\0", "test\0", "test\0", "cancelled");
     }
 }


### PR DESCRIPTION
This resolves #1065 which was discussed in #1064.

The Schedule.Run methods were capturing the S state parameter.

Have made the inline functions static to eliminated the possibility of capturing it.

Tests have been added to all Run method variants to prevent regression.