### PR TITLE
Fix fin enumerator

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
@@ -21,7 +21,7 @@ namespace LanguageExt
         IComparable<Fin<A>>, 
         IComparable, 
         IEquatable<Fin<A>>,
-        IEnumerable<Fin<A>>,
+        IEnumerable<A>,
         ISerializable
     {
         internal readonly Error error;
@@ -384,7 +384,7 @@ namespace LanguageExt
             (IsSucc && other.IsSucc && default(EqDefault<A>).Equals(value, other.value)) || (IsSucc == false && other.IsSucc == false);
 
         [Pure, MethodImpl(Opt.Default)]
-        public IEnumerator<Fin<A>> GetEnumerator()
+        public IEnumerator<A> GetEnumerator()
         {
             if (IsSucc)
             {

--- a/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Fin/Fin.cs
@@ -21,7 +21,7 @@ namespace LanguageExt
         IComparable<Fin<A>>, 
         IComparable, 
         IEquatable<Fin<A>>,
-        IEnumerable<A>,
+        IEnumerable<EitherData<Error, A>>,
         ISerializable
     {
         internal readonly Error error;
@@ -383,14 +383,18 @@ namespace LanguageExt
         public bool Equals(Fin<A> other) =>
             (IsSucc && other.IsSucc && default(EqDefault<A>).Equals(value, other.value)) || (IsSucc == false && other.IsSucc == false);
 
-        [Pure, MethodImpl(Opt.Default)]
-        public IEnumerator<A> GetEnumerator()
+        IEnumerable<EitherData<Error, A>> EitherEnum()
         {
-            if (IsSucc)
-            {
-                yield return Value;
-            }
+            yield return new EitherData<Error, A>(IsSucc ? EitherStatus.IsRight : EitherStatus.IsLeft, value, error);
         }
+
+        [Pure, MethodImpl(Opt.Default)]
+        public IEnumerator<EitherData<Error, A>> GetEnumerator() =>
+            EitherEnum().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            EitherEnum().GetEnumerator();
+    
 
         [Pure, MethodImpl(Opt.Default)]
         public override string ToString() =>
@@ -425,9 +429,6 @@ namespace LanguageExt
                 error = (Error)info.GetValue("Fail", typeof(Error));
             }
         }
-
-        IEnumerator IEnumerable.GetEnumerator() =>
-            GetEnumerator();
 
         [Pure, MethodImpl(Opt.Default)]
         public int CompareTo(object obj) =>

--- a/LanguageExt.Tests/FinTests.cs
+++ b/LanguageExt.Tests/FinTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Xunit;
+using static LanguageExt.Prelude;
+
+namespace LanguageExt.Tests
+{
+    
+    public class FinTests
+    {
+        [Fact] public void Equality()
+        {
+            var fin1 = FinSucc(1);
+            Assert.Equal(1, fin1);
+        }
+        
+        [Fact] public void Enumerability()
+        {
+            var fin1 = FinSucc(1);
+            Assert.Equal(1, fin1.HeadOrNone());
+        }
+    }
+}

--- a/LanguageExt.Tests/FinTests.cs
+++ b/LanguageExt.Tests/FinTests.cs
@@ -1,22 +1,32 @@
-﻿using System;
+﻿using System.Linq;
 using Xunit;
 using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {
-    
     public class FinTests
     {
-        [Fact] public void Equality()
+        [Fact]
+        public void Equality()
         {
             var fin1 = FinSucc(1);
             Assert.Equal(1, fin1);
         }
-        
-        [Fact] public void Enumerability()
+
+        [Fact]
+        public void Enumerability()
         {
             var fin1 = FinSucc(1);
-            Assert.Equal(1, fin1.HeadOrNone());
+            Assert.True(fin1.Single() is 1, fin1.ToString());
+        }
+
+        [Fact]
+        public void LinqEnumerability()
+        {
+            Assert.Equal(Array(6), from x in FinSucc(2) from y in Some(3) select x * y);
+            Assert.Equal(Array(6), from x in FinSucc(2) from y in Set(3) select x * y);
+            Assert.Equal(Array(6), from x in Some(2) from y in FinSucc(3) select x * y);
+            Assert.Equal(Array(6), from x in Some(2) from y in FinSucc(3) select x * y);
         }
     }
 }

--- a/LanguageExt.Tests/FinTests.cs
+++ b/LanguageExt.Tests/FinTests.cs
@@ -17,16 +17,16 @@ namespace LanguageExt.Tests
         public void Enumerability()
         {
             var fin1 = FinSucc(1);
-            Assert.True(fin1.Single() is 1, fin1.ToString());
+            Assert.True(fin1.ToSeq().Single() is 1, fin1.ToString());
         }
 
         [Fact]
         public void LinqEnumerability()
         {
-            Assert.Equal(Array(6), from x in FinSucc(2) from y in Some(3) select x * y);
-            Assert.Equal(Array(6), from x in FinSucc(2) from y in Set(3) select x * y);
-            Assert.Equal(Array(6), from x in Some(2) from y in FinSucc(3) select x * y);
-            Assert.Equal(Array(6), from x in Some(2) from y in FinSucc(3) select x * y);
+            Assert.Equal(Array(6), from x in FinSucc(2).ToSeq() from y in Some(3).ToSeq() select x * y);
+            Assert.Equal(Array(6), from x in FinSucc(2).ToSeq() from y in Set(3).ToSeq() select x * y);
+            Assert.Equal(Array(6), from x in Some(2).ToSeq() from y in FinSucc(3).ToSeq() select x * y);
+            Assert.Equal(Array(6), from x in Some(2).ToSeq() from y in FinSucc(3).ToSeq() select x * y);
         }
     }
 }


### PR DESCRIPTION
`Fin<T>` has wrong type in `IEnumerable<>`.

Side effect of the bug: XUnit will run into stack overflow if `Assert.Equal()` is used (see test).


Workaround: convert to `Option<T>` with e.g. `myFin.ToOption()`