### PR TITLE
Fix incorrect docstring for two LeftToSeq implementations.

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Value Monads/Either/Either/Either.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Either/Either/Either.cs
@@ -540,7 +540,7 @@ namespace LanguageExt
             RightAsEnumerable();
 
         /// <summary>
-        /// Convert either to sequence of 0 or 1 right values
+        /// Convert either to sequence of 0 or 1 left values
         /// </summary>
         [Pure]
         public Seq<L> LeftToSeq() =>

--- a/LanguageExt.Core/Monads/Alternative Value Monads/Either/EitherAsync/EitherAsync.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Either/EitherAsync/EitherAsync.cs
@@ -807,7 +807,7 @@ namespace LanguageExt
             RightAsEnumerable();
 
         /// <summary>
-        /// Convert either to sequence of 0 or 1 right values
+        /// Convert either to sequence of 0 or 1 left values
         /// </summary>
         [Pure]
         public Task<Seq<L>> LeftToSeq() =>


### PR DESCRIPTION
This is a minor correction of some incorrect doc strings that have tripped me up more than once. So I thought I'd contribute a fix.