### PR TITLE
Fix for #1115 Map<K,V>.itemOrNone Lens Get to return None when key does not exist

### DIFF
--- a/LanguageExt.Core/Immutable Collections/HashMap/HashMap.cs
+++ b/LanguageExt.Core/Immutable Collections/HashMap/HashMap.cs
@@ -57,7 +57,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Lens<HashMap<K, V>, Option<V>> itemOrNone(K key) => Lens<HashMap<K, V>, Option<V>>.New(
-            Get: la => la[key],
+            Get: la => la.Find(key),
             Set: a => la => a.Match(Some: x => la.AddOrUpdate(key, x), None: () => la.Remove(key))
             );
 

--- a/LanguageExt.Core/Immutable Collections/Map/Map.cs
+++ b/LanguageExt.Core/Immutable Collections/Map/Map.cs
@@ -100,7 +100,7 @@ namespace LanguageExt
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Lens<Map<K, V>, Option<V>> itemOrNone(K key) => Lens<Map<K, V>, Option<V>>.New(
-            Get: la => la[key],
+            Get: la => la.Find(key),
             Set: a => la => a.Match(Some: x => la.AddOrUpdate(key, x), None: () => la.Remove(key))
             );
 

--- a/LanguageExt.Core/Immutable Collections/TrackingHashMap/TrackingHashMap.Eq.cs
+++ b/LanguageExt.Core/Immutable Collections/TrackingHashMap/TrackingHashMap.Eq.cs
@@ -96,7 +96,7 @@ namespace LanguageExt
         /// </summary>
         [Pure]
         public static Lens<TrackingHashMap<EqK, K, V>, Option<V>> itemOrNone(K key) => Lens<TrackingHashMap<EqK, K, V>, Option<V>>.New(
-            Get: la => la[key],
+            Get: la => la.Find(key),
             Set: a => la => a.Match(Some: x => la.AddOrUpdate(key, x), None: () => la.Remove(key))
             );
 

--- a/LanguageExt.Core/Immutable Collections/TrackingHashMap/TrackingHashMap.cs
+++ b/LanguageExt.Core/Immutable Collections/TrackingHashMap/TrackingHashMap.cs
@@ -96,7 +96,7 @@ namespace LanguageExt
         /// </summary>
         [Pure]
         public static Lens<TrackingHashMap<K, V>, Option<V>> itemOrNone(K key) => Lens<TrackingHashMap<K, V>, Option<V>>.New(
-            Get: la => la[key],
+            Get: la => la.Find(key),
             Set: a => la => a.Match(Some: x => la.AddOrUpdate(key, x), None: () => la.Remove(key))
             );
 

--- a/LanguageExt.Tests/ArrayTests.cs
+++ b/LanguageExt.Tests/ArrayTests.cs
@@ -134,5 +134,46 @@ namespace LanguageExt.Tests
             Assert.False(Array<int>(1, 2).Equals(Array<int>(1, 2, 3)));
             Assert.False(Array<int>(1, 2, 3).Equals(Array<int>(1, 2)));
         }
+
+
+        [Fact]
+        public void itemLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var array = Array("0", "1", "2", "3", "4", "5");
+            var actual = Arr<string>.item(3).Get(array);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemLensGetShouldThrowExceptionForNonExistingValue()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                var array = Array("0", "1", "2", "3", "4", "5");
+                var actual = Arr<string>.item(10).Get(array);
+            });
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var array = Array("0", "1", "2", "3", "4", "5");
+            var actual = Arr<string>.itemOrNone(3).Get(array);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldReturnNoneForNonExistingValue()
+        {
+            var expected = Option<string>.None;
+            var array = Array("0", "1", "2", "3", "4", "5");
+            var actual = Arr<string>.itemOrNone(10).Get(array);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/LanguageExt.Tests/HashMapTests.cs
+++ b/LanguageExt.Tests/HashMapTests.cs
@@ -265,5 +265,45 @@ namespace LanguageExt.Tests
                 Assert.True(!items.Contains(value));
             }
         }
