### PR TITLE
Microsoft.Bcl.AsyncInterfaces upgrade from 5.0.0 to 6.0.0

### DIFF
--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -42,7 +42,7 @@
     <None Remove="obj\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0,)" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
     <PackageReference Include="System.Reflection.Emit" Version="[4.3.0,)" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="[4.5.4,)" />
     <PackageReference Include="System.ValueTuple" Version="[4.5.0,)" />

--- a/LanguageExt.FSharp/LanguageExt.FSharp.csproj
+++ b/LanguageExt.FSharp/LanguageExt.FSharp.csproj
@@ -44,6 +44,7 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="FSharp.Core" Version="[4.1.12,)" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\LanguageExt.Core\LanguageExt.Core.csproj" />

--- a/LanguageExt.Parsec/LanguageExt.Parsec.csproj
+++ b/LanguageExt.Parsec/LanguageExt.Parsec.csproj
@@ -43,6 +43,7 @@
         <None Remove="obj\**" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
         <PackageReference Include="System.ValueTuple" Version="[4.5.0,)" />
     </ItemGroup>
     <ItemGroup>

--- a/LanguageExt.Rx/LanguageExt.Rx.csproj
+++ b/LanguageExt.Rx/LanguageExt.Rx.csproj
@@ -61,6 +61,7 @@
         <None Remove="ValidationSeq.Extensions.cs" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
         <PackageReference Include="System.ValueTuple" Version="[4.5.0,)" />
         <PackageReference Include="System.Reactive" Version="[3.0.0,)" />
     </ItemGroup>

--- a/LanguageExt.Sys/LanguageExt.Sys.csproj
+++ b/LanguageExt.Sys/LanguageExt.Sys.csproj
@@ -43,6 +43,9 @@
         <EmbeddedResource Remove="obj\**" />
         <None Remove="obj\**" />
     </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
+    </ItemGroup>
 
 
 </Project>

--- a/LanguageExt.Transformers/LanguageExt.Transformers.csproj
+++ b/LanguageExt.Transformers/LanguageExt.Transformers.csproj
@@ -64,7 +64,7 @@
         <None Remove="obj\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[5.0.0,)" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="[6.0.0,)" />
         <PackageReference Include="System.Reflection.Emit" Version="[4.3.0,)" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="[4.5.4,)" />
         <PackageReference Include="System.ValueTuple" Version="[4.5.0,)" />


### PR DESCRIPTION
The commit [Break out transformer extension methods into their own package](https://github.com/louthy/language-ext/commit/d6fb39a34b973708ab955ce6e6c68bdfc9d2ad51) forces everybody on non-core FW to use `Microsoft.Bcl.AsyncInterfaces` v5 or the latest v6 but with an assembly redirect.

I am updating it to v6 so we are on the latest.

