### PR TITLE
Fix race condition when merging producers

### DIFF
--- a/LanguageExt.Core/Effects/Pipes/Producer/Producer.cs
+++ b/LanguageExt.Core/Effects/Pipes/Producer/Producer.cs
@@ -428,8 +428,7 @@ namespace LanguageExt.Pipes
                           });
                 #pragma warning restore CS4014                
 
-                // Keep processing until we're cancelled or all of the Producers have stopped producing 
-                while (running && !env.CancellationToken.IsCancellationRequested)
+                do
                 {
                     await wait.WaitOneAsync(env.CancellationToken).ConfigureAwait(false);
                     while (queue.TryDequeue(out var item))
@@ -437,6 +436,8 @@ namespace LanguageExt.Pipes
                         yield return item;
                     }
                 }
+                // Keep processing until we're cancelled or all of the Producers have stopped producing
+                while (running && !env.CancellationToken.IsCancellationRequested);
             }
         }
         

--- a/LanguageExt.Tests/PipesTests.cs
+++ b/LanguageExt.Tests/PipesTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using LanguageExt.Pipes;
+using LanguageExt.Sys.Test;
+using Xunit;
+
+using static LanguageExt.Pipes.Proxy;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests;
+
+public class PipesTests
+{
+    [Fact]
+    public Task MergeSynchronousProducersSucceeds() =>
+        compose(
+            Producer.merge<Runtime, int, Unit>(
+                yield(1),
+                yield(1)),
+            awaiting<int>().Map(ignore))
+        .RunEffect()
+        .RunUnit(Runtime.New())
+        .AsTask();
+}


### PR DESCRIPTION
The resulting producer of the function `Producer.merge` failed with an exception, when only synchronous producers were combined. The boolean variable `running` was set to false, before any items of the `queue` were yielded.

Fixes #1179