### PR TITLE
Fix Map<Ord,...> + Map<Ord,..> result type

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Map/Map.Ord.cs
+++ b/LanguageExt.Core/Immutable Collections/Map/Map.Ord.cs
@@ -714,12 +714,12 @@ namespace LanguageExt
             lhs.CompareTo(rhs) >= 0;
 
         [Pure]
-        public static Map<K, V> operator +(Map<OrdK, K, V> lhs, Map<OrdK, K, V> rhs) =>
-            new Map<K, V>(lhs.Value + rhs.Value);
+        public static Map<OrdK, K, V> operator +(Map<OrdK, K, V> lhs, Map<OrdK, K, V> rhs) =>
+            new Map<OrdK, K, V>(lhs.Value + rhs.Value);
 
         [Pure]
-        public static Map<K, V> operator -(Map<OrdK, K, V> lhs, Map<OrdK, K, V> rhs) =>
-            new Map<K, V>(lhs.Value - rhs.Value);
+        public static Map<OrdK, K, V> operator -(Map<OrdK, K, V> lhs, Map<OrdK, K, V> rhs) =>
+            new Map<OrdK, K, V>(lhs.Value - rhs.Value);
 
         /// <summary>
         /// Equality of keys and values with `EqDefault<V>` used for values

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -222,6 +222,19 @@ namespace LanguageExt.Tests
                 Assert.True(m.Count == max);
             }
         }
+        
+        [Fact]
+        public void MapOrdSumTest()
+        {
+            var m1 = Map<OrdStringOrdinalIgnoreCase, string, int>(("one", 1), ("two",2));
+            var m2 = Map<OrdStringOrdinalIgnoreCase, string, int>(("three", 3));
+
+            var sum = m1 + m2;
+            
+            Assert.Equal(sum, m1.AddRange(m2));
+            Assert.Equal(m2, sum.Clear() + m2);
+        }
+
 
         [Fact]
         public void MapOptionTest()

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -186,6 +186,18 @@ namespace LanguageExt.Tests
                 Assert.True(m.Count == max);
             }
         }
+        
+        [Fact]
+        public void SetOrdSumTest()
+        {
+            var m1 = Set<OrdStringOrdinalIgnoreCase, string>("one", "two");
+            var m2 = Set<OrdStringOrdinalIgnoreCase, string>("three");
+
+            var sum = m1 + m2;
+            
+            Assert.Equal(sum, m1.AddRange(m2));
+            Assert.Equal(m2, sum.Clear() + m2);
+        }
 
         [Fact]
         public void SetUnionTest1()


### PR DESCRIPTION
`Map<OrdK,...> + Map<OrdK,..>` returned a Map type without `OrdK`