### PR TITLE
Add reset color function to console trait

### DIFF
--- a/LanguageExt.Sys/Live/ConsoleIO.cs
+++ b/LanguageExt.Sys/Live/ConsoleIO.cs
@@ -29,6 +29,12 @@ namespace LanguageExt.Sys.Live
             return unit;
         }
 
+        public Unit ResetColor()
+        {
+            Console.ResetColor();
+            return unit;
+        }
+
         public ConsoleColor BgColor => 
             System.Console.BackgroundColor;
         

--- a/LanguageExt.Sys/MemoryConsole.cs
+++ b/LanguageExt.Sys/MemoryConsole.cs
@@ -23,6 +23,9 @@ namespace LanguageExt.Sys
     /// </remarks>
     public class MemoryConsole : IEnumerable<string>
     {
+        const ConsoleColor DefaultBgColor = ConsoleColor.Black;
+        const ConsoleColor DefaultColor = ConsoleColor.White;
+
         readonly ConcurrentQueue<ConsoleKeyInfo> KeyboardBuffer = new();
         readonly ConcurrentStack<string> Console = new();
 
@@ -121,8 +124,15 @@ namespace LanguageExt.Sys
             return default;
         }
 
-        internal ConsoleColor BgColor { get; private set; } = ConsoleColor.Black;
-        internal ConsoleColor Color { get; private set; } = ConsoleColor.White;
+        internal Unit ResetColor()
+        {
+            BgColor = DefaultBgColor;
+            Color = DefaultColor;
+            return default;
+        }
+
+        internal ConsoleColor BgColor { get; private set; } = DefaultBgColor;
+        internal ConsoleColor Color { get; private set; } = DefaultColor;
 
         internal Option<int> Read()
         {

--- a/LanguageExt.Sys/Sys/Console.cs
+++ b/LanguageExt.Sys/Sys/Console.cs
@@ -108,6 +108,9 @@ namespace LanguageExt.Sys
         public static Eff<RT, Unit> setColor(ConsoleColor color) =>
             default(RT).ConsoleEff.Map(e => e.SetColor(color));
 
+        public static Eff<RT, Unit> resetColor() =>
+            default(RT).ConsoleEff.Map(e => e.ResetColor());
+
         public static Eff<RT, ConsoleColor> bgColor =>
             default(RT).ConsoleEff.Map(static e => e.BgColor);
 

--- a/LanguageExt.Sys/Test/ConsoleIO.cs
+++ b/LanguageExt.Sys/Test/ConsoleIO.cs
@@ -29,6 +29,9 @@ namespace LanguageExt.Sys.Test
         public Unit SetColor(ConsoleColor color) =>
             mem.SetColor(color);
 
+        public Unit ResetColor() =>
+            mem.ResetColor();
+
         public ConsoleColor BgColor => 
             mem.BgColor;
         

--- a/LanguageExt.Sys/Traits/ConsoleIO.cs
+++ b/LanguageExt.Sys/Traits/ConsoleIO.cs
@@ -15,6 +15,10 @@ namespace LanguageExt.Sys.Traits
         Unit Write(string value);
         Unit SetBgColor(ConsoleColor color);
         Unit SetColor(ConsoleColor color);
+        /// <summary>
+        /// Sets the foreground and background console colors to their defaults.
+        /// </summary>
+        Unit ResetColor();
         ConsoleColor BgColor { get; }
         ConsoleColor Color { get; }
     }

--- a/Samples/EffectsExamples/Menu.cs
+++ b/Samples/EffectsExamples/Menu.cs
@@ -36,7 +36,7 @@ namespace EffectsExamples
             from exa in findExample(ix)
             from __0 in Console<RT>.setColor(ConsoleColor.Yellow)
             from __1 in Console<RT>.writeLine(exa.Desc)
-            from __2 in Console<RT>.setColor(ConsoleColor.White)
+            from __2 in Console<RT>.resetColor()
             from res in localCancel(exa.Example) | @catch(logError)
             from __3 in showComplete(5)
             select res;

--- a/Samples/TestBed/PipesTest.cs
+++ b/Samples/TestBed/PipesTest.cs
@@ -54,7 +54,7 @@ public static class PipesTestBed
       | Pipe.mapM<Runtime, DateTime>(dt => 
             from _1 in Console<Runtime>.setColor(ConsoleColor.Green)
             from _2 in Console<Runtime>.writeLine(dt.ToLongTimeString())
-            from _3 in Console<Runtime>.setColor(ConsoleColor.White)
+            from _3 in Console<Runtime>.resetColor()
             select dt)
       | writeLine<DateTime>(); 
 }


### PR DESCRIPTION
Regarding console color handling, this is the only missing function from the BCL. Thus this commit completes the console color functionalities.