### PR TITLE
Fix codegen record lens

### DIFF
--- a/LanguageExt.CodeGen/CodeGenUtil.cs
+++ b/LanguageExt.CodeGen/CodeGenUtil.cs
@@ -199,7 +199,7 @@ namespace LanguageExt.CodeGen
         public static TypeDeclarationSyntax AddLensProp(TypeDeclarationSyntax partialClass, TypeSyntax returnType, (SyntaxToken Identifier, TypeSyntax Type, SyntaxTokenList Modifiers, SyntaxList<AttributeListSyntax> Attrs) member) =>
             partialClass.AddMembers(
                 PropertyDeclaration(
-                    GenericName(Identifier("Lens"))
+                    GenericName(Identifier("LanguageExt.Lens"))
                         .WithTypeArgumentList(TypeArgumentList(SeparatedList<TypeSyntax>(new[] { returnType, member.Type }))),
                     Identifier(MakeCamelCaseId(member.Identifier).Text))
                 .WithModifiers(
@@ -220,7 +220,7 @@ namespace LanguageExt.CodeGen
         {
             var lfield = FieldDeclaration(
                 VariableDeclaration(
-                    GenericName(Identifier("Lens"))
+                    GenericName(Identifier("LanguageExt.Lens"))
                                  .WithTypeArgumentList(
                                     TypeArgumentList(SeparatedList<TypeSyntax>(new[] { returnType, member.Type }))))
                              .WithVariables(
@@ -231,7 +231,7 @@ namespace LanguageExt.CodeGen
                                                         InvocationExpression(
                                                                             MemberAccessExpression(
                                                                                 SyntaxKind.SimpleMemberAccessExpression,
-                                                                                GenericName("Lens")
+                                                                                GenericName("LanguageExt.Lens")
                                                                                     .WithTypeArgumentList(
                                                                                         TypeArgumentList(
                                                                                             SeparatedList<TypeSyntax>(new[] { returnType, member.Type }))),

--- a/LanguageExt.Tests/RecordCodeGenWithoutUsingLanguageExt.cs
+++ b/LanguageExt.Tests/RecordCodeGenWithoutUsingLanguageExt.cs
@@ -1,0 +1,9 @@
+namespace LanguageExt.Tests;
+
+[Record]
+public partial class RecordCodeGenWithoutUsingLanguageExt
+{
+    public int SomeProperty { get; }
+
+    public static RecordCodeGenWithoutUsingLanguageExt AnotherNew() => New(0b101010);
+}


### PR DESCRIPTION
Files containing '[Record]' classes (codegen) without `using LanguageExt;` failed to compile.