### PR TITLE
Add await support for `OptionAsync`

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.cs
+++ b/LanguageExt.Core/Monads/Alternative Value Monads/Option/OptionAsync/OptionAsync.cs
@@ -140,6 +140,14 @@ namespace LanguageExt
         }
 
         /// <summary>
+        /// Custom awaiter that turns an OptionAsync into an Option
+        /// </summary>
+        public TaskAwaiter<Option<A>> GetAwaiter()
+            => Data.Map(d =>
+                d.IsSome ? Option<A>.Some(d.Value!) : Option<A>.None)
+            .GetAwaiter();
+
+        /// <summary>
         /// Implicit conversion operator from A to Option<A>
         /// </summary>
         /// <param name="a">Unit value</param>

--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -300,6 +300,14 @@ namespace LanguageExt.Tests
             Assert.True(result);
         }
 
+        [Fact]
+        public async Task AwaitSomeCaseTest()
+            => Assert.Equal(Some(10), await OptionAsync<int>.Some(10));
+
+        [Fact]
+        public async Task AwaitNoneCaseTest()
+            => Assert.Equal(None, await OptionAsync<int>.None);
+
         // Not valuable any more 
         //[Fact]
         //public async void SequenceFlip()


### PR DESCRIPTION
I am not sure, if there is a reason why `await EitherAsync<string, int>.Right(4)` should work
 and `await OptionAsync<int>.Some(4)` should not, but here is the fix.
