### PR TITLE
Fix Distinct with custom comparer (hash bug)

### DIFF
--- a/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
@@ -1007,7 +1007,7 @@ namespace LanguageExt
         /// <returns>A new enumerable with all duplicate values removed</returns>
         [Pure]
         public static IEnumerable<T> distinct<EQ, T>(IEnumerable<T> list) where EQ : struct, Eq<T> =>
-            list.Distinct(new EqCompare<T>(static (x, y) => default(EQ).Equals(x, y)));
+            list.Distinct(new EqCompare<T>(static (x, y) => default(EQ).Equals(x, y), static x => default(EQ).GetHashCode(x)));
 
         /// <summary>
         /// Return a new enumerable with all duplicate values removed
@@ -1017,7 +1017,9 @@ namespace LanguageExt
         /// <returns>A new enumerable with all duplicate values removed</returns>
         [Pure]
         public static IEnumerable<T> distinct<T, K>(IEnumerable<T> list, Func<T, K> keySelector, Option<Func<K, K, bool>> compare = default(Option<Func<K, K, bool>>)) =>
-             list.Distinct(new EqCompare<T>((a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), a => keySelector(a)?.GetHashCode() ?? 0));
+             list.Distinct(new EqCompare<T>(
+                 (a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), 
+                 a => keySelector(a)?.GetHashCode() ?? 0));
 
         /// <summary>
         /// Returns a new enumerable with the first 'count' items from the enumerable provided

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
@@ -476,7 +476,7 @@ public static class SeqExtensions
     /// <returns>A new sequence with all duplicate values removed</returns>
     [Pure]
     public static Seq<T> Distinct<T, K>(this Seq<T> list, Func<T, K> keySelector, Option<Func<K, K, bool>> compare = default(Option<Func<K, K, bool>>)) =>
-        toSeq(Enumerable.Distinct(list, new EqCompare<T>((a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), a => keySelector(a)?.GetHashCode() ?? 0)));
+        toSeq(Enumerable.Distinct(list, new EqCompare<T>((a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), a => compare.Match(_  => 0, () => keySelector(a)?.GetHashCode() ?? 0))));
 
     /// <summary>
     /// Apply a sequence of values to a sequence of functions

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
@@ -476,7 +476,10 @@ public static class SeqExtensions
     /// <returns>A new sequence with all duplicate values removed</returns>
     [Pure]
     public static Seq<T> Distinct<T, K>(this Seq<T> list, Func<T, K> keySelector, Option<Func<K, K, bool>> compare = default(Option<Func<K, K, bool>>)) =>
-        toSeq(Enumerable.Distinct(list, new EqCompare<T>((a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), a => compare.Match(_  => 0, () => keySelector(a)?.GetHashCode() ?? 0))));
+        toSeq(Enumerable.Distinct(list, 
+            new EqCompare<T>(
+                (a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), 
+                a => compare.Match(Some: _  => 0, None: () => default(EqDefault<K>).GetHashCode(keySelector(a))))));
 
     /// <summary>
     /// Apply a sequence of values to a sequence of functions

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.Extensions.cs
@@ -466,7 +466,7 @@ public static class SeqExtensions
     /// <returns>A new sequence with all duplicate values removed</returns>
     [Pure]
     public static Seq<T> Distinct<EQ, T>(this Seq<T> list) where EQ : struct, Eq<T> =>
-        toSeq(Enumerable.Distinct(list, new EqCompare<T>((x, y) => default(EQ).Equals(x, y))));
+        toSeq(Enumerable.Distinct(list, new EqCompare<T>(static (x, y) => default(EQ).Equals(x, y), static x => default(EQ).GetHashCode(x))));
 
     /// <summary>
     /// Return a new sequence with all duplicate values removed

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.Module.cs
@@ -790,7 +790,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Seq<T> distinct<EQ, T>(Seq<T> list) where EQ : struct, Eq<T> =>
-            toSeq(list.Distinct(new EqCompare<T>((x, y) => default(EQ).Equals(x, y))));
+            toSeq(list.Distinct(new EqCompare<T>(static (x, y) => default(EQ).Equals(x, y), static x => default(EQ).GetHashCode(x))));
 
         /// <summary>
         /// Return a new sequence with all duplicate values removed
@@ -801,7 +801,9 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Seq<T> distinct<T, K>(Seq<T> list, Func<T, K> keySelector, Option<Func<K, K, bool>> compare = default(Option<Func<K, K, bool>>)) =>
-             toSeq(list.Distinct(new EqCompare<T>((a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), a => keySelector(a)?.GetHashCode() ?? 0)));
+             toSeq(list.Distinct(new EqCompare<T>(
+                 (a, b) => compare.IfNone(default(EqDefault<K>).Equals)(keySelector(a), keySelector(b)), 
+                 a => compare.Match(Some: _  => 0, None: () => default(EqDefault<K>).GetHashCode(keySelector(a))))));
 
         /// <summary>
         /// Returns a new sequence with the first 'count' items from the sequence provided

--- a/LanguageExt.Tests/DistinctTests.cs
+++ b/LanguageExt.Tests/DistinctTests.cs
@@ -1,0 +1,23 @@
+using System;
+using LanguageExt;
+using LanguageExt.ClassInstances;
+using static LanguageExt.Prelude;
+using Xunit;
+using System.Threading.Tasks;
+using LanguageExt.Common;
+
+namespace LanguageExt.Tests
+{
+    public class DistinctTests
+    {
+        [Fact]
+        void SeqDistinctIgnoreCase()
+        {
+            var items = Seq("Test", "other", "test");
+            
+            Assert.Equal(items, items.Distinct());
+            Assert.Equal(items.Take(3), items.Distinct(_ => _, fun<string, string, bool>(EqStringOrdinal.Inst.Equals)));
+            Assert.Equal(items.Take(2), items.Distinct(_ => _, fun<string, string, bool>(EqStringOrdinalIgnoreCase.Inst.Equals)));
+        }
+    }
+}


### PR DESCRIPTION
There is a bug in .Distinct() when a custom comparer is used. PR includes test and fix.

Bug is that default GetHashCode is used -- this is not valid with a custom (key) comparer.

First both commits only fix one occurence of the bug (there are more). Some things come to my mind (before adding more tests/fixes):

1. IMHO there should be a `Distinct<EQ, T, K>(...)` variant which I would prefer for my use case (avoiding runtime comparer).
2. Maybe avoid 'func parameter' style `Func<string,string,bool>` for helper functions like this (comparer). This would avoid hiding a gethashcode "problem" (either needs to be supplied or otherwise risks performance penalty). Should be enough to allow a variant with IEqualityComparer<T> parameter and make something like `EqCompare<T>` public to allow on-the-fly creation of Comparers using equals+gethashcode.
3. Do you mind merging https://github.com/louthy/language-ext/pull/841 (which is related here / giving wrapper EQ => IEqualityComparer)? This would be a (semi) replacement for (1.)

PS: In case you like to stay with 'comparer func parameter': Maybe code (and bugfix) should be improved by moving `IfNone` and `Match` outside to avoid calling this within each call of of the comparer. Maybe `comparer` the should be non-optional (adding another signature without comparer) to clean up code.