### PR TITLE
feature: adding Arr CollectionExprisionProvider

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
@@ -45,6 +45,15 @@ namespace LanguageExt
             new Arr<T>(items);
 
         /// <summary>
+        /// Create an array from a initial set of items
+        /// </summary>
+        /// <param name="items">Items</param>
+        /// <returns>Lst T</returns>
+        [Pure]
+        public static Arr<T> create<T>(ReadOnlySpan<T> items) =>
+            items.IsEmpty ? empty<T>() : create(items.ToArray());
+
+        /// <summary>
         /// Add an item to the array
         /// </summary>
         /// <param name="array">Array</param>

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -12,11 +12,14 @@ namespace LanguageExt
 {
     /// <summary>
     /// Immutable array
-    /// Native array O(1) read performance.  Modifications require copying of the entire 
-    /// array to generate the newly mutated version.  This is will be very expensive 
+    /// Native array O(1) read performance.  Modifications require copying of the entire
+    /// array to generate the newly mutated version.  This is will be very expensive
     /// for large arrays.
     /// </summary>
     /// <typeparam name="A">Value type</typeparam>
+#if NET8_0_OR_GREATER
+    [CollectionBuilder(typeof(Arr), nameof(Arr.create))]
+#endif
     [Serializable]
     public struct Arr<A> :
         IEnumerable<A>,
@@ -152,7 +155,7 @@ namespace LanguageExt
         ///
         ///     var res = arr.Case switch
         ///     {
-        ///       
+        ///
         ///        A value         => ...,
         ///        (var x, var xs) => ...,
         ///        _               => ...
@@ -678,7 +681,7 @@ namespace LanguageExt
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int CompareTo(object obj) =>
             obj is Arr<A> t ? CompareTo(t) : 1;
-        
+
         [Pure]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Arr<A> other) =>

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -17,9 +17,7 @@ namespace LanguageExt
     /// for large arrays.
     /// </summary>
     /// <typeparam name="A">Value type</typeparam>
-#if NET8_0_OR_GREATER
     [CollectionBuilder(typeof(Arr), nameof(Arr.create))]
-#endif
     [Serializable]
     public struct Arr<A> :
         IEnumerable<A>,

--- a/LanguageExt.Core/Immutable Collections/CollectionBuilderAttribute.cs
+++ b/LanguageExt.Core/Immutable Collections/CollectionBuilderAttribute.cs
@@ -1,0 +1,31 @@
+﻿#if !NET8_0_OR_GREATER
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices;
+
+/// <summary>Initialize the attribute to refer to the <paramref name="methodName"/> method on the <paramref name="builderType"/> type.</summary>
+/// <param name="builderType">The type of the builder to use to construct the collection.</param>
+/// <param name="methodName">The name of the method on the builder to use to construct the collection.</param>
+/// <remarks>
+/// <paramref name="methodName"/> must refer to a static method that accepts a single parameter of
+/// type <see cref="ReadOnlySpan{T}"/> and returns an instance of the collection being built containing
+/// a copy of the data from that span.  In future releases of .NET, additional patterns may be supported.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
+public sealed class CollectionBuilderAttribute : Attribute
+{
+    public CollectionBuilderAttribute(Type builderType, string methodName)
+    {
+        BuilderType = builderType;
+        MethodName = methodName;
+    }
+
+    /// <summary>Gets the type of the builder to use to construct the collection.</summary>
+    public Type BuilderType { get; }
+
+    /// <summary>Gets the name of the method on the builder to use to construct the collection.</summary>
+    /// <remarks>This should match the metadata name of the target method. For example, this might be ".ctor" if targeting the type's constructor.</remarks>
+    public string MethodName { get; }
+}
+#endif

--- a/LanguageExt.Core/LanguageExt.Core.csproj
+++ b/LanguageExt.Core/LanguageExt.Core.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Configuration">
     <NoWarn>1701;1702;1705;IDE1006;CS1591;CS1573;CS1712;CS1570;CS1711;CS1572;CS1587</NoWarn>
     <DefineConstants>CONTRACTS_FULL</DefineConstants>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <PackageVersion>4.4.7</PackageVersion>
@@ -41,7 +41,7 @@
     <EmbeddedResource Remove="obj\**" />
     <None Remove="obj\**" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="[4.5.4,)" />


### PR DESCRIPTION
enabling C#12 new `collection exprision` syntax for `Arr<T>`
```csharp
Arr<int> arr = [1, 2, 3];
```