### PR TITLE
Added Prism optics for manipulating Option<A> fields

### DIFF
--- a/LanguageExt.Core/Lens/Lens.cs
+++ b/LanguageExt.Core/Lens/Lens.cs
@@ -114,5 +114,15 @@ namespace LanguageExt
             Lens<IEnumerable<A>, IEnumerable<B>>.New(
                 Get: lst => lst.Map(la.Get),
                 Set: val => lst => lst.Zip(val).Map(ab => la.Set(ab.Item2, ab.Item1)));
+
+        /// <summary>
+        /// Convert a Lens<A,B> to a Prism<A,B>
+        /// </summary>
+        public static Prism<A, B> ToPrism<A, B>(this Lens<A, B> la) => Prism<A, B>.New(la);
+
+        /// <summary>
+        /// Convert a Lens<A, Option<B>> to a Prism<A,B>
+        /// </summary>
+        public static Prism<A, B> ToPrism<A, B>(this Lens<A, Option<B>> la) => Prism<A, B>.New(la);
     }
 }

--- a/LanguageExt.Core/Prism/Prelude_Prism.cs
+++ b/LanguageExt.Core/Prism/Prelude_Prism.cs
@@ -1,0 +1,89 @@
+﻿namespace LanguageExt
+{
+    public static partial class Prelude
+    {
+        /// <summary>
+        /// Convert a lens to a prism
+        /// </summary>
+        public static Prism<A, B> prism<A, B>(Lens<A, B> la) =>
+            Prism<A, B>.New(la);
+
+        /// <summary>
+        /// Convert a lens to a prism
+        /// </summary>
+        public static Prism<A, B> prism<A, B>(Lens<A, Option<B>> la) => 
+            Prism<A, B>.New(la);
+
+        /// <summary>
+        /// Sequentially composes two prisms
+        /// </summary>
+        public static Prism<A, C> prism<A, B, C>(Prism<A, B> pa, Prism<B, C> pb) => 
+            Prism<A, C>.New(
+                Get: a => pa.Get(a).Bind(pb.Get),
+                Set: v => pa.Update(pb.SetF(v)));
+
+        /// <summary>
+        /// Sequentially composes three prisms
+        /// </summary>
+        public static Prism<A, D> prism<A, B, C, D>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc) =>
+            Prism<A, D>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get),
+                Set: v => pa.Update(pb.Update(pc.SetF(v))));
+
+        /// <summary>
+        /// Sequentially composes four prisms
+        /// </summary>
+        public static Prism<A, E> prism<A, B, C, D, E>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd) =>
+            Prism<A, E>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.SetF(v)))));
+
+        /// <summary>
+        /// Sequentially composes five prisms
+        /// </summary>
+        public static Prism<A, F> prism<A, B, C, D, E, F>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe) =>
+            Prism<A, F>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.SetF(v))))));
+
+        /// <summary>
+        /// Sequentially composes six prisms
+        /// </summary>
+        public static Prism<A, G> prism<A, B, C, D, E, F, G>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe, Prism<F, G> pf) =>
+            Prism<A, G>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get).Bind(pf.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.Update(pf.SetF(v)))))));
+
+        /// <summary>
+        /// Sequentially composes seven prisms
+        /// </summary>
+        public static Prism<A, H> prism<A, B, C, D, E, F, G, H>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe, Prism<F, G> pf, Prism<G, H> pg) =>
+            Prism<A, H>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get).Bind(pf.Get).Bind(pg.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.Update(pf.Update(pg.SetF(v))))))));
+
+        /// <summary>
+        /// Sequentially composes eight prisms
+        /// </summary>
+        public static Prism<A, I> prism<A, B, C, D, E, F, G, H, I>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe, Prism<F, G> pf, Prism<G, H> pg, Prism<H, I> ph) =>
+            Prism<A, I>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get).Bind(pf.Get).Bind(pg.Get).Bind(ph.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.Update(pf.Update(pg.Update(ph.SetF(v)))))))));
+
+        /// <summary>
+        /// Sequentially composes nine prisms
+        /// </summary>
+        public static Prism<A, J> prism<A, B, C, D, E, F, G, H, I, J>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe, Prism<F, G> pf, Prism<G, H> pg, Prism<H, I> ph, Prism<I, J> pi) =>
+            Prism<A, J>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get).Bind(pf.Get).Bind(pg.Get).Bind(ph.Get).Bind(pi.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.Update(pf.Update(pg.Update(ph.Update(pi.SetF(v))))))))));
+
+        /// <summary>
+        /// Sequentially composes ten prisms
+        /// </summary>
+        public static Prism<A, K> prism<A, B, C, D, E, F, G, H, I, J, K>(Prism<A, B> pa, Prism<B, C> pb, Prism<C, D> pc, Prism<D, E> pd, Prism<E, F> pe, Prism<F, G> pf, Prism<G, H> pg, Prism<H, I> ph, Prism<I, J> pi, Prism<J, K> pj) =>
+            Prism<A, K>.New(
+                Get: a => pa.Get(a).Bind(pb.Get).Bind(pc.Get).Bind(pd.Get).Bind(pe.Get).Bind(pf.Get).Bind(pg.Get).Bind(ph.Get).Bind(pi.Get).Bind(pj.Get),
+                Set: v => pa.Update(pb.Update(pc.Update(pd.Update(pe.Update(pf.Update(pg.Update(ph.Update(pi.Update(pj.SetF(v)))))))))));
+    }
+}

