### PR TITLE
fixes Map.Equals bug

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Map/Map.Internal.cs
+++ b/LanguageExt.Core/Immutable Collections/Map/Map.Internal.cs
@@ -1463,7 +1463,7 @@ namespace LanguageExt
             {
                 iterA.MoveNext();
                 iterB.MoveNext();
-                if (!default(OrdK).Equals(iterA.Current.Key, iterB.Current.Key)) return false;
+                if (default(OrdK).Compare(iterA.Current.Key, iterB.Current.Key) != 0) return false;
                 if (!default(EqV).Equals(iterA.Current.Value, iterB.Current.Value)) return false;
             }
             return true;

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -567,14 +567,13 @@ namespace LanguageExt.Tests
         [Fact]
         public void MapWithUnicodeCharsEquality()
         {
-            // fails from net5.0 on when default OrdString is used instead of OrdStringOrdinal 
             // https://docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
+            // from net5.0 on the following maps will have only 1 element because string.Compare by default (i.e. OrdString) returns 0 for some keys which are not equal 
             var m1 = Map<OrdString, string, int>(("", 4)).TryAdd("\u0005", 4);
             var m2 = Map<OrdString, string, int>(("\u0005", 4)).TryAdd("", 4);
         
-            Assert.Equal(1, m1.Count);
-            Assert.Equal(1, m2.Count);
-            Assert.Equal(0,  default(OrdString).Compare(m1.Keys.Head(), m2.Keys.Head()));
+            Assert.Equal(m1.Count, m2.Count);
+            Assert.All( m1.Keys.Zip(m2.Keys), _ => Assert.Equal(0, default(OrdString).Compare(_.Item1, _.Item2)));
             Assert.Equal(m1, m2);
         }
         

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -564,6 +564,20 @@ namespace LanguageExt.Tests
             Assert.True(m.FindExactOrSuccessor(15) == (15, 15));
         }
 
+        [Fact]
+        public void MapWithUnicodeCharsEquality()
+        {
+            // fails from net5.0 on when default OrdString is used instead of OrdStringOrdinal 
+            // https://docs.microsoft.com/en-us/dotnet/standard/base-types/string-comparison-net-5-plus
+            var m1 = Map<OrdString, string, int>(("", 4)).TryAdd("\u0005", 4);
+            var m2 = Map<OrdString, string, int>(("\u0005", 4)).TryAdd("", 4);
+        
+            Assert.Equal(1, m1.Count);
+            Assert.Equal(1, m2.Count);
+            Assert.Equal(0,  default(OrdString).Compare(m1.Keys.Head(), m2.Keys.Head()));
+            Assert.Equal(m1, m2);
+        }
+        
         // Exponential test - takes too long to run
         //[Fact]
         //public void Issue_454()


### PR DESCRIPTION
(Related to #842.)

From net50 on `OrdString` will have `CompareTo(...) == 0` but `Equals(...) == false` for some (unicode) strings.
Map should use `CompareTo` everywhere (and never `Equals`) to be consistent.

Fix coming up...