### PR TITLE
awaiting an OptionAsync should not throw ValueIsNoneException

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.Awaiter.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.Awaiter.cs
@@ -16,12 +16,12 @@ namespace LanguageExt
         public bool IsCompleted =>
             awaiter.IsCompleted;
 
-        public A GetResult()
+        public Option<A> GetResult()
         {
             var (isSome, value) = awaiter.GetResult();
             return isSome
                 ? value
-                : throw new ValueIsNoneException();
+                : Option<A>.None;
         }
 
         public void OnCompleted(Action completion) =>

--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -300,6 +300,12 @@ namespace LanguageExt.Tests
             Assert.True(result);
         }
 
+        [Fact]
+        public async void AwaitAsync_IsNone()
+        {
+            await GetValue(false);
+        }
+
         // Not valuable any more 
         //[Fact]
         //public async void SequenceFlip()

--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -300,10 +300,14 @@ namespace LanguageExt.Tests
             Assert.True(result);
         }
 
-        [Fact]
-        public async void AwaitAsync_IsNone()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void AwaitAsync(bool isSome)
         {
-            await GetValue(false);
+            var result = await GetValue(isSome);
+            
+            Assert.Equal(isSome, result.IsSome);
         }
 
         // Not valuable any more 


### PR DESCRIPTION
Doing

    await OptionAsync<T>.None;

throws a `ValueIsNoneException` exception.

IMO this is not helpful
 - it's masking that we're working with an option type where we should expect/handle the none case
 - handling the none case with a try/catch seems a like a bad idea to me

Therefore I propose the awaiter to return an `Option<A>` (instead of `A`).

Note, that of course this is a **breaking change** to the API. Personally I don't really expect people have used it, but I don't know.

It's a simple change and it does not cause any of the unit tests to fail.