+
+        [Fact]
+        public void itemLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = HashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = HashMap<int, string>.item(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemLensGetShouldThrowExceptionForNonExistingValue()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var map = HashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+                var actual = HashMap<int, string>.item(10).Get(map);
+            });
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = HashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = HashMap<int, string>.itemOrNone(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldReturnNoneForNonExistingValue()
+        {
+            var expected = Option<string>.None;
+            var map = HashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = HashMap<int, string>.itemOrNone(10).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -579,5 +579,45 @@ namespace LanguageExt.Tests
             var output4 = foldBackUntil(input, 0, (s, x) => s + x, predstate: s => s >= 90);
             Assert.Equal(90, output4);
         }
+
+        [Fact]
+        public void itemLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var list = List("0","1", "2", "3", "4", "5");
+            var actual = Lst<string>.item(3).Get(list);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemLensGetShouldThrowExceptionForNonExistingValue()
+        {
+            Assert.Throws<IndexOutOfRangeException>(() =>
+            {
+                var list = List("0", "1", "2", "3", "4", "5");
+                var actual = Lst<string>.item(10).Get(list);
+            });
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var list = List("0", "1", "2", "3", "4", "5");
+            var actual = Lst<string>.itemOrNone(3).Get(list);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldReturnNoneForNonExistingValue()
+        {
+            var expected = Option<string>.None;
+            var list = List("0", "1", "2", "3", "4", "5");
+            var actual = Lst<string>.itemOrNone(10).Get(list);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -579,5 +579,45 @@ namespace LanguageExt.Tests
 
         //    map.Filter(_ => false);
         //}
+
+        [Fact]
+        public void itemLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = Map((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = Map<int, string>.item(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemLensGetShouldThrowExceptionForNonExistingValue()
+        {
+            Assert.Throws<Exception>(() =>
+            {
+                var map = Map((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+                var actual = Map<int, string>.item(10).Get(map);
+            });
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = Map((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = Map<int, string>.itemOrNone(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldReturnNoneForNonExistingValue()
+        {
+            var expected = Option<string>.None;
+            var map = Map((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = Map<int, string>.itemOrNone(10).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/LanguageExt.Tests/TrackingHashMapTests.cs
+++ b/LanguageExt.Tests/TrackingHashMapTests.cs
@@ -1,0 +1,54 @@
+﻿using LanguageExt;
+using static LanguageExt.Prelude;
+using static LanguageExt.HashMap;
+using Xunit;
+using System;
+using System.Linq;
+using LanguageExt.ClassInstances;
+
+namespace LanguageExt.Tests
+{
+    public class TrackingHashMapTests
+
+    {
+        [Fact]
+        public void itemLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = TrackingHashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = TrackingHashMap<int, string>.item(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemLensGetShouldThrowExceptionForNonExistingValue()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var map = TrackingHashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+                var actual = TrackingHashMap<int, string>.item(10).Get(map);
+            });
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldGetExistingValue()
+        {
+            var expected = "3";
+            var map = TrackingHashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = TrackingHashMap<int, string>.itemOrNone(3).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void itemOrNoneLensGetShouldReturnNoneForNonExistingValue()
+        {
+            var expected = Option<string>.None;
+            var map = TrackingHashMap((1, "1"), (2, "2"), (3, "3"), (4, "4"), (5, "5"));
+            var actual = TrackingHashMap<int, string>.itemOrNone(10).Get(map);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Updates the behaviour of itemOrNone Lenses for `Map`, `HashMap` and `TrackingHashMap` to return None if key doesn't exist in the map.
This resolves the issue raised in [#1115](https://github.com/louthy/language-ext/issues/1115)

Also includes unit tests to verify the new behaviour and the existing behaviour of `Arr` and `Lst`  itemOrNone Lenses


