### PR TITLE
feat: Support for Random IO

### DIFF
--- a/LanguageExt.Core/Utility/Math.cs
+++ b/LanguageExt.Core/Utility/Math.cs
@@ -1,0 +1,92 @@
+﻿#nullable enable
+
+using System.Runtime.InteropServices;
+using static System.BitConverter;
+
+namespace LanguageExt;
+
+/// <summary>
+/// Provides implementations of math functions missing from the standard library 
+/// </summary>
+public static class MathExt
+{
+    /// <summary>
+    /// Gets the floating-point number that is next after <paramref name="fromNumber"/> in the direction of <paramref name="towardNumber"/>
+    /// </summary>
+    /// <remarks>See https://github.com/MachineCognitis/C.math.NET/blob/master/C.math/math.cs#L1695</remarks>
+    /// <param name="fromNumber">A floating-point number</param>
+    /// <param name="towardNumber">A floating-point number</param>
+    /// <returns>The floating-point number that is next after <paramref name="fromNumber"/> in the direction of <paramref name="towardNumber"/></returns>
+    public static double NextAfter(double fromNumber, double towardNumber)
+    {
+        // If either fromNumber or towardNumber is NaN, return NaN.
+        if (double.IsNaN(towardNumber) || double.IsNaN(fromNumber))
+            return double.NaN;
+
+        // If no direction.
+        if (fromNumber == towardNumber)
+            return towardNumber;
+
+        // If fromNumber is zero, return smallest subnormal.
+        if (fromNumber == 0)
+            return towardNumber > 0 ? double.Epsilon : -double.Epsilon;
+
+        // All other cases are handled by incrementing or decrementing the bits value.
+        // Transitions to infinity, to subnormal, and to zero are all taken care of this way.
+        var bits = DoubleToInt64Bits(fromNumber);
+        // A xor here avoids nesting conditionals. We have to increment if fromValue lies between 0 and toValue.
+        if ((fromNumber > 0) ^ (fromNumber > towardNumber))
+            bits += 1;
+        else
+            bits -= 1;
+
+        return Int64BitsToDouble(bits);
+    }
+
+    /// <summary>
+    /// For more information see https://stackoverflow.com/a/59273138
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    struct FloatToInt 
+    {
+        [FieldOffset(0)]private float f;
+        [FieldOffset(0)]private int i;
+        public static int Convert(float value) =>
+            new FloatToInt { f = value }.i;
+        public static float Convert(int value) =>
+            new FloatToInt { i = value }.f;
+    }
+    
+    /// <summary>
+    /// Gets the floating-point number that is next after <paramref name="fromNumber"/> in the direction of <paramref name="towardNumber"/>
+    /// </summary>
+    /// <remarks>See https://github.com/MachineCognitis/C.math.NET/blob/master/C.math/math.cs#L1771</remarks>
+    /// <param name="fromNumber">A floating-point number.</param>
+    /// <param name="towardNumber">A floating-point number.</param>
+    /// <returns>The floating-point number that is next after <paramref name="fromNumber"/> in the direction of <paramref name="towardNumber"/></returns>
+    public static float NextAfter(float fromNumber, float towardNumber)
+    {
+        // If either fromNumber or towardNumber is NaN, return NaN.
+        if (float.IsNaN(towardNumber) || float.IsNaN(fromNumber))
+            return float.NaN;
+
+        // If no direction or if fromNumber is infinity or is not a number, return fromNumber.
+        if (fromNumber == towardNumber)
+            return towardNumber;
+
+        // If fromNumber is zero, return smallest subnormal.
+        if (fromNumber == 0)
+            return towardNumber > 0 ? float.Epsilon : -float.Epsilon;
+
+        // All other cases are handled by incrementing or decrementing the bits value.
+        // Transitions to infinity, to subnormal, and to zero are all taken care of this way.
+        var bits = FloatToInt.Convert(fromNumber);
+        // A xor here avoids nesting conditionals. We have to increment if fromValue lies between 0 and toValue.
+        if ((fromNumber > 0) ^ (fromNumber > towardNumber))
+            bits += 1;
+        else
+            bits -= 1;
+
+        return FloatToInt.Convert(bits);
+    }
+}

--- a/LanguageExt.Sys/Live/RandomIO.cs
+++ b/LanguageExt.Sys/Live/RandomIO.cs
@@ -23,7 +23,8 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
     public int NextInt(int? min = default, int? max = default) =>
         (min, max) switch
         {
-            ({ } m, { } mx) => _rng.Next(m, mx),
+            ({ } m, { } mx) when m <= mx => _rng.Next(m, mx),
+            ({ } m, { } mx) when m >= mx => _rng.Next(mx,m),
             (_, { } mx) => _rng.Next(mx),
             _ => _rng.Next()
         };

--- a/LanguageExt.Sys/Live/RandomIO.cs
+++ b/LanguageExt.Sys/Live/RandomIO.cs
@@ -1,0 +1,78 @@
+﻿#nullable enable
+
+using System;
+
+namespace LanguageExt.Sys.Live;
+
+/// <summary>
+/// Live random access
+/// </summary>
+public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
+{
+    private readonly Random _rng;
+
+    public RandomIO(Random rng) =>
+        _rng = rng;
+
+    /// <summary>
+    /// Returns a non-negative int
+    /// </summary>
+    /// <param name="min">minimum int to return</param>
+    /// <param name="max">maximum int to return</param>
+    /// <returns>int</returns>
+    public int GenerateInt(int? min = default, int? max = default) =>
+        (min, max) switch
+        {
+            ({ } m, { } mx) => _rng.Next(m, mx),
+            (_, { } mx) => _rng.Next(mx),
+            _ => _rng.Next()
+        };
+
+    /// <summary>
+    /// Fills the elements of a specified array of bytes with random numbers
+    /// </summary>
+    /// <param name="length">number of bytes to fill</param>
+    /// <returns>bytes</returns>
+    public byte[] GenerateByteArray(long length)
+    {
+        var array = new byte[length];
+        _rng.NextBytes(array);
+        return array;
+    }
+
+    /// <summary>
+    /// Returns a non-negative double
+    /// </summary>
+    /// <returns>double</returns>
+    public double GenerateDouble() =>
+        _rng.NextDouble();
+
+    /// <summary>
+    /// Returns a non-negative long
+    /// </summary>
+    /// <returns>long</returns>
+    public long GenerateLong()
+    {
+        var buf = new byte[8];
+        _rng.NextBytes(buf);
+        return Math.Abs(BitConverter.ToInt64(buf, 0));
+    }
+
+    /// <summary>
+    /// Returns a non-negative float
+    /// </summary>
+    /// <returns>float</returns>
+    public float GenerateFloat()
+    {
+        var buffer = new byte[4];
+        _rng.NextBytes(buffer);
+        return Math.Abs(BitConverter.ToSingle(buffer, 0));
+    }
+
+    /// <summary>
+    /// Returns a non-negative guid
+    /// </summary>
+    /// <returns>guid</returns>
+    public Guid GenerateGuid() =>
+        Guid.NewGuid();
+}

--- a/LanguageExt.Sys/Live/RandomIO.cs
+++ b/LanguageExt.Sys/Live/RandomIO.cs
@@ -20,7 +20,7 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// <param name="min">minimum int to return</param>
     /// <param name="max">maximum int to return</param>
     /// <returns>int</returns>
-    public int GenerateInt(int? min = default, int? max = default) =>
+    public int NextInt(int? min = default, int? max = default) =>
         (min, max) switch
         {
             ({ } m, { } mx) => _rng.Next(m, mx),
@@ -29,11 +29,11 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
         };
 
     /// <summary>
-    /// Fills the elements of a specified array of bytes with random numbers
+    /// Returns an array of bytes with random numbers
     /// </summary>
     /// <param name="length">number of bytes to fill</param>
     /// <returns>bytes</returns>
-    public byte[] GenerateByteArray(long length)
+    public byte[] NextByteArray(long length)
     {
         var array = new byte[length];
         _rng.NextBytes(array);
@@ -44,14 +44,14 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative double
     /// </summary>
     /// <returns>double</returns>
-    public double GenerateDouble() =>
+    public double NextDouble() =>
         _rng.NextDouble();
 
     /// <summary>
     /// Returns a non-negative long
     /// </summary>
     /// <returns>long</returns>
-    public long GenerateLong()
+    public long NextLong()
     {
         var buf = new byte[8];
         _rng.NextBytes(buf);
@@ -62,7 +62,7 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative float
     /// </summary>
     /// <returns>float</returns>
-    public float GenerateFloat()
+    public float NextFloat()
     {
         var buffer = new byte[4];
         _rng.NextBytes(buffer);
@@ -73,6 +73,6 @@ public struct RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative guid
     /// </summary>
     /// <returns>guid</returns>
-    public Guid GenerateGuid() =>
+    public Guid NextGuid() =>
         Guid.NewGuid();
 }

--- a/LanguageExt.Sys/Live/Runtime.cs
+++ b/LanguageExt.Sys/Live/Runtime.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Text;
 using System.Threading;
@@ -19,7 +21,8 @@ namespace LanguageExt.Sys.Live
         HasTextRead<Runtime>,
         HasTime<Runtime>,
         HasEnvironment<Runtime>,
-        HasDirectory<Runtime>
+        HasDirectory<Runtime>,
+        HasRandom<Runtime>
     {
         readonly RuntimeEnv env;
 
@@ -133,6 +136,13 @@ namespace LanguageExt.Sys.Live
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, Traits.EnvironmentIO> EnvironmentEff =>
             SuccessEff(Sys.Live.EnvironmentIO.Default);
+        
+        /// <summary>
+        /// Access the random synchronous effect environment
+        /// </summary>
+        /// <returns>Random synchronous effect environment</returns>
+        public Eff<Runtime, Traits.RandomIO> RandomEff =>
+            SuccessEff<Runtime, Traits.RandomIO>(new Sys.Live.RandomIO(new Random()));
     }
     
     public class RuntimeEnv

--- a/LanguageExt.Sys/Live/Runtime.cs
+++ b/LanguageExt.Sys/Live/Runtime.cs
@@ -41,30 +41,34 @@ namespace LanguageExt.Sys.Live
         /// <summary>
         /// Constructor function
         /// </summary>
-        public static Runtime New() =>
-            new Runtime(new RuntimeEnv(new CancellationTokenSource(), System.Text.Encoding.Default));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(int? seed = default) =>
+            new Runtime(new RuntimeEnv(new CancellationTokenSource(), Encoding.Default, seed));
 
         /// <summary>
         /// Constructor function
         /// </summary>
         /// <param name="source">Cancellation token source</param>
-        public static Runtime New(CancellationTokenSource source) =>
-            new Runtime(new RuntimeEnv(source, System.Text.Encoding.Default));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(CancellationTokenSource source, int? seed = default) =>
+            new Runtime(new RuntimeEnv(source, Encoding.Default, seed));
 
         /// <summary>
         /// Constructor function
         /// </summary>
         /// <param name="encoding">Text encoding</param>
-        public static Runtime New(Encoding encoding) =>
-            new Runtime(new RuntimeEnv(new CancellationTokenSource(), encoding));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(Encoding encoding, int? seed = default) =>
+            new Runtime(new RuntimeEnv(new CancellationTokenSource(), encoding, seed));
 
         /// <summary>
         /// Constructor function
         /// </summary>
         /// <param name="encoding">Text encoding</param>
         /// <param name="source">Cancellation token source</param>
-        public static Runtime New(Encoding encoding, CancellationTokenSource source) =>
-            new Runtime(new RuntimeEnv(source, encoding));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(Encoding encoding, CancellationTokenSource source, int? seed = default) =>
+            new Runtime(new RuntimeEnv(source, encoding, seed));
 
         /// <summary>
         /// Create a new Runtime with a fresh cancellation token
@@ -99,42 +103,42 @@ namespace LanguageExt.Sys.Live
         /// </summary>
         /// <returns>Console environment</returns>
         public Eff<Runtime, Traits.ConsoleIO> ConsoleEff =>
-            SuccessEff(Sys.Live.ConsoleIO.Default);
+            SuccessEff(ConsoleIO.Default);
 
         /// <summary>
         /// Access the file environment
         /// </summary>
         /// <returns>File environment</returns>
         public Eff<Runtime, Traits.FileIO> FileEff =>
-            SuccessEff(Sys.Live.FileIO.Default);
+            SuccessEff(FileIO.Default);
 
         /// <summary>
         /// Access the directory environment
         /// </summary>
         /// <returns>Directory environment</returns>
         public Eff<Runtime, Traits.DirectoryIO> DirectoryEff =>
-            SuccessEff(Sys.Live.DirectoryIO.Default);
+            SuccessEff(DirectoryIO.Default);
 
         /// <summary>
         /// Access the TextReader environment
         /// </summary>
         /// <returns>TextReader environment</returns>
         public Eff<Runtime, Traits.TextReadIO> TextReadEff =>
-            SuccessEff(Sys.Live.TextReadIO.Default);
+            SuccessEff(TextReadIO.Default);
 
         /// <summary>
         /// Access the time environment
         /// </summary>
         /// <returns>Time environment</returns>
         public Eff<Runtime, Traits.TimeIO> TimeEff  =>
-            SuccessEff(Sys.Live.TimeIO.Default);
+            SuccessEff(TimeIO.Default);
 
         /// <summary>
         /// Access the operating-system environment
         /// </summary>
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, Traits.EnvironmentIO> EnvironmentEff =>
-            SuccessEff(Sys.Live.EnvironmentIO.Default);
+            SuccessEff(EnvironmentIO.Default);
 
         /// <summary>
         /// Creates a new runtime from this with a new Random IO and optional seed
@@ -167,7 +171,7 @@ namespace LanguageExt.Sys.Live
             Random = RandomIO.New(seed);
         }
 
-        public RuntimeEnv(CancellationTokenSource source, Encoding encoding) : this(source, source.Token, encoding)
+        public RuntimeEnv(CancellationTokenSource source, Encoding encoding, int? seed = default) : this(source, source.Token, encoding, seed)
         {
         }
 

--- a/LanguageExt.Sys/Live/Runtime.cs
+++ b/LanguageExt.Sys/Live/Runtime.cs
@@ -159,12 +159,12 @@ namespace LanguageExt.Sys.Live
         public readonly Encoding Encoding;
         public readonly Traits.RandomIO Random;
 
-        public RuntimeEnv(CancellationTokenSource source, CancellationToken token, Encoding encoding, Random? randomProvider = default)
+        public RuntimeEnv(CancellationTokenSource source, CancellationToken token, Encoding encoding, int? seed = default)
         {
             Source   = source;
             Token    = token;
             Encoding = encoding;
-            Random = new RandomIO(randomProvider ?? new Random());
+            Random = RandomIO.New(seed);
         }
 
         public RuntimeEnv(CancellationTokenSource source, Encoding encoding) : this(source, source.Token, encoding)
@@ -172,6 +172,6 @@ namespace LanguageExt.Sys.Live
         }
 
         public RuntimeEnv LocalRandom(int? seed = default) =>