--- a/LanguageExt.Core/Prism/Prism.cs
+++ b/LanguageExt.Core/Prism/Prism.cs
@@ -1,0 +1,13 @@
+﻿namespace LanguageExt
+{
+    public static class Prism
+    {
+        /// <summary>
+        /// Identity lens
+        /// </summary>
+        public static Prism<A, A> identity<A>() =>
+            Prism<A, A>.New(
+                Get: a => a,
+                Set: a => _ => a);
+    }
+}

--- a/LanguageExt.Core/Prism/PrismAB.cs
+++ b/LanguageExt.Core/Prism/PrismAB.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics.Contracts;
+
+namespace LanguageExt
+{
+    /// <summary>
+    /// Primitive prism type for creating transformations through Options
+    /// </summary>
+    public readonly struct Prism<A, B>
+    {
+        public readonly Func<A, Option<B>> Get;
+        public readonly Func<B, Func<A, A>> SetF;
+
+        private Prism(Func<A, Option<B>> get, Func<B, Func<A, A>> set)
+        {
+            Get = get;
+            SetF = set;
+        }
+
+        public A Set(B value, A cont)
+            => SetF(value)(cont);
+
+        public static Prism<A, B> New(Func<A, Option<B>> Get,
+                                      Func<B, Func<A, A>> Set)
+            => new Prism<A, B>(Get, Set);
+
+        public static Prism<A, B> New(Lens<A, B> lens) =>
+            Prism<A, B>.New(
+                Get: a => lens.Get(a),
+                Set: v => lens.SetF(v)
+            );
+
+        public static Prism<A, B> New(Lens<A, Option<B>> lens) =>
+            Prism<A, B>.New(
+                Get: a => lens.Get(a),
+                Set: v => lens.SetF(v)
+            );
+
+        public Func<A, A> Update(Func<B, B> f)
+        {
+            var self = this;
+            return a => self.Get(a)
+                            .Map(v => self.Set(f(v), a))
+                            .IfNone(a);
+        }
+
+        public A Update(Func<B, B> f, A value)
+        {
+            var self = this;
+            return Get(value).Map(v => self.Set(f(v), value))
+                             .IfNone(value);
+        }
+
+        /// <summary>
+        /// Implicit conversion operator from Lens<A,B> to Prism<A,B>
+        /// </summary>
+        /// <param name="value">Value</param>
+        [Pure]
+        public static implicit operator Prism<A, B>(Lens<A, B> value) => 
+            New(value);
+
+        /// <summary>
+        /// Implicit conversion operator from Option<A> to Result<A>
+        /// </summary>
+        /// <param name="value">Value</param>
+        [Pure]
+        public static implicit operator Prism<A, B>(Lens<A, Option<B>> value) => 
+            New(value);
+
+    }
+}

--- a/LanguageExt.Tests/PrismTests.cs
+++ b/LanguageExt.Tests/PrismTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using LanguageExt;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests
+{
+    public class PrismTests
+    {
+        private static readonly Prism<Job, int> jobWorkerCarMileage = prism(Job.worker.ToPrism(), Worker.car.ToPrism(), Car.mileage.ToPrism());
+
+        [Fact]
+        public void PrismShouldGetSome()
+        {
+            var expected = Some(20000);
+            
+            var car = new Car("Maserati", "Ghibli", 20000);
+            var worker = new Worker("Joe Bloggs", 50000, car);
+            var job = new Job("Programmer", "Write code and tests.", worker);
+
+            var actual = jobWorkerCarMileage.Get(job);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PrismShouldGetNone()
+        {
+            var expected = Option<int>.None;
+            
+            var worker = new Worker("Joe Bloggs", 50000, Option<Car>.None);
+            var job = new Job("Programmer", "Write code and tests.", worker);
+
+            var actual = jobWorkerCarMileage.Get(job);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PrismShouldSetWhenOptionalPartOfChainIsSome()
+        {
+            var expectedCar = new Car("Maserati", "Ghibli", 25000);
+            var expectedWorker = new Worker("Joe Bloggs", 50000, expectedCar);
+            var expected = new Job("Programmer", "Write code and tests.", expectedWorker);
+            
+            var car = new Car("Maserati", "Ghibli", 20000);
+            var worker = new Worker("Joe Bloggs", 50000, car);
+            var job = new Job("Programmer", "Write code and tests.", worker);
+            
+            var actual = jobWorkerCarMileage.Set(25000, job);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void PrismShouldNotSetWhenOptionalPartOfChainIsNone()
+        {
+            var expectedWorker = new Worker("Joe Bloggs", 50000, Option<Car>.None);
+            var expected = new Job("Programmer", "Write code and tests.", expectedWorker);
+
+            var worker = new Worker("Joe Bloggs", 50000, Option<Car>.None);
+            var job = new Job("Programmer", "Write code and tests.", worker);
+
+            var actual = jobWorkerCarMileage.Set(25000, job);
+
+            Assert.Equal(expected, actual);
+        }
+
+    }
+    
+    [Record]
+    public partial class Worker
+    {
+        public readonly string Name;
+        public readonly int Salary;
+        public readonly Option<Car> Car;
+    }
+
+    [Record]
+    public partial class Job
+    {
+        public readonly string Name;
+        public readonly string Description;
+        public readonly Worker Worker;
+    }
+}
+


### PR DESCRIPTION
Composing Lenses for records with optional fields can get a bit messy.
Haskell and other FP languages have the concept of Prisms for dealing with these cases.

A Prism is very similar to a Lens but with the following signatures for its Get and Set
 Get: `Func<A, Option<B>>`
 Set: `Func<B, Func<A, A>>`

The Get maps the option to the child properties attempting to be accessed and the Set will only set values if the Prism chain is all Somes.