### PR TITLE
Remove MemoryFS dependency on Windows Path implementation

### DIFF
--- a/LanguageExt.Tests/MemoryFSTests.cs
+++ b/LanguageExt.Tests/MemoryFSTests.cs
@@ -211,8 +211,8 @@ namespace LanguageExt.Tests
 
             var comp = from _1 in Dir.create(srcdir)
                        from _2 in Dir.create(destdir)
-                       from sf in SuccessEff(Path.Combine(srcdir, file))
-                       from df in SuccessEff(Path.Combine(destdir, file))
+                       from sf in SuccessEff(Combine(srcdir, file))
+                       from df in SuccessEff(Combine(destdir, file))
                        from _3 in File.writeAllText(sf, "Hello, World")
                        from _4 in Dir.move(sf, df)
                        from tx in File.readAllText(df)
@@ -222,7 +222,10 @@ namespace LanguageExt.Tests
             var r = await comp.Run(rt);
             Assert.True(r == (false, "Hello, World"), FailMsg(r));
         }
-        
+
+        static string Combine(string path1, string path2) =>
+             path1 + (path1.EndsWith("\\") ? path2 : "\\" + path2);
+
         static string FailMsg<A>(Fin<A> ma) =>
             ma.Match(Succ: _ => "", Fail: e => e.Message);
     }


### PR DESCRIPTION
Hi, long term fan of language-ext 😄 

I ran all `LanguageExt.Tests` tests on macOS (.NET 7.0) and some fail, mostly due to `MemoryFS` using `Path.IsPathRooted()`, `Path.DirectorySeparatorChar` etc with error:

```
System.IO.IOException : Path not rooted: C:
   at LanguageExt.Sys.MemoryFS.ParsePath(String path) in /Users/_/code/language-ext/LanguageExt.Sys/MemoryFS.cs:line 51
```

In this PR I've modified `MemoryFS` and `MemoryFSTests` to behave the same independent of the host OS, and therefore enable the tests to pass. The replacement methods aren't 100% realistic but I hope acceptable for this usage. There remains a dependency on `System.IO` for some exceptions and other types.

`MemoryFS` use of  Windows file paths is unchanged so there is no breaking change.

Thanks
