### PR TITLE
Nullability Annotations for Prelude of OptionAsync

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.Prelude.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.Prelude.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -150,7 +151,7 @@ namespace LanguageExt
         /// <param name="value">Value to be made OptionAsyncal, or null</param>
         /// <returns>If the value is null it will be None else Some(value)</returns>
         [Pure]
-        public static OptionAsync<T> OptionalAsync<T>(Task<T> value) =>
+        public static OptionAsync<T> OptionalAsync<T>(Task<T?> value) =>
             OptionAsync<T>.OptionalAsync(value);
 
         /// <summary>
@@ -160,7 +161,7 @@ namespace LanguageExt
         /// <param name="f">A function that returns the value to construct the OptionAsync with</param>
         /// <returns>A lazy OptionAsync<T></returns>
         [Pure]
-        public static OptionAsync<T> OptionalAsync<T>(Func<Unit, Task<T>> f) =>
+        public static OptionAsync<T> OptionalAsync<T>(Func<Unit, Task<T?>> f) =>
             OptionAsync<T>.OptionalAsync(f(unit));
 
         /// <summary>


### PR DESCRIPTION
This relates to #1193 - as [commented](https://github.com/louthy/language-ext/issues/1193#issuecomment-1445282575) this doesn't fix a bug in LanugageExt but just improves the API:

I enabled nullable for the whole of OptionAsync.Prelude.cs - went through all methods and changed nullability where necessary.

(I also ran all the unit tests which are still green).