### PR TITLE
Fix links that got injured during master to main branch name change

### DIFF
--- a/LanguageExt.Core/Immutable Collections/README.md
+++ b/LanguageExt.Core/Immutable Collections/README.md
@@ -1,4 +1,4 @@
-This a suite of [very high-performance immutable-collections](https://github.com/louthy/language-ext/blob/master/Performance.md).
+This a suite of [very high-performance immutable-collections](https://github.com/louthy/language-ext/blob/main/Performance.md).
 
 * For lists you should always prefer to use `Seq<A>` - it is about 10x faster than `Lst<A>`.  The only reason you'd pick 
   `Lst<A>` is if you needed to do inserts into the middle of the list: `Seq<A>` doesn't allow this (it only allows prepending or 

--- a/README.md
+++ b/README.md
@@ -1138,7 +1138,7 @@ public void TreeTests()
     Assert.True(treeA != treeC);
 }
 ```
-There are some [unit tests](https://github.com/louthy/language-ext/blob/master/LanguageExt.Tests/RecordTypesTest.cs) to see this in action.
+There are some [unit tests](https://github.com/louthy/language-ext/blob/main/LanguageExt.Tests/RecordTypesTest.cs) to see this in action.
 
 > Inheritance is not supported in `Record` derived types, so if you derive a type from a type that derives from `Record` then you won't magically inherit any equality, ordering, hash-code, etc. behaviours. This feature is explicitly here to implement record-like functionality, which do not support inheritance in other functional languages. Equality of origin is explicitly checked for.
 
@@ -2027,5 +2027,5 @@ As well as the extensions, there are also static classes for the transformer typ
 ```
 ## Contributing & Code of Conduct
 
-If you would like to get involved with this project, please first read the [Contribution Guidelines](https://github.com/louthy/language-ext/blob/master/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/louthy/language-ext/blob/master/CODE_OF_CONDUCT.md).
+If you would like to get involved with this project, please first read the [Contribution Guidelines](https://github.com/louthy/language-ext/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/louthy/language-ext/blob/main/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
This resolves the "Branch not found, redirected to default branch." warning displayed by GitHub,