-            new RuntimeEnv(Source, Token, Encoding, seed != null ? new Random(seed.Value) : new Random()); 
+            new RuntimeEnv(Source, Token, Encoding, seed); 
     }
 }

--- a/LanguageExt.Sys/Sys/Random.cs
+++ b/LanguageExt.Sys/Sys/Random.cs
@@ -1,0 +1,219 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using LanguageExt.ClassInstances.Pred;
+using LanguageExt.Sys.Traits;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Sys;
+
+/// <summary>
+/// Random IO
+/// </summary>
+/// <typeparam name="RT">runtime</typeparam>
+public static class Random<RT> where RT : struct, HasRandom<RT>
+{
+    /// <summary>
+    /// Returns a non-negative int
+    /// </summary>
+    /// <param name="min">minimum int to return</param>
+    /// <param name="max">maximum int to return</param>
+    /// <returns>int</returns>
+    [Pure]
+    public static Eff<RT, int> generateInt(int? min = default, int? max = default) =>
+        default(RT).RandomEff.Map(io => io.GenerateInt(min, max));
+
+    /// <summary>
+    /// Fills the elements of a specified array of bytes with random numbers
+    /// </summary>
+    /// <param name="length">number of bytes to fill</param>
+    [Pure]
+    public static Eff<RT, byte[]> generateByteArray(long length) =>
+        default(RT).RandomEff.Map(io => io.GenerateByteArray(length));
+
+    /// <summary>
+    /// Returns a non-negative double
+    /// </summary>
+    /// <param name="min">minimum double to return</param>
+    /// <param name="max">maximum double to return</param>
+    /// <returns>double</returns>
+    [Pure]
+    public static Eff<RT, double> generateDouble(double? min = default, double? max = default)
+    {
+        var minV = min ?? 0.0;
+        var maxV = max ?? 1.0;
+        return default(RT).RandomEff.Map(static io => io.GenerateDouble()).Map(d => d % (maxV - minV) + minV);
+    }
+
+    /// <summary>
+    /// Returns a non-negative long
+    /// </summary>
+    /// <param name="min">minimum long to return</param>
+    /// <param name="max">maximum long to return</param>
+    /// <returns>long</returns>
+    [Pure]
+    public static Eff<RT, long> generateLong(long? min = default, long? max = default)
+    {
+        var minV = min ?? 0;
+        var maxV = max ?? long.MaxValue;
+        return default(RT).RandomEff.Map(static io => io.GenerateLong()).Map(l => l % (maxV - minV) + minV);
+    }
+
+    /// <summary>
+    /// Returns a non-negative float
+    /// </summary>
+    /// <param name="min">minimum float to return</param>
+    /// <param name="max">maximum float to return</param>
+    /// <returns>float</returns>
+    [Pure]
+    public static Eff<RT, float> generateFloat(float? min = default, float? max = default)
+    {
+        var minV = min ?? 0.0f;
+        var maxV = max ?? float.MaxValue;
+        return default(RT).RandomEff.Map(static io => io.GenerateFloat()).Map(d => d % (maxV - minV) + minV);
+    }
+
+    /// <summary>
+    /// Returns a non-negative guid
+    /// </summary>
+    /// <returns>guid</returns>
+    [Pure]
+    public static Eff<RT, Guid> generateGuid() =>
+        default(RT).RandomEff.Map(static io => io.GenerateGuid());
+
+    /// <summary>
+    /// Returns a random character
+    /// </summary>
+    /// <param name="min">min char</param>
+    /// <param name="max">max char</param>
+    /// <returns>char</returns>
+    public static Eff<RT, char> generateChar(char? min = default, char? max = default) =>
+        generateInt(min ?? 32, max ?? 126).Map(static i => (char)i);
+
+    /// <summary>
+    /// Random duration
+    /// </summary>
+    /// <param name="min">min duration</param>
+    /// <param name="max">max duration</param>
+    /// <returns>random duration</returns>
+    [Pure]
+    public static Eff<RT, Duration> generateDuration(Duration? min = default, Duration? max = default) =>
+        generateDouble(min, max).Map(static d => (Duration)d);
+
+    /// <summary>
+    /// Random time span
+    /// </summary>
+    /// <param name="min">min duration</param>
+    /// <param name="max">max duration</param>
+    /// <returns>random time span</returns>
+    [Pure]
+    public static Eff<RT, TimeSpan> generateTimespan(Duration? min = default, Duration? max = default) =>
+        generateDuration(min, max).Map(static d => (TimeSpan)d);
+
+    /// <summary>
+    /// Random date time with offset
+    /// </summary>
+    /// <param name="min">min duration</param>
+    /// <param name="max">max duration</param>
+    /// <returns>random date time offset</returns>
+    [Pure]
+    public static Eff<RT, DateTimeOffset> generateDateTimeOffset(
+        DateTimeOffset? min = default,
+        DateTimeOffset? max = default) =>
+        generateLong(
+                (min ?? DateTimeOffset.MinValue).ToUnixTimeMilliseconds(),
+                (max ?? DateTimeOffset.MaxValue).ToUnixTimeMilliseconds())
+            .Map(static ticks => new DateTimeOffset(ticks, TimeSpan.Zero));
+
+    /// <summary>
+    /// Random date time
+    /// </summary>
+    /// <param name="min">min duration</param>
+    /// <param name="max">max duration</param>
+    /// <returns>random date time</returns>
+    [Pure]
+    public static Eff<RT, DateTime> generateDateTime(DateTime? min = default, DateTime? max = default) =>
+        generateDateTimeOffset(min, max).Map(static dto => dto.UtcDateTime);
+
+    /// <summary>
+    /// Random length enumerable T
+    /// </summary>
+    /// <param name="effect">effect T</param>
+    /// <param name="min">min length</param>
+    /// <param name="max">max length</param>
+    /// <typeparam name="T">some T</typeparam>
+    /// <returns>enumerable of T</returns>
+    public static Eff<RT, IEnumerable<T>> generateRange<T>(
+        Eff<RT, T> effect,
+        int? min = default,
+        int? max = default) =>
+        generateInt(Math.Abs(min ?? 0), max ?? 1000)
+            .Bind(length => Range(0, length).Select(_ => effect).Sequence());
+
+    /// <summary>
+    /// Generates a random string
+    /// </summary>
+    /// <param name="min">min length</param>
+    /// <param name="max">max length</param>
+    /// <param name="minChar">min char</param>
+    /// <param name="maxChar">max char</param>
+    /// <returns>string</returns>
+    public static Eff<RT, string> generateString(
+        int? min = default,
+        int? max = default,
+        char? minChar = default,
+        char? maxChar = default) =>
+        generateRange(generateChar(minChar, maxChar), min, max ?? 100)
+            .Map(x => new string(x.ToArray()));
+
+    /// <summary>
+    /// Returns a random element with an equal probability
+    /// </summary>
+    /// <param name="elements">list of elements</param>
+    /// <typeparam name="T">some T</typeparam>
+    /// <returns>random T</returns>
+    public static Eff<RT, T> uniform<T>(Lst<NonEmpty, T> elements) =>
+        generateInt(0, elements.Count - 1).Map(i => elements[i]);
+
+    /// <summary>
+    /// Returns a random element with a weighted probability
+    /// </summary>
+    /// <param name="elements">weighted list of elements</param>
+    /// <typeparam name="T">some T</typeparam>
+    /// <returns>random T</returns>
+    public static Eff<RT, T> weighted<T>(Lst<NonEmpty, (int weight, T element)> elements)
+    {
+        var el = elements.Map(x => x with { weight = Math.Abs(x.weight) });
+        return generateInt(0, el.Sum(x => x.weight))
+            .Map(rand =>
+                {
+                    var sum = 0;
+                    return el.First(x =>
+                            {
+                                sum += x.weight;
+                                return rand < sum;
+                            }).element;
+                });
+    }
+
+    /// <summary>
+    /// Returns a random enum from the enumeration
+    /// </summary>
+    /// <typeparam name="E">enum</typeparam>
+    /// <returns>enum</returns>
+    public static Eff<RT, E> generateEnum<E>() where E : struct, Enum
+    {
+        var values = Enum.GetValues(typeof(E)).OfType<E>().ToArr();
+        return uniform<E>(List(values[0], values.Tail().ToArray()));
+    }
+
+    /// <summary>
+    /// Returns a random boolean
+    /// </summary>
+    /// <returns>enum</returns>
+    public static Eff<RT, bool> generateBool() =>
+        uniform<bool>(List(true, false));
+}

