### PR TITLE
Fix [Record] HashableAttribute (runtime error)

### DIFF
--- a/LanguageExt.Core/Class Instances/Hashable/HashableException.cs
+++ b/LanguageExt.Core/Class Instances/Hashable/HashableException.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt.ClassInstances
 {

--- a/LanguageExt.Core/Class Instances/Hashable/HashablePair.cs
+++ b/LanguageExt.Core/Class Instances/Hashable/HashablePair.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt
 {

--- a/LanguageExt.Core/Class Instances/Hashable/HashableTuple.cs
+++ b/LanguageExt.Core/Class Instances/Hashable/HashableTuple.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt.ClassInstances
 {

--- a/LanguageExt.Core/Type Classes/Hashable/Hashable.cs
+++ b/LanguageExt.Core/Type Classes/Hashable/Hashable.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using LanguageExt.Attributes;
 using LanguageExt.TypeClasses;
 
-namespace LanguageExt
+namespace LanguageExt.TypeClasses
 {
     /// <summary>
     /// Hashable type-class

--- a/LanguageExt.Core/Type Classes/HashableAsync/HashableAsync.cs
+++ b/LanguageExt.Core/Type Classes/HashableAsync/HashableAsync.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using LanguageExt.Attributes;
 using LanguageExt.TypeClasses;
 
-namespace LanguageExt
+namespace LanguageExt.TypeClasses
 {
     /// <summary>
     /// HashableAsync type-class

--- a/LanguageExt.Core/Utility/Fnv.cs
+++ b/LanguageExt.Core/Utility/Fnv.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using LanguageExt.TypeClasses;
 
 namespace LanguageExt
 {

--- a/LanguageExt.Tests/RecordAttributeTests.cs
+++ b/LanguageExt.Tests/RecordAttributeTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using LanguageExt.ClassInstances;
+using Xunit;
+
+namespace LanguageExt.Tests
+{
+    public partial class RecordAttributeTests
+    {
+        [Record]
+        public partial class TestRecord
+        {
+            [Ord(typeof(OrdStringOrdinalIgnoreCase))]
+            [Eq(typeof(OrdStringOrdinalIgnoreCase))]
+            [Hashable(typeof(OrdStringOrdinalIgnoreCase))]
+            public string DirPath { get; }
+        }
+
+        [Fact]
+        public void RecordCustomComparer()
+        {
+            var test = TestRecord.New(@"c:\temp");
+
+            Assert.Equal(TestRecord.New(@"C:\Temp"), test);
+            Assert.Equal(TestRecord.New(@"C:\Temp").GetHashCode(), test.GetHashCode());
+            Assert.Equal(0, TestRecord.New(@"C:\Temp").CompareTo(test));
+        }
+
+        [Fact]
+        public void RecordCustomComparerAttributes()
+        {
+            var attributes = typeof(TestRecord).GetProperty(nameof(TestRecord.DirPath))!.GetCustomAttributes(false);
+
+            Assert.Equal(3, attributes.Length);
+        }
+    }
+}


### PR DESCRIPTION
Using `[Hashable(...)]` in `[Record]` results in runtime error.

Found this bug because I didn't use `[Hashable(...)]` but just  `[Eq(...)]` and  `[Ord(...)]` resulting in different hash codes.

---

IMHO it's error-prone (and boilerplate) to require all three attributes for simple cases like the one shown in the test case.

GetHashCode maybe should be implemented by using the first existing of
1. [Hashable]
2. [Eq]
3. [Ord]
4. HashDefault

I'm not sure whether `Ord` should (or does) fully superseed `Eq` which could result in a similar list for implementation of `Equals`. I often use [Record] types having one or more case insensitive string properties as keys for e.g. `Map` and `HashMap` or with `.GroupBy(..)`.

Edit: somehow related to https://github.com/louthy/language-ext/pull/842 (CompareTo==0 vs. Equals==true)