--- a/LanguageExt.Sys/Sys/Random.cs
+++ b/LanguageExt.Sys/Sys/Random.cs
@@ -18,6 +18,16 @@ namespace LanguageExt.Sys;
 /// <typeparam name="RT">runtime</typeparam>
 public static class Random<RT> where RT : struct, HasRandom<RT>
 {
+    /// <summary>
+    /// Create a new random context and run the provided Eff in that context
+    /// </summary>
+    /// <param name="ma">Operation to run in the next context</param>
+    /// <param name="seed">optional seed for the random instance</param>
+    /// <typeparam name="A">Bound value type</typeparam>
+    /// <returns>An effect that captures the operation running in context</returns>
+    public static Eff<RT, A> localRandom<A>(Eff<RT, A> ma, int? seed = default) => 
+        EffMaybe<RT, A>(rt => ma.Run(rt.LocalRandom(seed)));
+    
     [Pure]
     static (T min, T max) ensureBounds<T, TNum>(T min, T max) where TNum : struct, Ord<T> 
     {

--- a/LanguageExt.Sys/Sys/Random.cs
+++ b/LanguageExt.Sys/Sys/Random.cs
@@ -225,17 +225,14 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     {
         var el = elements.Map(x => x with { weight = Math.Abs(x.weight) });
         return nextInt(0, el.Sum(x => x.weight))
-            .Map(
-                rand =>
+            .Map(rand =>
                 {
                     var sum = 0;
-                    return el.First(
-                            x =>
+                    return el.First(x =>
                             {
                                 sum += x.weight;
                                 return rand < sum;
-                            })
-                        .element;
+                            }).element;
                 });
     }
 

--- a/LanguageExt.Sys/Sys/Random.cs
+++ b/LanguageExt.Sys/Sys/Random.cs
@@ -4,8 +4,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using LanguageExt.ClassInstances;
 using LanguageExt.ClassInstances.Pred;
 using LanguageExt.Sys.Traits;
+using LanguageExt.TypeClasses;
 using static LanguageExt.Prelude;
 
 namespace LanguageExt.Sys;
@@ -23,16 +25,26 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">maximum int to return</param>
     /// <returns>int</returns>
     [Pure]
-    public static Eff<RT, int> generateInt(int? min = default, int? max = default) =>
-        default(RT).RandomEff.Map(io => io.GenerateInt(min, max));
+    public static Eff<RT, int> nextInt(int? min = default, int? max = default) =>
+        default(RT).RandomEff.Map(io => io.NextInt(min, max));
 
     /// <summary>
     /// Fills the elements of a specified array of bytes with random numbers
     /// </summary>
     /// <param name="length">number of bytes to fill</param>
     [Pure]
-    public static Eff<RT, byte[]> generateByteArray(long length) =>
-        default(RT).RandomEff.Map(io => io.GenerateByteArray(length));
+    public static Eff<RT, byte[]> nextByteArray(long length) =>
+        default(RT).RandomEff.Map(io => io.NextByteArray(length));
+
+    [Pure]
+    static Eff<RT, (T result, T min, T max)> bounded<T, TNum>(Eff<RT, T> effect, T min, T max)
+        where TNum : struct, Ord<T> =>
+        effect.Map(r =>
+            {
+                min = default(TNum).Compare(min, max) == -1 ? min : max;
+                max = default(TNum).Compare(max, min) == 1 ? max : min;
+                return (r, min, max);
+            });
 
     /// <summary>
     /// Returns a non-negative double
@@ -41,12 +53,12 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">maximum double to return</param>
     /// <returns>double</returns>
     [Pure]
-    public static Eff<RT, double> generateDouble(double? min = default, double? max = default)
-    {
-        var minV = min ?? 0.0;
-        var maxV = max ?? 1.0;
-        return default(RT).RandomEff.Map(static io => io.GenerateDouble()).Map(d => d % (maxV - minV) + minV);
-    }
+    public static Eff<RT, double> nextDouble(double? min = default, double? max = default) =>
+        bounded<double, TDouble>(
+                default(RT).RandomEff.Map(static io => io.NextDouble()),
+                min ?? 0.0,
+                max ?? 1.0)
+            .Map(static t => t.result % (t.max - t.min) + t.min);
 
     /// <summary>
     /// Returns a non-negative long
@@ -55,12 +67,12 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">maximum long to return</param>
     /// <returns>long</returns>
     [Pure]
-    public static Eff<RT, long> generateLong(long? min = default, long? max = default)
-    {
-        var minV = min ?? 0;
-        var maxV = max ?? long.MaxValue;
-        return default(RT).RandomEff.Map(static io => io.GenerateLong()).Map(l => l % (maxV - minV) + minV);
-    }
+    public static Eff<RT, long> nextLong(long? min = default, long? max = default) =>
+        bounded<long, TLong>(
+            default(RT).RandomEff.Map(static io => io.NextLong()),
+            min ?? 0,
+            max ?? long.MaxValue)
+            .Map(static t => t.result % (t.max - t.min) + t.min);
 
     /// <summary>
     /// Returns a non-negative float
@@ -69,20 +81,20 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">maximum float to return</param>
     /// <returns>float</returns>
     [Pure]
-    public static Eff<RT, float> generateFloat(float? min = default, float? max = default)
-    {
-        var minV = min ?? 0.0f;
-        var maxV = max ?? float.MaxValue;
-        return default(RT).RandomEff.Map(static io => io.GenerateFloat()).Map(d => d % (maxV - minV) + minV);
-    }
+    public static Eff<RT, float> nextFloat(float? min = default, float? max = default) =>
+        bounded<float, TFloat>(
+            default(RT).RandomEff.Map(static io => io.NextFloat()),
+            min ?? 0.0f,
+            max ?? float.MaxValue)
+            .Map(static t => t.result % (t.max - t.min) + t.min);
 
     /// <summary>
     /// Returns a non-negative guid
     /// </summary>
     /// <returns>guid</returns>
     [Pure]
-    public static Eff<RT, Guid> generateGuid() =>
-        default(RT).RandomEff.Map(static io => io.GenerateGuid());
+    public static Eff<RT, Guid> nextGuid() =>
+        default(RT).RandomEff.Map(static io => io.NextGuid());
 
     /// <summary>
     /// Returns a random character
@@ -90,8 +102,8 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="min">min char</param>
     /// <param name="max">max char</param>
     /// <returns>char</returns>
-    public static Eff<RT, char> generateChar(char? min = default, char? max = default) =>
-        generateInt(min ?? 32, max ?? 126).Map(static i => (char)i);
+    public static Eff<RT, char> nextChar(char? min = default, char? max = default) =>
+        nextInt(min ?? 32, max ?? 126).Map(static i => (char)i);
 
     /// <summary>
     /// Random duration
@@ -100,8 +112,8 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">max duration</param>
     /// <returns>random duration</returns>
     [Pure]
-    public static Eff<RT, Duration> generateDuration(Duration? min = default, Duration? max = default) =>
-        generateDouble(min, max).Map(static d => (Duration)d);
+    public static Eff<RT, Duration> nextDuration(Duration? min = default, Duration? max = default) =>
+        nextDouble(min, max).Map(static d => (Duration)d);
 
     /// <summary>
     /// Random time span
@@ -110,8 +122,8 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">max duration</param>
     /// <returns>random time span</returns>
     [Pure]
-    public static Eff<RT, TimeSpan> generateTimespan(Duration? min = default, Duration? max = default) =>
-        generateDuration(min, max).Map(static d => (TimeSpan)d);
+    public static Eff<RT, TimeSpan> nextTimespan(Duration? min = default, Duration? max = default) =>
+        nextDuration(min, max).Map(static d => (TimeSpan)d);
 
     /// <summary>
     /// Random date time with offset
@@ -120,10 +132,10 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">max duration</param>
     /// <returns>random date time offset</returns>
     [Pure]
-    public static Eff<RT, DateTimeOffset> generateDateTimeOffset(
+    public static Eff<RT, DateTimeOffset> nextDateTimeOffset(
         DateTimeOffset? min = default,
         DateTimeOffset? max = default) =>
-        generateLong(
+        nextLong(
                 (min ?? DateTimeOffset.MinValue).ToUnixTimeMilliseconds(),
                 (max ?? DateTimeOffset.MaxValue).ToUnixTimeMilliseconds())
             .Map(static ticks => new DateTimeOffset(ticks, TimeSpan.Zero));
@@ -135,8 +147,8 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">max duration</param>
     /// <returns>random date time</returns>
     [Pure]
-    public static Eff<RT, DateTime> generateDateTime(DateTime? min = default, DateTime? max = default) =>
-        generateDateTimeOffset(min, max).Map(static dto => dto.UtcDateTime);
+    public static Eff<RT, DateTime> nextDateTime(DateTime? min = default, DateTime? max = default) =>
+        nextDateTimeOffset(min, max).Map(static dto => dto.UtcDateTime);
 
     /// <summary>
     /// Random length enumerable T
@@ -146,11 +158,11 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="max">max length</param>
     /// <typeparam name="T">some T</typeparam>
     /// <returns>enumerable of T</returns>
-    public static Eff<RT, IEnumerable<T>> generateRange<T>(
+    public static Eff<RT, IEnumerable<T>> nextRange<T>(
         Eff<RT, T> effect,
         int? min = default,
         int? max = default) =>
-        generateInt(Math.Abs(min ?? 0), max ?? 1000)
+        nextInt(Math.Abs(min ?? 0), max ?? 1000)
             .Bind(length => Range(0, length).Select(_ => effect).Sequence());
 
     /// <summary>
@@ -161,12 +173,12 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <param name="minChar">min char</param>
     /// <param name="maxChar">max char</param>
     /// <returns>string</returns>
-    public static Eff<RT, string> generateString(
+    public static Eff<RT, string> nextString(
         int? min = default,
         int? max = default,
         char? minChar = default,
         char? maxChar = default) =>
-        generateRange(generateChar(minChar, maxChar), min, max ?? 100)
+        nextRange(nextChar(minChar, maxChar), min, max ?? 100)
             .Map(x => new string(x.ToArray()));
 
     /// <summary>
@@ -176,7 +188,7 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// <typeparam name="T">some T</typeparam>
     /// <returns>random T</returns>
     public static Eff<RT, T> uniform<T>(Lst<NonEmpty, T> elements) =>
-        generateInt(0, elements.Count - 1).Map(i => elements[i]);
+        nextInt(0, elements.Count - 1).Map(i => elements[i]);
 
     /// <summary>
     /// Returns a random element with a weighted probability
@@ -187,15 +199,18 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     public static Eff<RT, T> weighted<T>(Lst<NonEmpty, (int weight, T element)> elements)
     {
         var el = elements.Map(x => x with { weight = Math.Abs(x.weight) });
-        return generateInt(0, el.Sum(x => x.weight))
-            .Map(rand =>
+        return nextInt(0, el.Sum(x => x.weight))
+            .Map(
+                rand =>
                 {
                     var sum = 0;
-                    return el.First(x =>
+                    return el.First(
+                            x =>
                             {
                                 sum += x.weight;
                                 return rand < sum;
-                            }).element;
+                            })
+                        .element;
                 });
     }
 
@@ -204,7 +219,7 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// </summary>
     /// <typeparam name="E">enum</typeparam>
     /// <returns>enum</returns>
-    public static Eff<RT, E> generateEnum<E>() where E : struct, Enum
+    public static Eff<RT, E> nextEnum<E>() where E : struct, Enum
     {
         var values = Enum.GetValues(typeof(E)).OfType<E>().ToArr();
         return uniform<E>(List(values[0], values.Tail().ToArray()));
@@ -214,6 +229,6 @@ public static class Random<RT> where RT : struct, HasRandom<RT>
     /// Returns a random boolean
     /// </summary>
     /// <returns>enum</returns>
-    public static Eff<RT, bool> generateBool() =>
+    public static Eff<RT, bool> nextBool() =>
         uniform<bool>(List(true, false));
 }

--- a/LanguageExt.Sys/Test/RandomIO.cs
+++ b/LanguageExt.Sys/Test/RandomIO.cs
@@ -23,7 +23,8 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     public int NextInt(int? min = default, int? max = default) =>
         (min, max) switch
         {
-            ({ } m, { } mx) => _rng.Next(m, mx),
+            ({ } m, { } mx) when m <= mx => _rng.Next(m, mx),
+            ({ } m, { } mx) when m >= mx => _rng.Next(mx,m),
             (_, { } mx) => _rng.Next(mx),
             _ => _rng.Next()
         };

--- a/LanguageExt.Sys/Test/RandomIO.cs
+++ b/LanguageExt.Sys/Test/RandomIO.cs
@@ -9,25 +9,39 @@ namespace LanguageExt.Sys.Test;
 /// </summary>
 public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
 {
+    public const int Seed = 123456789;
+    
     readonly Random _rng;
 
     public RandomIO(int seed) => 
         _rng = new Random(seed);
 
     /// <summary>
+    /// Creates a new seeded instance of random IO
+    /// </summary>
+    /// <param name="seed">seed</param>
+    /// <returns>random IO</returns>
+    public static RandomIO New(int seed = Seed) => new(seed);
+    
+    /// <summary>
     /// Returns a non-negative int
     /// </summary>
     /// <param name="min">minimum int to return</param>
     /// <param name="max">maximum int to return</param>
     /// <returns>int</returns>
-    public int NextInt(int? min = default, int? max = default) =>
-        (min, max) switch
+    public int NextInt(int? min = default, int? max = default)
+    {
+        lock (_rng)
         {
-            ({ } m, { } mx) when m <= mx => _rng.Next(m, mx),
-            ({ } m, { } mx) when m >= mx => _rng.Next(mx,m),
-            (_, { } mx) => _rng.Next(mx),
-            _ => _rng.Next()
-        };
+            return (min, max) switch
+            {
+                ({ } m, { } mx) when m <= mx => _rng.Next(m, mx),
+                ({ } m, { } mx) when m >= mx => _rng.Next(mx, m),
+                (_, { } mx) => _rng.Next(mx),
+                _ => _rng.Next()
+            };
+        }
+    }
 
     /// <summary>
     /// Returns an array of bytes with random numbers
@@ -36,17 +50,25 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// <returns>bytes</returns>
     public byte[] NextByteArray(long length)
     {
-        var array = new byte[length];
-        _rng.NextBytes(array);
-        return array;
+        lock (_rng)
+        {
+            var array = new byte[length];
+            _rng.NextBytes(array);
+            return array;
+        }
     }
 
     /// <summary>
     /// Returns a non-negative double
     /// </summary>
     /// <returns>double</returns>
-    public double NextDouble() => 
-        _rng.NextDouble();
+    public double NextDouble()
+    {
+        lock (_rng)
+        {
+            return _rng.NextDouble();
+        }
+    }
 
     /// <summary>
     /// Returns a non-negative long
@@ -54,9 +76,12 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// <returns>long</returns>
     public long NextLong()
     {
-        var buf = new byte[8];
-        _rng.NextBytes(buf);
-        return Math.Abs(BitConverter.ToInt64(buf, 0));
+        lock (_rng)
+        {
+            var buf = new byte[8];
+            _rng.NextBytes(buf);
+            return Math.Abs(BitConverter.ToInt64(buf, 0));
+        }
     }
 
     /// <summary>
@@ -65,9 +90,12 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// <returns>float</returns>
     public float NextFloat()
     {
-        var buffer = new byte[4];
-        _rng.NextBytes(buffer);
-        return Math.Abs(BitConverter.ToSingle(buffer, 0));
+        lock (_rng)
+        {
+            var buffer = new byte[4];
+            _rng.NextBytes(buffer);
+            return Math.Abs(BitConverter.ToSingle(buffer, 0));
+        }
     }
 
     /// <summary>

--- a/LanguageExt.Sys/Test/RandomIO.cs
+++ b/LanguageExt.Sys/Test/RandomIO.cs
@@ -20,7 +20,7 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// <param name="min">minimum int to return</param>
     /// <param name="max">maximum int to return</param>
     /// <returns>int</returns>
-    public int GenerateInt(int? min = default, int? max = default) =>
+    public int NextInt(int? min = default, int? max = default) =>
         (min, max) switch
         {
             ({ } m, { } mx) => _rng.Next(m, mx),
@@ -29,11 +29,11 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
         };
 
     /// <summary>
-    /// Fills the elements of a specified array of bytes with random numbers
+    /// Returns an array of bytes with random numbers
     /// </summary>
     /// <param name="length">number of bytes to fill</param>
     /// <returns>bytes</returns>
-    public byte[] GenerateByteArray(long length)
+    public byte[] NextByteArray(long length)
     {
         var array = new byte[length];
         _rng.NextBytes(array);
@@ -44,14 +44,14 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative double
     /// </summary>
     /// <returns>double</returns>
-    public double GenerateDouble() => 
+    public double NextDouble() => 
         _rng.NextDouble();
 
     /// <summary>
     /// Returns a non-negative long
     /// </summary>
     /// <returns>long</returns>
-    public long GenerateLong()
+    public long NextLong()
     {
         var buf = new byte[8];
         _rng.NextBytes(buf);
@@ -62,7 +62,7 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative float
     /// </summary>
     /// <returns>float</returns>
-    public float GenerateFloat()
+    public float NextFloat()
     {
         var buffer = new byte[4];
         _rng.NextBytes(buffer);
@@ -73,6 +73,6 @@ public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
     /// Returns a non-negative guid
     /// </summary>
     /// <returns>guid</returns>
-    public Guid GenerateGuid() =>
-        new(GenerateByteArray(16));
+    public Guid NextGuid() =>
+        new(NextByteArray(16));
 }

--- a/LanguageExt.Sys/Test/RandomIO.cs
+++ b/LanguageExt.Sys/Test/RandomIO.cs
@@ -1,0 +1,78 @@
+﻿#nullable enable
+
+using System;
+
+namespace LanguageExt.Sys.Test;
+
+/// <summary>
+/// Test random access, controlled with a provided seed
+/// </summary>
+public sealed class RandomIO : LanguageExt.Sys.Traits.RandomIO
+{
+    readonly Random _rng;
+
+    public RandomIO(int seed) => 
+        _rng = new Random(seed);
+
+    /// <summary>
+    /// Returns a non-negative int
+    /// </summary>
+    /// <param name="min">minimum int to return</param>
+    /// <param name="max">maximum int to return</param>
+    /// <returns>int</returns>
+    public int GenerateInt(int? min = default, int? max = default) =>
+        (min, max) switch
+        {
+            ({ } m, { } mx) => _rng.Next(m, mx),
+            (_, { } mx) => _rng.Next(mx),
+            _ => _rng.Next()
+        };
+
+    /// <summary>
+    /// Fills the elements of a specified array of bytes with random numbers
+    /// </summary>
+    /// <param name="length">number of bytes to fill</param>
+    /// <returns>bytes</returns>
+    public byte[] GenerateByteArray(long length)
+    {
+        var array = new byte[length];
+        _rng.NextBytes(array);
+        return array;
+    }
+
+    /// <summary>
+    /// Returns a non-negative double
+    /// </summary>
+    /// <returns>double</returns>
+    public double GenerateDouble() => 
+        _rng.NextDouble();
+
+    /// <summary>
+    /// Returns a non-negative long
+    /// </summary>
+    /// <returns>long</returns>
+    public long GenerateLong()
+    {
+        var buf = new byte[8];
+        _rng.NextBytes(buf);
+        return Math.Abs(BitConverter.ToInt64(buf, 0));
+    }
+
+    /// <summary>
+    /// Returns a non-negative float
+    /// </summary>
+    /// <returns>float</returns>
+    public float GenerateFloat()
+    {
+        var buffer = new byte[4];
+        _rng.NextBytes(buffer);
+        return Math.Abs(BitConverter.ToSingle(buffer, 0));
+    }
+
+    /// <summary>
+    /// Returns a non-negative guid
+    /// </summary>
+    /// <returns>guid</returns>
+    public Guid GenerateGuid() =>
+        new(GenerateByteArray(16));
+}

--- a/LanguageExt.Sys/Test/Runtime.cs
+++ b/LanguageExt.Sys/Test/Runtime.cs
@@ -171,7 +171,15 @@ namespace LanguageExt.Sys.Test
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, Traits.EnvironmentIO> EnvironmentEff =>
             Eff<Runtime, Traits.EnvironmentIO>(rt => new Test.EnvironmentIO(rt.Env.SysEnv));
-        
+
+        /// <summary>
+        /// Creates a new runtime from this with a new Random IO and optional seed
+        /// </summary>
+        /// <remarks>This is for sub-systems to run in their own local random/controlled random contexts</remarks>
+        /// <returns>New runtime</returns>
+        public Runtime LocalRandom(int? seed = default) =>
+            new Runtime(env.LocalRandom(seed));
+
         /// <summary>
         /// Access the random synchronous effect environment
         /// </summary>
@@ -227,5 +235,8 @@ namespace LanguageExt.Sys.Test
 
         public RuntimeEnv LocalCancel =>
             new RuntimeEnv(new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv,Seed); 
+        
+        public RuntimeEnv LocalRandom(int? seed = default) =>
+            new RuntimeEnv(new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv, seed ?? Seed); 
     }
 }

--- a/LanguageExt.Sys/Test/Runtime.cs
+++ b/LanguageExt.Sys/Test/Runtime.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using LanguageExt.Effects.Traits;
 using LanguageExt.Sys.Traits;
 using static LanguageExt.Prelude;
+using static LanguageExt.Sys.Test.RandomIO;
 
 namespace LanguageExt.Sys.Test
 {
@@ -23,7 +24,6 @@ namespace LanguageExt.Sys.Test
         HasDirectory<Runtime>,
         HasRandom<Runtime>
     {
-        public const int Seed = 123456789;
         public readonly RuntimeEnv env;
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace LanguageExt.Sys.Test
         /// <param name="seed">seed to used for the random generator</param>
         public static Runtime New(TestTimeSpec? timeSpec = default, int seed = Seed) =>
             new Runtime(new RuntimeEnv(new CancellationTokenSource(),
-                                       System.Text.Encoding.Default,
+                                       Encoding.Default,
                                        new MemoryConsole(),
                                        new MemoryFS(),
                                        timeSpec,
@@ -60,7 +60,7 @@ namespace LanguageExt.Sys.Test
         /// <param name="seed">seed to used for the random generator</param>
         public static Runtime New(CancellationTokenSource source, TestTimeSpec? timeSpec = default, int seed = Seed) =>
             new Runtime(new RuntimeEnv(source, 
-                                       System.Text.Encoding.Default, 
+                                       Encoding.Default, 
                                        new MemoryConsole(), 
                                        new MemoryFS(),
                                        timeSpec,
@@ -131,7 +131,7 @@ namespace LanguageExt.Sys.Test
         /// </summary>
         /// <returns>Console environment</returns>
         public Eff<Runtime, Traits.ConsoleIO> ConsoleEff =>
-            Eff<Runtime, Traits.ConsoleIO>(rt => new Test.ConsoleIO(rt.Env.Console));
+            Eff<Runtime, Traits.ConsoleIO>(rt => new ConsoleIO(rt.Env.Console));
 
         /// <summary>
         /// Access the file environment
@@ -139,7 +139,7 @@ namespace LanguageExt.Sys.Test
         /// <returns>File environment</returns>
         public Eff<Runtime, Traits.FileIO> FileEff =>
             from n in Time<Runtime>.now
-            from r in Eff<Runtime, Traits.FileIO>(rt => new Test.FileIO(rt.Env.FileSystem, n))
+            from r in Eff<Runtime, Traits.FileIO>(rt => new FileIO(rt.Env.FileSystem, n))
             select r;
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace LanguageExt.Sys.Test
         /// <returns>Directory environment</returns>
         public Eff<Runtime, Traits.DirectoryIO> DirectoryEff =>
             from n in Time<Runtime>.now
-            from r in Eff<Runtime, Traits.DirectoryIO>(rt => new Test.DirectoryIO(rt.Env.FileSystem, n))
+            from r in Eff<Runtime, Traits.DirectoryIO>(rt => new DirectoryIO(rt.Env.FileSystem, n))
             select r;
         
         /// <summary>
@@ -156,21 +156,21 @@ namespace LanguageExt.Sys.Test
         /// </summary>
         /// <returns>TextReader environment</returns>
         public Eff<Runtime, Traits.TextReadIO> TextReadEff =>
-            SuccessEff(Test.TextReadIO.Default);
+            SuccessEff(TextReadIO.Default);
 
         /// <summary>
         /// Access the time environment
         /// </summary>
         /// <returns>Time environment</returns>
         public Eff<Runtime, Traits.TimeIO> TimeEff  =>
-            Eff<Runtime, Traits.TimeIO>(rt => new Test.TimeIO(rt.Env.TimeSpec));
+            Eff<Runtime, Traits.TimeIO>(rt => new TimeIO(rt.Env.TimeSpec));
 
         /// <summary>
         /// Access the operating-system environment
         /// </summary>
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, Traits.EnvironmentIO> EnvironmentEff =>
-            Eff<Runtime, Traits.EnvironmentIO>(rt => new Test.EnvironmentIO(rt.Env.SysEnv));
+            Eff<Runtime, Traits.EnvironmentIO>(rt => new EnvironmentIO(rt.Env.SysEnv));
 
         /// <summary>
         /// Creates a new runtime from this with a new Random IO and optional seed
@@ -218,7 +218,7 @@ namespace LanguageExt.Sys.Test
             TimeSpec   = timeSpec ?? TestTimeSpec.RunningFromNow();
             SysEnv     = sysEnv;
             Seed       = seed;
-            Random     = new RandomIO(Seed);
+            Random     = New(seed);
         }
 
         public RuntimeEnv(
@@ -234,7 +234,7 @@ namespace LanguageExt.Sys.Test
         }
 
         public RuntimeEnv LocalCancel =>
-            new RuntimeEnv(new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv,Seed); 
+            new RuntimeEnv(new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv, Seed); 
         
         public RuntimeEnv LocalRandom(int? seed = default) =>
             new RuntimeEnv(new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv, seed ?? Seed); 

--- a/LanguageExt.Sys/Traits/RandomIO.cs
+++ b/LanguageExt.Sys/Traits/RandomIO.cs
@@ -13,38 +13,38 @@ public interface RandomIO
     /// <param name="min">minimum int to return</param>
     /// <param name="max">maximum int to return</param>
     /// <returns>int</returns>
-    int GenerateInt(int? min = default, int? max = default);
+    int NextInt(int? min = default, int? max = default);
 
     /// <summary>
-    /// Fills the elements of a specified array of bytes with random numbers
+    /// Returns an array of bytes with random numbers
     /// </summary>
     /// <param name="length">number of bytes to fill</param>
     /// <returns>bytes</returns>
-    byte[] GenerateByteArray(long length);
+    byte[] NextByteArray(long length);
 
     /// <summary>
     /// Returns a non-negative double
     /// </summary>
     /// <returns>double</returns>
-    double GenerateDouble();
+    double NextDouble();
 
     /// <summary>
     /// Returns a non-negative long
     /// </summary>
     /// <returns>long</returns>
-    long GenerateLong();
+    long NextLong();
 
     /// <summary>
     /// Returns a non-negative float
     /// </summary>
     /// <returns>float</returns>
-    float GenerateFloat();
+    float NextFloat();
 
     /// <summary>
     /// Returns a non-negative guid
     /// </summary>
     /// <returns>guid</returns>
-    Guid GenerateGuid();
+    Guid NextGuid();
 }
 
 /// <summary>

--- a/LanguageExt.Sys/Traits/RandomIO.cs
+++ b/LanguageExt.Sys/Traits/RandomIO.cs
@@ -1,0 +1,62 @@
+﻿#nullable enable
+
+using System;
+using LanguageExt.Attributes;
+
+namespace LanguageExt.Sys.Traits;
+
+public interface RandomIO
+{
+    /// <summary>
+    /// Returns a non-negative int
+    /// </summary>
+    /// <param name="min">minimum int to return</param>
+    /// <param name="max">maximum int to return</param>
+    /// <returns>int</returns>
+    int GenerateInt(int? min = default, int? max = default);
+
+    /// <summary>
+    /// Fills the elements of a specified array of bytes with random numbers
+    /// </summary>
+    /// <param name="length">number of bytes to fill</param>
+    /// <returns>bytes</returns>
+    byte[] GenerateByteArray(long length);
+
+    /// <summary>
+    /// Returns a non-negative double
+    /// </summary>
+    /// <returns>double</returns>
+    double GenerateDouble();
+
+    /// <summary>
+    /// Returns a non-negative long
+    /// </summary>
+    /// <returns>long</returns>
+    long GenerateLong();
+
+    /// <summary>
+    /// Returns a non-negative float
+    /// </summary>
+    /// <returns>float</returns>
+    float GenerateFloat();
+
+    /// <summary>
+    /// Returns a non-negative guid
+    /// </summary>
+    /// <returns>guid</returns>
+    Guid GenerateGuid();
+}
+
+/// <summary>
+/// Type-class giving a struct the trait of supporting Random IO
+/// </summary>
+/// <typeparam name="RT">Runtime</typeparam>
+[Typeclass("*")]
+public interface HasRandom<RT> where RT : struct
+{
+    /// <summary>
+    /// Access the random synchronous effect environment
+    /// </summary>
+    /// <returns>Random synchronous effect environment</returns>
+    Eff<RT, RandomIO> RandomEff { get; }
+}

--- a/LanguageExt.Sys/Traits/RandomIO.cs
+++ b/LanguageExt.Sys/Traits/RandomIO.cs
@@ -55,6 +55,13 @@ public interface RandomIO
 public interface HasRandom<RT> where RT : struct
 {
     /// <summary>
+    /// Creates a new runtime from this with a new Random IO and optional seed
+    /// </summary>
+    /// <remarks>This is for sub-systems to run in their own local random/controlled random contexts</remarks>
+    /// <returns>New runtime</returns>
+    RT LocalRandom(int? seed = default);
+    
+    /// <summary>
     /// Access the random synchronous effect environment
     /// </summary>
     /// <returns>Random synchronous effect environment</returns>

--- a/LanguageExt.SysX/Live/Runtime.cs
+++ b/LanguageExt.SysX/Live/Runtime.cs
@@ -169,13 +169,7 @@ namespace LanguageExt.SysX.Live
         /// <remarks>This is for sub-systems to run in their own local random/controlled random contexts</remarks>
         /// <returns>New runtime</returns>
         public Runtime LocalRandom(int? seed = default) =>
-            new Runtime(
-                env with
-                {
-                    Random = seed != null
-                        ? new Sys.Live.RandomIO(new Random(seed.Value))
-                        : new Sys.Live.RandomIO(new Random())
-                });
+            new Runtime(env with { Random = Sys.Live.RandomIO.New(seed) });
 
         /// <summary>
         /// Access the random synchronous effect environment
@@ -192,12 +186,12 @@ namespace LanguageExt.SysX.Live
         Encoding Encoding,
         RandomIO Random) : IDisposable
     {
-        public RuntimeEnv(ActivityEnv activity, CancellationTokenSource source, Encoding encoding, Random? randomProvider = default) : 
+        public RuntimeEnv(ActivityEnv activity, CancellationTokenSource source, Encoding encoding, int? seed = default) : 
             this(activity,
                  source, 
                  source.Token, 
                  encoding,
-                 new Sys.Live.RandomIO(randomProvider ?? new Random()))
+                  Sys.Live.RandomIO.New(seed))
         {
         }
 

--- a/LanguageExt.SysX/Live/Runtime.cs
+++ b/LanguageExt.SysX/Live/Runtime.cs
@@ -4,7 +4,6 @@ using System;
 using System.Text;
 using System.Threading;
 using System.Diagnostics;
-using System.Reflection;
 using LanguageExt.Sys.Traits;
 using LanguageExt.SysX.Traits;
 using static LanguageExt.Prelude;
@@ -42,24 +41,27 @@ namespace LanguageExt.SysX.Live
         /// <summary>
         /// Constructor function
         /// </summary>
-        public static Runtime New() =>
-            new Runtime(new RuntimeEnv(ActivityEnv.Default, new CancellationTokenSource(), Encoding.Default));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(int? seed = default) =>
+            new Runtime(new RuntimeEnv(ActivityEnv.Default, new CancellationTokenSource(), Encoding.Default, seed));
 
         /// <summary>
         /// Constructor function
         /// </summary>
         /// <param name="activity">Tracing activity</param>
         /// <param name="source">Cancellation token source</param>
-        public static Runtime New(ActivityEnv activity, CancellationTokenSource source) =>
-            new Runtime(new RuntimeEnv(activity, source, Encoding.Default));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(ActivityEnv activity, CancellationTokenSource source, int? seed = default) =>
+            new Runtime(new RuntimeEnv(activity, source, Encoding.Default, seed));
 
         /// <summary>
         /// Constructor function
         /// </summary>
         /// <param name="activity">Tracing activity</param>
         /// <param name="encoding">Text encoding</param>
-        public static Runtime New(ActivityEnv activity, Encoding encoding) =>
-            new Runtime(new RuntimeEnv(activity, new CancellationTokenSource(), encoding));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(ActivityEnv activity, Encoding encoding, int? seed = default) =>
+            new Runtime(new RuntimeEnv(activity, new CancellationTokenSource(), encoding, seed));
 
         /// <summary>
         /// Constructor function
@@ -67,8 +69,9 @@ namespace LanguageExt.SysX.Live
         /// <param name="activity">Tracing activity</param>
         /// <param name="encoding">Text encoding</param>
         /// <param name="source">Cancellation token source</param>
-        public static Runtime New(ActivityEnv activity, Encoding encoding, CancellationTokenSource source) =>
-            new Runtime(new RuntimeEnv(activity, source, encoding));
+        /// <param name="seed">seed to used for the random generator</param>
+        public static Runtime New(ActivityEnv activity, Encoding encoding, CancellationTokenSource source, int? seed = default) =>
+            new Runtime(new RuntimeEnv(activity, source, encoding, seed));
 
         /// <summary>
         /// Create a new Runtime with a fresh cancellation token

--- a/LanguageExt.SysX/Live/Runtime.cs
+++ b/LanguageExt.SysX/Live/Runtime.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Text;
 using System.Threading;
@@ -19,7 +21,8 @@ namespace LanguageExt.SysX.Live
         HasTextRead<Runtime>,
         HasTime<Runtime>,
         HasEnvironment<Runtime>,
-        HasDirectory<Runtime>
+        HasDirectory<Runtime>,
+        HasRandom<Runtime>
     {
         readonly RuntimeEnv env;
 
@@ -159,6 +162,13 @@ namespace LanguageExt.SysX.Live
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, EnvironmentIO> EnvironmentEff =>
             SuccessEff(Sys.Live.EnvironmentIO.Default);
+ 
+        /// <summary>
+        /// Access the random synchronous effect environment
+        /// </summary>
+        /// <returns>Random synchronous effect environment</returns>
+        public Eff<Runtime, RandomIO> RandomEff =>
+            SuccessEff<Runtime, RandomIO>(new Sys.Live.RandomIO(new Random()));
     }
     
     public record RuntimeEnv(

--- a/LanguageExt.SysX/Live/Runtime.cs
+++ b/LanguageExt.SysX/Live/Runtime.cs
@@ -164,24 +164,40 @@ namespace LanguageExt.SysX.Live
             SuccessEff(Sys.Live.EnvironmentIO.Default);
  
         /// <summary>
+        /// Creates a new runtime from this with a new Random IO and optional seed
+        /// </summary>
+        /// <remarks>This is for sub-systems to run in their own local random/controlled random contexts</remarks>
+        /// <returns>New runtime</returns>
+        public Runtime LocalRandom(int? seed = default) =>
+            new Runtime(
+                env with
+                {
+                    Random = seed != null
+                        ? new Sys.Live.RandomIO(new Random(seed.Value))
+                        : new Sys.Live.RandomIO(new Random())
+                });
+
+        /// <summary>
         /// Access the random synchronous effect environment
         /// </summary>
         /// <returns>Random synchronous effect environment</returns>
         public Eff<Runtime, RandomIO> RandomEff =>
-            SuccessEff<Runtime, RandomIO>(new Sys.Live.RandomIO(new Random()));
+            Eff<Runtime, RandomIO>(static rt => rt.env.Random);
     }
     
     public record RuntimeEnv(
         ActivityEnv Activity,
         CancellationTokenSource Source, 
         CancellationToken Token, 
-        Encoding Encoding) : IDisposable
+        Encoding Encoding,
+        RandomIO Random) : IDisposable
     {
-        public RuntimeEnv(ActivityEnv activity, CancellationTokenSource source, Encoding encoding) : 
+        public RuntimeEnv(ActivityEnv activity, CancellationTokenSource source, Encoding encoding, Random? randomProvider = default) : 
             this(activity,
                  source, 
                  source.Token, 
-                 encoding)
+                 encoding,
+                 new Sys.Live.RandomIO(randomProvider ?? new Random()))
         {
         }
 

--- a/LanguageExt.SysX/Test/Runtime.cs
+++ b/LanguageExt.SysX/Test/Runtime.cs
@@ -221,7 +221,15 @@ namespace LanguageExt.SysX.Test
         /// <returns>Operating-system environment environment</returns>
         public Eff<Runtime, LanguageExt.Sys.Traits.EnvironmentIO> EnvironmentEff =>
             Eff<Runtime, LanguageExt.Sys.Traits.EnvironmentIO>(rt => new LanguageExt.Sys.Test.EnvironmentIO(rt.Env.SysEnv));
-    
+
+        /// <summary>
+        /// Creates a new runtime from this with a new Random IO and optional seed
+        /// </summary>
+        /// <remarks>This is for sub-systems to run in their own local random/controlled random contexts</remarks>
+        /// <returns>New runtime</returns>
+        public Runtime LocalRandom(int? seed = default) =>
+            new Runtime(env.LocalRandom(seed));
+
         /// <summary>
         /// Access the random synchronous effect environment
         /// </summary>
@@ -258,5 +266,8 @@ namespace LanguageExt.SysX.Test
 
         public RuntimeEnv LocalCancel =>
             new RuntimeEnv(Activity, new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv, Seed); 
+          
+        public RuntimeEnv LocalRandom(int? seed = default) =>
+            new RuntimeEnv(Activity, new CancellationTokenSource(), Encoding, Console, FileSystem, TimeSpec, SysEnv, seed ?? Seed); 
     }
 }

--- a/LanguageExt.SysX/Test/Runtime.cs
+++ b/LanguageExt.SysX/Test/Runtime.cs
@@ -9,6 +9,7 @@ using LanguageExt.Sys.Test;
 using static LanguageExt.Prelude;
 using LanguageExt.Sys;
 using LanguageExt.SysX.Traits;
+using static LanguageExt.Sys.Test.RandomIO;
 using RandomIO = LanguageExt.Sys.Traits.RandomIO;
 
 namespace LanguageExt.SysX.Test
@@ -26,7 +27,6 @@ namespace LanguageExt.SysX.Test
         HasDirectory<Runtime>,
         HasRandom<Runtime>
     {
-        public const int Seed = 123456789;
         public readonly RuntimeEnv env;
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace LanguageExt.SysX.Test
         MemorySystemEnvironment SysEnv,
         int Seed) 
     {
-        public readonly RandomIO Random = new Sys.Test.RandomIO(Seed);
+        public readonly RandomIO Random = New(Seed);
         
         public RuntimeEnv(
             ActivityEnv activity,

--- a/LanguageExt.Tests/LanguageExt.Tests.csproj
+++ b/LanguageExt.Tests/LanguageExt.Tests.csproj
@@ -39,6 +39,7 @@
     <ProjectReference Include="..\LanguageExt.FSharp\LanguageExt.FSharp.csproj" />
     <ProjectReference Include="..\LanguageExt.Parsec\LanguageExt.Parsec.csproj" />
     <ProjectReference Include="..\LanguageExt.Rx\LanguageExt.Rx.csproj" />
+    <ProjectReference Include="..\LanguageExt.SysX\LanguageExt.SysX.csproj" />
     <ProjectReference Include="..\LanguageExt.Sys\LanguageExt.Sys.csproj" />
     <ProjectReference Include="..\LanguageExt.Transformers\LanguageExt.Transformers.csproj" />
   </ItemGroup>

--- a/LanguageExt.Tests/MathExtTests.cs
+++ b/LanguageExt.Tests/MathExtTests.cs
@@ -1,0 +1,63 @@
+﻿#nullable enable
+
+using FluentAssertions;
+using Xunit;
+
+namespace LanguageExt.Tests;
+
+public static class MathExtTests
+{
+    [Theory(DisplayName = "NextAfter will return a double that is greater than zero in the direction of positive infinity")]
+    [InlineData(0.0d, 5E-324)]
+    [InlineData(1.0d, 1.0000000000000002)]
+    public static void Case1(double value, double result) =>
+        MathExt.NextAfter(value, double.MaxValue).Should().BeGreaterThan(0).And.Be(result);
+
+    [Theory(DisplayName = "NextAfter will return a double that is less than zero in the direction of negative infinity")]
+    [InlineData(0.0d, -5E-324)]
+    [InlineData(1.0d, 0.9999999999999999)]
+    public static void Case2(double value, double result) =>
+        MathExt.NextAfter(value, double.MinValue).Should().Be(result);
+
+    [Fact(DisplayName = "NextAfter double will return a its starting point when called twice in both directions")]
+    public static void Case3() =>
+        MathExt.NextAfter(MathExt.NextAfter(0.0d, double.MaxValue), double.MinValue).Should().Be(0.0d);
+
+    [Theory(DisplayName = "NextAfter double edge cases are handled gracefully")]
+    [InlineData(double.NaN, double.NaN, double.NaN)]
+    [InlineData(0.0d, double.NaN, double.NaN)]
+    [InlineData(double.NaN, 0.0d, double.NaN)]
+    [InlineData(0.0d, 0.0d, 0.0d)]
+    [InlineData(double.Epsilon, double.Epsilon, double.Epsilon)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity)]
+    public static void Case4(double value, double next, double result) =>
+        MathExt.NextAfter(value, next).Should().Be(result);
+
+    [Theory(DisplayName = "NextAfter will return a float that is greater than zero in the direction of positive infinity")]    
+    [InlineData(0.0f, 1E-45F)]
+    [InlineData(1.0f, 1.0000001F)]
+    public static void Case5(float value, float result) =>
+        MathExt.NextAfter(value, float.MaxValue).Should().BeGreaterThan(0).And.Be(result);
+
+    [Theory(DisplayName = "NextAfter will return a float that is less than zero in the direction of negative infinity")]
+    [InlineData(0.0f, -1E-45F)]
+    [InlineData(1.0f, 0.99999994F)]
+    public static void Case6(float value, float result) =>
+        MathExt.NextAfter(value, float.MinValue).Should().Be(result);
+
+    [Fact(DisplayName = "NextAfter float will return a its starting point when called twice in both directions")]
+    public static void Case7() =>
+        MathExt.NextAfter(MathExt.NextAfter(0.0f, float.MaxValue), float.MinValue).Should().Be(0.0f);
+
+    [Theory(DisplayName = "NextAfter float edge cases are handled gracefully")]
+    [InlineData(float.NaN, float.NaN, float.NaN)]
+    [InlineData(0.0f, float.NaN, float.NaN)]
+    [InlineData(float.NaN, 0.0f, float.NaN)]
+    [InlineData(0.0f, 0.0f, 0.0f)]
+    [InlineData(float.Epsilon, float.Epsilon, float.Epsilon)]
+    [InlineData(float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity)]
+    [InlineData(float.NegativeInfinity, float.NegativeInfinity, float.NegativeInfinity)]
+    public static void Case8(float value, float next, float result) =>
+        MathExt.NextAfter(value, next).Should().Be(result);
+}

--- a/LanguageExt.Tests/RandomTests.cs
+++ b/LanguageExt.Tests/RandomTests.cs
@@ -1,0 +1,356 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using CodeGeneration.Roslyn;
+using FluentAssertions;
+using LanguageExt.Sys;
+using LanguageExt.Sys.Traits;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests;
+
+using LR = Random<Sys.Live.Runtime>;
+using TR = Random<Sys.Test.Runtime>;
+using LRX = Random<SysX.Live.Runtime>;
+using TRX = Random<SysX.Test.Runtime>;
+
+public static class RandomTests
+{
+    static Sys.Live.Runtime live = Sys.Live.Runtime.New();    
+    static SysX.Live.Runtime liveX = SysX.Live.Runtime.New();
+    
+    static Sys.Test.Runtime test() => 
+        Sys.Test.Runtime.New(seed: 1234567);
+    
+    static SysX.Test.Runtime testX() => 
+        SysX.Test.Runtime.New(seed: 1234567);
+
+    [Fact(DisplayName = "Generate int provides a random int")]
+    public static void Case1() => 
+        LR.generateInt().Run(live).ThrowIfFail().Should().BePositive();
+
+    [Fact(DisplayName = "Generate int provides a random int between 2 values")]
+    public static void Case2() =>
+        LR.generateInt(2, 6).Run(live).ThrowIfFail().Should().BePositive().And.BeInRange(2, 6);
+
+    [Fact(DisplayName = "Generate int provides a random int up to a max value")]
+    public static void Case3() =>
+        LR.generateInt(0, 6).Run(live).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+
+    [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Live)")]
+    public static void Case3a() =>
+        LRX.generateInt(0, 6).Run(liveX).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+
+    [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Test)")]
+    public static void Case3b() =>
+        TRX.generateInt(0, 6).Run(testX()).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+    
+    sealed class MockRandom : RandomIO
+    {
+        public int GenerateInt(int? min = default, int? max = default) => 666;
+
+        public byte[] GenerateByteArray(long length) => throw new NotImplementedException();
+
+        public double GenerateDouble() => throw new NotImplementedException();
+
+        public long GenerateLong() => throw new NotImplementedException();
+
+        public float GenerateFloat() => throw new NotImplementedException();
+
+        public Guid GenerateGuid() => throw new NotImplementedException();
+    }
+
+    struct CustomRuntime : HasRandom<CustomRuntime>
+    {
+        public Eff<CustomRuntime, RandomIO> RandomEff =>
+            SuccessEff<CustomRuntime, RandomIO>(new MockRandom());
+    }
+
+    [Fact(DisplayName = "Random can be mocked")]
+    public static void Case4() =>
+        Random<CustomRuntime>.generateInt()
+            .Run(new CustomRuntime())
+            .ThrowIfFail()
+            .Should()
+            .Be(666);
+
+    [Fact(DisplayName = "Random bytes can be generated to length")]
+    public static void Case5() => 
+        LR.generateByteArray(7).Run(live).ThrowIfFail().Should().HaveCount(7);
+    
+    [Fact(DisplayName = "Random bytes can be generated to length (SysX.Live)")]
+    public static void Case5a() => 
+        LRX.generateByteArray(7).Run(liveX).ThrowIfFail().Should().HaveCount(7);
+    
+    [Fact(DisplayName = "Random bytes can be generated to length (SysX.Test)")]
+    public static void Case5b() => 
+        TRX.generateByteArray(7).Run(testX()).ThrowIfFail().Should().HaveCount(7);
+
+    [Fact(DisplayName = "Random doubles can be generated")]
+    public static void Case6() => 
+        LR.generateDouble().Run(live).ThrowIfFail().Should().BePositive();
+
+    [Fact(DisplayName = "Random longs can be generated")]
+    public static void Case7() =>
+        LR.generateLong().Run(live).ThrowIfFail().Should().BeInRange(long.MinValue, long.MaxValue);
+
+    [Fact(DisplayName = "Random floats can be generated")]
+    public static void Case8() =>
+        LR.generateFloat().Run(live).ThrowIfFail().Should().BeInRange(float.MinValue, float.MaxValue);
+
+    [Fact(DisplayName = "Random guids can be generated")]
+    public static void Case9() => 
+        LR.generateGuid().Run(live).ThrowIfFail().Should().NotBeEmpty();
+
+    [Fact(DisplayName = "Random guids can be generated")]
+    public static void Case10() => 
+        LR.generateChar().Run(live).ThrowIfFail().Should().NotBeNull();
+
+    [Fact(DisplayName = "Random durations between a range can be generated")]
+    public static void Case11() =>
+        LR.generateDuration(10 * seconds, 1 * minute)
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeInRange(10 * seconds, 1 * minute);
+
+    [Fact(DisplayName = "Random time spans between a range can be generated")]
+    public static void Case12() =>
+        LR.generateTimespan(10 * seconds, 1 * minute)
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeGreaterThan(TimeSpan.FromSeconds(10))
+            .And.BeLessThan(TimeSpan.FromMinutes(1));
+
+    [Fact(DisplayName = "Random date time offsets between a range can be generated")]
+    public static void Case13() =>
+        LR.generateDateTimeOffset(DateTimeOffset.Now, DateTimeOffset.Now + TimeSpan.FromDays(10))
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeWithin(TimeSpan.FromDays(10));
+
+    [Fact(DisplayName = "Random date time between a range can be generated")]
+    public static void Case14() =>
+        LR.generateDateTime(DateTime.Now, DateTime.Now + TimeSpan.FromDays(10))
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeWithin(TimeSpan.FromDays(10));
+
+    [Fact(DisplayName = "Random ranges can be generated")]
+    public static void Case17() =>
+        LR.generateRange(LR.generateChar(), 4, 25)
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .HaveCountGreaterOrEqualTo(4)
+            .And.HaveCountLessThan(25);
+
+    [Fact(DisplayName = "Random ranges can be generated with other random effects")]
+    public static void Case18() =>
+        LR.generateRange(LR.generateGuid(), 4, 25)
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .HaveCountGreaterOrEqualTo(4)
+            .And.HaveCountLessThanOrEqualTo(25);
+
+    [Fact(DisplayName = "Generate int provides a random int deterministically")]
+    public static void Case19() => 
+        TR.generateInt().Run(test()).ThrowIfFail().Should().Be(1673116976);
+
+    [Fact(DisplayName = "Generate int provides a random int between 2 values deterministically")]
+    public static void Case20() => 
+        TR.generateInt(2, 6).Run(test()).ThrowIfFail().Should().Be(5);
+
+    [Fact(DisplayName = "Generate int provides a random int up to a max value deterministically")]
+    public static void Case21() => 
+        TR.generateInt(0, 6).Run(test()).ThrowIfFail().Should().Be(4);
+
+    [Fact(DisplayName = "Random bytes can be generated to length deterministically")]
+    public static void Case22() =>
+        TR.generateByteArray(7)
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .BeEquivalentTo(new[] { 0x30, 0xE6, 0x63, 0xCA, 0x5F, 0x41, 0x21 });
+
+    [Fact(DisplayName = "Random doubles can be generated deterministically")]
+    public static void Case23() =>
+        TR.generateDouble().Run(test()).ThrowIfFail().Should().Be(0.7791058052233913);
+
+    [Fact(DisplayName = "Random doubles within range can be generated deterministically")]
+    public static void Case23b() =>
+        TR.generateDouble(0.8, 0.9).Run(test()).ThrowIfFail().Should().Be(0.8791058052233915);
+
+    [Fact(DisplayName = "Random longs can be generated deterministically")]
+    public static void Case24() =>
+        TR.generateLong().Run(test()).ThrowIfFail().Should().Be(5197507324635506224L);
+
+    [Fact(DisplayName = "Random longs within a range can be generated deterministically")]
+    public static void Case24b() =>
+        TR.generateLong(10L, 900L).Run(test()).ThrowIfFail().Should().Be(264L);
+
+    [Fact(DisplayName = "Random floats can be generated deterministically")]
+    public static void Case25() => 
+        TR.generateFloat().Run(test()).ThrowIfFail().Should().Be(3733900F);
+
+    [Fact(DisplayName = "Random floats within a range can be generated deterministically")]
+    public static void Case25b() => 
+        TR.generateFloat(0.8F, 0.9F).Run(test()).ThrowIfFail().Should().Be(0.8353472F);
+
+    [Fact(DisplayName = "Random guids can be generated deterministically")]
+    public static void Case26() =>
+        TR.generateGuid()
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .Be(Guid.Parse("ca63e630-415f-4821-1f8f-fbe9db201f70"));
+
+    [Fact(DisplayName = "Random char can be generated deterministically")]
+    public static void Case27() => 
+        TR.generateChar().Run(test()).ThrowIfFail().Should().Be('i');
+
+    [Fact(DisplayName = "Random durations between a range can be generated deterministically")]
+    public static void Case28() =>
+        TR.generateDuration(10 * seconds, 1 * minute)
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .Be(10000.779105805223);
+
+    [Fact(DisplayName = "Random time spans between a range can be generated deterministically")]
+    public static void Case29() =>
+        TR.generateTimespan(10 * seconds, 1 * minute)
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .Be(TimeSpan.FromMilliseconds(10000.779105805223));
+
+    [Fact(DisplayName = "Random ranges can be generated deterministically")]
+    public static void Case30() =>
+        TR.generateRange(TR.generateChar(), 4, 25).Run(test()).ThrowIfFail().Should().HaveCount(20);
+
+    [Fact(DisplayName = "Random ranges can be generated with other random effects deterministically")]
+    public static void Case31() =>
+        TR.generateRange(TR.generateGuid(), 4, 25)
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .HaveCount(20)
+            .And.Contain(x => x == Guid.Parse("448f4128-f539-deef-e7ba-f20ed04afc32"));
+
+    [Fact(DisplayName = "Random strings can be generated")]
+    public static void Case32() =>
+        LR.generateString(4, 25).Run(live).ThrowIfFail().Should().NotBeEmpty();
+
+    [Fact(DisplayName = "Random strings can be generated deterministically")]
+    public static void Case33() =>
+        TR.generateString(4, 25).Run(test()).ThrowIfFail().Should().Be("g9.XyvJR3Ng\"J-v<br`E");
+
+    [Fact(DisplayName = "Random chars in a range can be generated")]
+    public static void Case34() =>
+        LR.generateChar('a', 'z')
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeGreaterOrEqualTo('a')
+            .And.BeLessThanOrEqualTo('z');
+
+    [Fact(DisplayName = "Random chars in a range can be generated deterministically")]
+    public static void Case35() => 
+        TR.generateChar('a', 'z').Run(test()).ThrowIfFail().Should().Be('t');
+
+    [Fact(DisplayName = "Random pick will get a random element from the collection")]
+    public static void Case36() =>
+        LR.uniform<int>(List(1, 2, 3, 4, 5))
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeGreaterThan(0)
+            .And.BeLessThan(6);
+
+    [Fact(DisplayName = "Random pick will get a random element from the collection deterministically")]
+    public static void Case37() =>
+        TR.uniform<int>(List(1, 2, 3, 4, 5)).Run(test()).ThrowIfFail().Should().Be(4);
+
+    [Fact(DisplayName = "Random enum will get a random enum from the enumeration")]
+    public static void Case38() =>
+        LR.generateEnum<LogLevel>().Run(live).ThrowIfFail().Should().BeOneOf(Enum.GetValues<LogLevel>());
+
+    [Fact(DisplayName = "Random enum will get a random enum from the enumeration deterministically")]
+    public static void Case39() =>
+        TR.generateEnum<LogLevel>().Run(test()).ThrowIfFail().Should().Be(LogLevel.Warning);
+
+    [Fact(DisplayName = "Random boolean can be generated deterministically")]
+    public static void Case40() => 
+        TR.generateBool().Run(test()).ThrowIfFail().Should().BeTrue();
+
+    [Fact(DisplayName = "Random weighted pick can be returned")]
+    public static void Case41()
+    {
+        var result = TR.weighted<int>(
+                List((5, 1), (15, 2), (30, 3), (30, 4), (15, 5), (5, 6))
+            )
+            .Fold(Schedule.recurs(1000), Seq.empty<int>(), (seq, i) => seq.Add(i))
+            .Run(test())
+            .ThrowIfFail()
+            .GroupBy(x => x)
+            .ToDictionary(x => x.Key, x => Math.Round((double)x.Count() / 1000 * 100));
+        result[1].Should().Be(5);
+        result[2].Should().Be(14);
+        result[3].Should().Be(31);
+        result[4].Should().Be(29);
+        result[5].Should().Be(15);
+        result[6].Should().Be(5);
+    }
+
+    [Fact(DisplayName = "Random weighted pick can be returned with a sum of weights less than 100")]
+    public static void Case42()
+    {
+        var result = TR.weighted<int>(List((1, 1), (1, 2), (30, 3), (30, 4), (1, 5), (1, 6)))
+            .Fold(Schedule.recurs(1000), Seq.empty<int>(), (seq, i) => seq.Add(i))
+            .Run(test())
+            .ThrowIfFail()
+            .GroupBy(x => x)
+            .ToDictionary(x => x.Key, x => Math.Round((double)x.Count() / 1000 * 100));
+        result[1].Should().Be(1);
+        result[2].Should().Be(1);
+        result[3].Should().Be(48);
+        result[4].Should().Be(46);
+        result[5].Should().Be(2);
+        result[6].Should().Be(2);
+    }
+
+    [Fact(DisplayName = "Random weighted pick can be returned with a sum of weights greater than 100")]
+    public static void Case43()
+    {
+        var result = TR.weighted<int>(
+                List((30, 1), (30, 2), (30, 3), (30, 4), (1, 5), (1, 6))
+            )
+            .Fold(Schedule.recurs(1000), Seq.empty<int>(), (seq, i) => seq.Add(i))
+            .Run(test())
+            .ThrowIfFail()
+            .GroupBy(x => x)
+            .ToDictionary(x => x.Key, x => Math.Round((double)x.Count() / 1000 * 100));
+        result[1].Should().Be(24);
+        result[2].Should().Be(25);
+        result[3].Should().Be(24);
+        result[4].Should().Be(25);
+        result[5].Should().Be(1);
+        result[6].Should().Be(1);
+    }
+
+    [Fact(DisplayName = "Random tuples can be generated")]
+    public static void Case44() => (
+            from a in TR.generateInt()
+            from b in TR.generateInt()
+            select (a, b)).Run(test())
+        .ThrowIfFail()
+        .Should()
+        .Be((1673116976, 1631631590));
+}

--- a/LanguageExt.Tests/RandomTests.cs
+++ b/LanguageExt.Tests/RandomTests.cs
@@ -41,11 +41,11 @@ public static class RandomTests
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Live)")]
     public static void Case3a() =>
-        LRX.nextInt(0, 6).Run(liveX).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+        LRX.nextInt(max: 6).Run(liveX).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Test)")]
     public static void Case3b() =>
-        TRX.nextInt(0, 6).Run(testX()).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+        TRX.nextInt(max: 6).Run(testX()).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
     
     sealed class MockRandom : RandomIO
     {
@@ -362,4 +362,21 @@ public static class RandomTests
             .AsEnumerable()
             .Should()
             .ContainInOrder(2, 3, 1, 5, 4);
+    
+    [Fact(DisplayName = "Min and max can be assigned the wrong way round and it swaps the bounds (Test)")]
+    public static void Case46() =>
+        TR.nextInt(3, 1)
+            .Run(test())
+            .ThrowIfFail()
+            .Should()
+            .Be(2);
+    
+    [Fact(DisplayName = "Min and max can be assigned the wrong way round and it swaps the bounds (Live)")]
+    public static void Case47() =>
+        LR.nextInt(3, 1)
+            .Run(live)
+            .ThrowIfFail()
+            .Should()
+            .BeGreaterOrEqualTo(1)
+            .And.BeLessThanOrEqualTo(3);
 }

--- a/LanguageExt.Tests/RandomTests.cs
+++ b/LanguageExt.Tests/RandomTests.cs
@@ -185,7 +185,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random doubles within range can be generated deterministically")]
     public static void Case23b() =>
-        TR.nextDouble(0.8, 0.9).Run(test()).ThrowIfFail().Should().Be(0.8791058052233915);
+        TR.nextDouble(0.8, 0.9).Run(test()).ThrowIfFail().Should().Be(0.8779105805223392);
 
     [Fact(DisplayName = "Random longs can be generated deterministically")]
     public static void Case24() =>
@@ -197,11 +197,11 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random floats can be generated deterministically")]
     public static void Case25() => 
-        TR.nextFloat().Run(test()).ThrowIfFail().Should().Be(3733900F);
+        TR.nextFloat().Run(test()).ThrowIfFail().Should().Be(3.4028233E+38F);
 
     [Fact(DisplayName = "Random floats within a range can be generated deterministically")]
     public static void Case25b() => 
-        TR.nextFloat(0.8F, 0.9F).Run(test()).ThrowIfFail().Should().Be(0.8353472F);
+        TR.nextFloat(0.8F, 0.9F).Run(test()).ThrowIfFail().Should().Be(0.8999999F);
 
     [Fact(DisplayName = "Random guids can be generated deterministically")]
     public static void Case26() =>
@@ -221,7 +221,7 @@ public static class RandomTests
             .Run(test())
             .ThrowIfFail()
             .Should()
-            .Be(10000.779105805223);
+            .Be(48955.290261169568);
 
     [Fact(DisplayName = "Random time spans between a range can be generated deterministically")]
     public static void Case29() =>
@@ -229,7 +229,7 @@ public static class RandomTests
             .Run(test())
             .ThrowIfFail()
             .Should()
-            .Be(TimeSpan.FromMilliseconds(10000.779105805223));
+            .Be(TimeSpan.FromMilliseconds(48955.290261169568));
 
     [Fact(DisplayName = "Random ranges can be generated deterministically")]
     public static void Case30() =>
@@ -267,7 +267,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random pick will get a random element from the collection")]
     public static void Case36() =>
-        LR.uniform<int>(List(1, 2, 3, 4, 5))
+        LR.uniform(1, 2, 3, 4, 5)
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -293,8 +293,8 @@ public static class RandomTests
     [Fact(DisplayName = "Random weighted pick can be returned")]
     public static void Case41()
     {
-        var result = TR.weighted<int>(
-                List((5, 1), (15, 2), (30, 3), (30, 4), (15, 5), (5, 6))
+        var result = TR.weighted(
+                (5, 1), (15, 2), (30, 3), (30, 4), (15, 5), (5, 6)
             )
             .Fold(Schedule.recurs(1000), Seq.empty<int>(), (seq, i) => seq.Add(i))
             .Run(test())
@@ -353,4 +353,13 @@ public static class RandomTests
         .ThrowIfFail()
         .Should()
         .Be((1673116976, 1631631590));
+
+    [Fact(DisplayName = "Lists can be shuffled")]
+    public static void Case45() =>
+        TR.shuffle(1, 2, 3, 4, 5)
+            .Run(test())
+            .ThrowIfFail()
+            .AsEnumerable()
+            .Should()
+            .ContainInOrder(2, 3, 1, 5, 4);
 }

--- a/LanguageExt.Tests/RandomTests.cs
+++ b/LanguageExt.Tests/RandomTests.cs
@@ -29,37 +29,37 @@ public static class RandomTests
 
     [Fact(DisplayName = "Generate int provides a random int")]
     public static void Case1() => 
-        LR.generateInt().Run(live).ThrowIfFail().Should().BePositive();
+        LR.nextInt().Run(live).ThrowIfFail().Should().BePositive();
 
     [Fact(DisplayName = "Generate int provides a random int between 2 values")]
     public static void Case2() =>
-        LR.generateInt(2, 6).Run(live).ThrowIfFail().Should().BePositive().And.BeInRange(2, 6);
+        LR.nextInt(2, 6).Run(live).ThrowIfFail().Should().BePositive().And.BeInRange(2, 6);
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value")]
     public static void Case3() =>
-        LR.generateInt(0, 6).Run(live).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+        LR.nextInt(0, 6).Run(live).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Live)")]
     public static void Case3a() =>
-        LRX.generateInt(0, 6).Run(liveX).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+        LRX.nextInt(0, 6).Run(liveX).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value (SysX.Test)")]
     public static void Case3b() =>
-        TRX.generateInt(0, 6).Run(testX()).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
+        TRX.nextInt(0, 6).Run(testX()).ThrowIfFail().Should().BeGreaterOrEqualTo(0).And.BeLessThan(6);
     
     sealed class MockRandom : RandomIO
     {
-        public int GenerateInt(int? min = default, int? max = default) => 666;
+        public int NextInt(int? min = default, int? max = default) => 666;
 
-        public byte[] GenerateByteArray(long length) => throw new NotImplementedException();
+        public byte[] NextByteArray(long length) => throw new NotImplementedException();
 
-        public double GenerateDouble() => throw new NotImplementedException();
+        public double NextDouble() => throw new NotImplementedException();
 
-        public long GenerateLong() => throw new NotImplementedException();
+        public long NextLong() => throw new NotImplementedException();
 
-        public float GenerateFloat() => throw new NotImplementedException();
+        public float NextFloat() => throw new NotImplementedException();
 
-        public Guid GenerateGuid() => throw new NotImplementedException();
+        public Guid NextGuid() => throw new NotImplementedException();
     }
 
     struct CustomRuntime : HasRandom<CustomRuntime>
@@ -70,7 +70,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random can be mocked")]
     public static void Case4() =>
-        Random<CustomRuntime>.generateInt()
+        Random<CustomRuntime>.nextInt()
             .Run(new CustomRuntime())
             .ThrowIfFail()
             .Should()
@@ -78,39 +78,39 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random bytes can be generated to length")]
     public static void Case5() => 
-        LR.generateByteArray(7).Run(live).ThrowIfFail().Should().HaveCount(7);
+        LR.nextByteArray(7).Run(live).ThrowIfFail().Should().HaveCount(7);
     
     [Fact(DisplayName = "Random bytes can be generated to length (SysX.Live)")]
     public static void Case5a() => 
-        LRX.generateByteArray(7).Run(liveX).ThrowIfFail().Should().HaveCount(7);
+        LRX.nextByteArray(7).Run(liveX).ThrowIfFail().Should().HaveCount(7);
     
     [Fact(DisplayName = "Random bytes can be generated to length (SysX.Test)")]
     public static void Case5b() => 
-        TRX.generateByteArray(7).Run(testX()).ThrowIfFail().Should().HaveCount(7);
+        TRX.nextByteArray(7).Run(testX()).ThrowIfFail().Should().HaveCount(7);
 
     [Fact(DisplayName = "Random doubles can be generated")]
     public static void Case6() => 
-        LR.generateDouble().Run(live).ThrowIfFail().Should().BePositive();
+        LR.nextDouble().Run(live).ThrowIfFail().Should().BePositive();
 
     [Fact(DisplayName = "Random longs can be generated")]
     public static void Case7() =>
-        LR.generateLong().Run(live).ThrowIfFail().Should().BeInRange(long.MinValue, long.MaxValue);
+        LR.nextLong().Run(live).ThrowIfFail().Should().BeInRange(long.MinValue, long.MaxValue);
 
     [Fact(DisplayName = "Random floats can be generated")]
     public static void Case8() =>
-        LR.generateFloat().Run(live).ThrowIfFail().Should().BeInRange(float.MinValue, float.MaxValue);
+        LR.nextFloat().Run(live).ThrowIfFail().Should().BeInRange(float.MinValue, float.MaxValue);
 
     [Fact(DisplayName = "Random guids can be generated")]
     public static void Case9() => 
-        LR.generateGuid().Run(live).ThrowIfFail().Should().NotBeEmpty();
+        LR.nextGuid().Run(live).ThrowIfFail().Should().NotBeEmpty();
 
     [Fact(DisplayName = "Random guids can be generated")]
     public static void Case10() => 
-        LR.generateChar().Run(live).ThrowIfFail().Should().NotBeNull();
+        LR.nextChar().Run(live).ThrowIfFail().Should().NotBeNull();
 
     [Fact(DisplayName = "Random durations between a range can be generated")]
     public static void Case11() =>
-        LR.generateDuration(10 * seconds, 1 * minute)
+        LR.nextDuration(10 * seconds, 1 * minute)
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -118,7 +118,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random time spans between a range can be generated")]
     public static void Case12() =>
-        LR.generateTimespan(10 * seconds, 1 * minute)
+        LR.nextTimespan(10 * seconds, 1 * minute)
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -127,7 +127,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random date time offsets between a range can be generated")]
     public static void Case13() =>
-        LR.generateDateTimeOffset(DateTimeOffset.Now, DateTimeOffset.Now + TimeSpan.FromDays(10))
+        LR.nextDateTimeOffset(DateTimeOffset.Now, DateTimeOffset.Now + TimeSpan.FromDays(10))
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -135,7 +135,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random date time between a range can be generated")]
     public static void Case14() =>
-        LR.generateDateTime(DateTime.Now, DateTime.Now + TimeSpan.FromDays(10))
+        LR.nextDateTime(DateTime.Now, DateTime.Now + TimeSpan.FromDays(10))
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -143,7 +143,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random ranges can be generated")]
     public static void Case17() =>
-        LR.generateRange(LR.generateChar(), 4, 25)
+        LR.nextRange(LR.nextChar(), 4, 25)
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -152,7 +152,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random ranges can be generated with other random effects")]
     public static void Case18() =>
-        LR.generateRange(LR.generateGuid(), 4, 25)
+        LR.nextRange(LR.nextGuid(), 4, 25)
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -161,19 +161,19 @@ public static class RandomTests
 
     [Fact(DisplayName = "Generate int provides a random int deterministically")]
     public static void Case19() => 
-        TR.generateInt().Run(test()).ThrowIfFail().Should().Be(1673116976);
+        TR.nextInt().Run(test()).ThrowIfFail().Should().Be(1673116976);
 
     [Fact(DisplayName = "Generate int provides a random int between 2 values deterministically")]
     public static void Case20() => 
-        TR.generateInt(2, 6).Run(test()).ThrowIfFail().Should().Be(5);
+        TR.nextInt(2, 6).Run(test()).ThrowIfFail().Should().Be(5);
 
     [Fact(DisplayName = "Generate int provides a random int up to a max value deterministically")]
     public static void Case21() => 
-        TR.generateInt(0, 6).Run(test()).ThrowIfFail().Should().Be(4);
+        TR.nextInt(0, 6).Run(test()).ThrowIfFail().Should().Be(4);
 
     [Fact(DisplayName = "Random bytes can be generated to length deterministically")]
     public static void Case22() =>
-        TR.generateByteArray(7)
+        TR.nextByteArray(7)
             .Run(test())
             .ThrowIfFail()
             .Should()
@@ -181,31 +181,31 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random doubles can be generated deterministically")]
     public static void Case23() =>
-        TR.generateDouble().Run(test()).ThrowIfFail().Should().Be(0.7791058052233913);
+        TR.nextDouble().Run(test()).ThrowIfFail().Should().Be(0.7791058052233913);
 
     [Fact(DisplayName = "Random doubles within range can be generated deterministically")]
     public static void Case23b() =>
-        TR.generateDouble(0.8, 0.9).Run(test()).ThrowIfFail().Should().Be(0.8791058052233915);
+        TR.nextDouble(0.8, 0.9).Run(test()).ThrowIfFail().Should().Be(0.8791058052233915);
 
     [Fact(DisplayName = "Random longs can be generated deterministically")]
     public static void Case24() =>
-        TR.generateLong().Run(test()).ThrowIfFail().Should().Be(5197507324635506224L);
+        TR.nextLong().Run(test()).ThrowIfFail().Should().Be(5197507324635506224L);
 
     [Fact(DisplayName = "Random longs within a range can be generated deterministically")]
     public static void Case24b() =>
-        TR.generateLong(10L, 900L).Run(test()).ThrowIfFail().Should().Be(264L);
+        TR.nextLong(10L, 900L).Run(test()).ThrowIfFail().Should().Be(264L);
 
     [Fact(DisplayName = "Random floats can be generated deterministically")]
     public static void Case25() => 
-        TR.generateFloat().Run(test()).ThrowIfFail().Should().Be(3733900F);
+        TR.nextFloat().Run(test()).ThrowIfFail().Should().Be(3733900F);
 
     [Fact(DisplayName = "Random floats within a range can be generated deterministically")]
     public static void Case25b() => 
-        TR.generateFloat(0.8F, 0.9F).Run(test()).ThrowIfFail().Should().Be(0.8353472F);
+        TR.nextFloat(0.8F, 0.9F).Run(test()).ThrowIfFail().Should().Be(0.8353472F);
 
     [Fact(DisplayName = "Random guids can be generated deterministically")]
     public static void Case26() =>
-        TR.generateGuid()
+        TR.nextGuid()
             .Run(test())
             .ThrowIfFail()
             .Should()
@@ -213,11 +213,11 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random char can be generated deterministically")]
     public static void Case27() => 
-        TR.generateChar().Run(test()).ThrowIfFail().Should().Be('i');
+        TR.nextChar().Run(test()).ThrowIfFail().Should().Be('i');
 
     [Fact(DisplayName = "Random durations between a range can be generated deterministically")]
     public static void Case28() =>
-        TR.generateDuration(10 * seconds, 1 * minute)
+        TR.nextDuration(10 * seconds, 1 * minute)
             .Run(test())
             .ThrowIfFail()
             .Should()
@@ -225,7 +225,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random time spans between a range can be generated deterministically")]
     public static void Case29() =>
-        TR.generateTimespan(10 * seconds, 1 * minute)
+        TR.nextTimespan(10 * seconds, 1 * minute)
             .Run(test())
             .ThrowIfFail()
             .Should()
@@ -233,11 +233,11 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random ranges can be generated deterministically")]
     public static void Case30() =>
-        TR.generateRange(TR.generateChar(), 4, 25).Run(test()).ThrowIfFail().Should().HaveCount(20);
+        TR.nextRange(TR.nextChar(), 4, 25).Run(test()).ThrowIfFail().Should().HaveCount(20);
 
     [Fact(DisplayName = "Random ranges can be generated with other random effects deterministically")]
     public static void Case31() =>
-        TR.generateRange(TR.generateGuid(), 4, 25)
+        TR.nextRange(TR.nextGuid(), 4, 25)
             .Run(test())
             .ThrowIfFail()
             .Should()
@@ -246,15 +246,15 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random strings can be generated")]
     public static void Case32() =>
-        LR.generateString(4, 25).Run(live).ThrowIfFail().Should().NotBeEmpty();
+        LR.nextString(4, 25).Run(live).ThrowIfFail().Should().NotBeEmpty();
 
     [Fact(DisplayName = "Random strings can be generated deterministically")]
     public static void Case33() =>
-        TR.generateString(4, 25).Run(test()).ThrowIfFail().Should().Be("g9.XyvJR3Ng\"J-v<br`E");
+        TR.nextString(4, 25).Run(test()).ThrowIfFail().Should().Be("g9.XyvJR3Ng\"J-v<br`E");
 
     [Fact(DisplayName = "Random chars in a range can be generated")]
     public static void Case34() =>
-        LR.generateChar('a', 'z')
+        LR.nextChar('a', 'z')
             .Run(live)
             .ThrowIfFail()
             .Should()
@@ -263,7 +263,7 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random chars in a range can be generated deterministically")]
     public static void Case35() => 
-        TR.generateChar('a', 'z').Run(test()).ThrowIfFail().Should().Be('t');
+        TR.nextChar('a', 'z').Run(test()).ThrowIfFail().Should().Be('t');
 
     [Fact(DisplayName = "Random pick will get a random element from the collection")]
     public static void Case36() =>
@@ -280,15 +280,15 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random enum will get a random enum from the enumeration")]
     public static void Case38() =>
-        LR.generateEnum<LogLevel>().Run(live).ThrowIfFail().Should().BeOneOf(Enum.GetValues<LogLevel>());
+        LR.nextEnum<LogLevel>().Run(live).ThrowIfFail().Should().BeOneOf(Enum.GetValues<LogLevel>());
 
     [Fact(DisplayName = "Random enum will get a random enum from the enumeration deterministically")]
     public static void Case39() =>
-        TR.generateEnum<LogLevel>().Run(test()).ThrowIfFail().Should().Be(LogLevel.Warning);
+        TR.nextEnum<LogLevel>().Run(test()).ThrowIfFail().Should().Be(LogLevel.Warning);
 
     [Fact(DisplayName = "Random boolean can be generated deterministically")]
     public static void Case40() => 
-        TR.generateBool().Run(test()).ThrowIfFail().Should().BeTrue();
+        TR.nextBool().Run(test()).ThrowIfFail().Should().BeTrue();
 
     [Fact(DisplayName = "Random weighted pick can be returned")]
     public static void Case41()
@@ -347,8 +347,8 @@ public static class RandomTests
 
     [Fact(DisplayName = "Random tuples can be generated")]
     public static void Case44() => (
-            from a in TR.generateInt()
-            from b in TR.generateInt()
+            from a in TR.nextInt()
+            from b in TR.nextInt()
             select (a, b)).Run(test())
         .ThrowIfFail()
         .Should()


### PR DESCRIPTION
This implements an environment trait to support injectable random IO.

This can be extended to support new performance improvements in net6+ around generating fractional primitives.

This does not re-invent anything, it just wraps the default netcore Random class and adds enough functions on top to be useful. Inspiration from the Haskell and Elm Random modules was taken, but no additional type-class(es) was added, this can be looked into later, if the flexibility offered here is not enough.

Another great random module is the rust one, that was very powerful but overkill for what most C# dev needs.

Open to any and all comments and suggestions for improvement.