### PR TITLE
refactor: use global usings static for prelude

### DIFF
--- a/LanguageExt.Tests/AffTests.cs
+++ b/LanguageExt.Tests/AffTests.cs
@@ -3,7 +3,6 @@ using System;
 using LanguageExt;
 using LanguageExt.Common;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
 
 namespace AffTests
 {

--- a/LanguageExt.Tests/Appendable.cs
+++ b/LanguageExt.Tests/Appendable.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 using static LanguageExt.TypeClass;
 

--- a/LanguageExt.Tests/ApplicativeTests.cs
+++ b/LanguageExt.Tests/ApplicativeTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/ArrayTests.cs
+++ b/LanguageExt.Tests/ArrayTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System;
 using System.Linq;
-using static LanguageExt.Prelude;
 using static LanguageExt.List;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/AtomHashMapEqTests.cs
+++ b/LanguageExt.Tests/AtomHashMapEqTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using Xunit;
+﻿using Xunit;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/AtomHashMapTests.cs
+++ b/LanguageExt.Tests/AtomHashMapTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using Xunit;
+﻿using Xunit;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/AtomTests.cs
+++ b/LanguageExt.Tests/AtomTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using static LanguageExt.Prelude;
 using Xunit;
 using System.Diagnostics;
 

--- a/LanguageExt.Tests/ChoiceTests.cs
+++ b/LanguageExt.Tests/ChoiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using Xunit;
 using System.Threading.Tasks;
 using LanguageExt.Common;

--- a/LanguageExt.Tests/CollectionOrderingTests.cs
+++ b/LanguageExt.Tests/CollectionOrderingTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/CollectionToStringTests.cs
+++ b/LanguageExt.Tests/CollectionToStringTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/CompositionTests.cs
+++ b/LanguageExt.Tests/CompositionTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/CompositionsTests.cs
+++ b/LanguageExt.Tests/CompositionsTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.TypeClass;
+﻿using static LanguageExt.TypeClass;
 using static LanguageExt.Compositions;
 using LanguageExt.ClassInstances;
 using Xunit;

--- a/LanguageExt.Tests/CondTest.cs
+++ b/LanguageExt.Tests/CondTest.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 using static LanguageExt.CondExt;
 using Newtonsoft.Json;
 

--- a/LanguageExt.Tests/DelayTests.cs
+++ b/LanguageExt.Tests/DelayTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.PreludeRx;
+﻿using static LanguageExt.PreludeRx;
 using System.Reactive;
 using System;
 using System.Threading;

--- a/LanguageExt.Tests/DistinctTests.cs
+++ b/LanguageExt.Tests/DistinctTests.cs
@@ -1,6 +1,5 @@
 using System;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using Xunit;
 using System.Threading.Tasks;
 using LanguageExt.Common;

--- a/LanguageExt.Tests/Divisible.cs
+++ b/LanguageExt.Tests/Divisible.cs
@@ -1,6 +1,5 @@
 ﻿using Xunit;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 

--- a/LanguageExt.Tests/EitherApply.cs
+++ b/LanguageExt.Tests/EitherApply.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Xunit;
 using LanguageExt.TypeClasses;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/EitherAsyncTests.cs
+++ b/LanguageExt.Tests/EitherAsyncTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/EitherCoalesceTests.cs
+++ b/LanguageExt.Tests/EitherCoalesceTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/EitherTests.cs
+++ b/LanguageExt.Tests/EitherTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/EitherUnsafeApply.cs
+++ b/LanguageExt.Tests/EitherUnsafeApply.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/EnumerableTTests.cs
+++ b/LanguageExt.Tests/EnumerableTTests.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.ClassInstances;
 //using LanguageExt.Trans;
-using static LanguageExt.Prelude;
 using Xunit;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/EqualityTests.cs
+++ b/LanguageExt.Tests/EqualityTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/LanguageExt.Tests/ErrorTests.cs
+++ b/LanguageExt.Tests/ErrorTests.cs
@@ -3,7 +3,6 @@ using System.Runtime.Serialization;
 using Xunit;
 using LanguageExt.Common;
 using Newtonsoft.Json;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests;
 

--- a/LanguageExt.Tests/ExceptionMatching.cs
+++ b/LanguageExt.Tests/ExceptionMatching.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/FunTests.cs
+++ b/LanguageExt.Tests/FunTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/GlobalUsings.cs
+++ b/LanguageExt.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static LanguageExt.Prelude;

--- a/LanguageExt.Tests/HashMapTests.cs
+++ b/LanguageExt.Tests/HashMapTests.cs
@@ -1,5 +1,5 @@
 ﻿//using LanguageExt.Trans;
-using static LanguageExt.Prelude;
+
 using static LanguageExt.HashMap;
 using Xunit;
 using System;

--- a/LanguageExt.Tests/HashSetTests.cs
+++ b/LanguageExt.Tests/HashSetTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.HashSet;
+﻿using static LanguageExt.HashSet;
 using Xunit;
 using System;
 using System.Linq;

--- a/LanguageExt.Tests/IssuesTests.cs
+++ b/LanguageExt.Tests/IssuesTests.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using LanguageExt;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using Xunit;
 using Newtonsoft.Json;

--- a/LanguageExt.Tests/LensTests.cs
+++ b/LanguageExt.Tests/LensTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/LinqTests.cs
+++ b/LanguageExt.Tests/LinqTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/List.Predicate.Tests.cs
+++ b/LanguageExt.Tests/List.Predicate.Tests.cs
@@ -1,5 +1,4 @@
 ﻿using LanguageExt.ClassInstances.Pred;
-using static LanguageExt.Prelude;
 using Xunit;
 using System;
 using LanguageExt.ClassInstances.Const;

--- a/LanguageExt.Tests/ListMatchingTests.cs
+++ b/LanguageExt.Tests/ListMatchingTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System;
 using System.Linq;
-using static LanguageExt.Prelude;
 using static LanguageExt.List;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/MapTests.cs
+++ b/LanguageExt.Tests/MapTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.Map;
+﻿using static LanguageExt.Map;
 using Xunit;
 using System;
 using System.Linq;

--- a/LanguageExt.Tests/MemoTests.cs
+++ b/LanguageExt.Tests/MemoTests.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Linq;
 using static LanguageExt.List;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/MemoryConsoleTests.cs
+++ b/LanguageExt.Tests/MemoryConsoleTests.cs
@@ -4,8 +4,6 @@ using LanguageExt.Sys;
 using LanguageExt.Sys.IO;
 using LanguageExt.Sys.Test;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
-
 using Console = LanguageExt.Sys.Console<LanguageExt.Sys.Test.Runtime>;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/MemoryFSTests.cs
+++ b/LanguageExt.Tests/MemoryFSTests.cs
@@ -4,8 +4,6 @@ using LanguageExt.Sys;
 using LanguageExt.Sys.IO;
 using LanguageExt.Sys.Test;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
-
 using File = LanguageExt.Sys.IO.File<LanguageExt.Sys.Test.Runtime>;
 using Dir  = LanguageExt.Sys.IO.Directory<LanguageExt.Sys.Test.Runtime>;
 

--- a/LanguageExt.Tests/MonadTests.cs
+++ b/LanguageExt.Tests/MonadTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System;
 using static LanguageExt.List;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Multiplicable.cs
+++ b/LanguageExt.Tests/Multiplicable.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/NonNullTests.cs
+++ b/LanguageExt.Tests/NonNullTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using Xunit;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/OptionApply.cs
+++ b/LanguageExt.Tests/OptionApply.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Xunit;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/OptionAsyncTests.cs
+++ b/LanguageExt.Tests/OptionAsyncTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/OptionCoalesceTests.cs
+++ b/LanguageExt.Tests/OptionCoalesceTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/OptionTTests.cs
+++ b/LanguageExt.Tests/OptionTTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 //using LanguageExt.Trans;
 using LanguageExt.TypeClasses;
 using static LanguageExt.TypeClass;
-using static LanguageExt.Prelude;
 using static LanguageExt.List;
 using Xunit;
 using LanguageExt.ClassInstances;

--- a/LanguageExt.Tests/OptionTests.cs
+++ b/LanguageExt.Tests/OptionTests.cs
@@ -1,7 +1,6 @@
 ﻿using Xunit;
 using System;
 using System.Collections.Generic;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/OptionUnsafeApply.cs
+++ b/LanguageExt.Tests/OptionUnsafeApply.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/ParsecIOTests.cs
+++ b/LanguageExt.Tests/ParsecIOTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.Common;
 using LanguageExt.Parsec;
-using static LanguageExt.Prelude;
 using static LanguageExt.Parsec.PrimIO;
 using static LanguageExt.Parsec.ItemIO;
 using static LanguageExt.Parsec.IndentIO;

--- a/LanguageExt.Tests/ParsecTests.cs
+++ b/LanguageExt.Tests/ParsecTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Xunit;
 using M = LanguageExt.Map;
 using LanguageExt.Parsec;
-using static LanguageExt.Prelude;
 using static LanguageExt.Parsec.Prim;
 using static LanguageExt.Parsec.Char;
 using static LanguageExt.Parsec.Expr;

--- a/LanguageExt.Tests/Parsing/AbstractParseTTests.cs
+++ b/LanguageExt.Tests/Parsing/AbstractParseTTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Parsing
 {

--- a/LanguageExt.Tests/PartialAndCurryingTests.cs
+++ b/LanguageExt.Tests/PartialAndCurryingTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/PatchTests.cs
+++ b/LanguageExt.Tests/PatchTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.Patch;
+﻿using static LanguageExt.Patch;
 using LanguageExt.ClassInstances;
 using Xunit;
 

--- a/LanguageExt.Tests/PipesTests.cs
+++ b/LanguageExt.Tests/PipesTests.cs
@@ -4,7 +4,6 @@ using LanguageExt.Sys.Test;
 using Xunit;
 
 using static LanguageExt.Pipes.Proxy;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests;
 

--- a/LanguageExt.Tests/PredicateTests.cs
+++ b/LanguageExt.Tests/PredicateTests.cs
@@ -1,5 +1,4 @@
 ﻿using LanguageExt.ClassInstances.Pred;
-using static LanguageExt.Prelude;
 using Xunit;
 using System;
 using LanguageExt.ClassInstances.Const;

--- a/LanguageExt.Tests/PrismTests.cs
+++ b/LanguageExt.Tests/PrismTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/QueryTests.cs
+++ b/LanguageExt.Tests/QueryTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 using static LanguageExt.Query;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/QueueTests.cs
+++ b/LanguageExt.Tests/QueueTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.List;
+﻿using static LanguageExt.List;
 using static LanguageExt.Queue;
 using Xunit;
 

--- a/LanguageExt.Tests/RangeTests.cs
+++ b/LanguageExt.Tests/RangeTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using Xunit;
+﻿using Xunit;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/Read-Me.cs
+++ b/LanguageExt.Tests/Read-Me.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/RefTest.cs
+++ b/LanguageExt.Tests/RefTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Regression/Issue283.cs
+++ b/LanguageExt.Tests/Regression/Issue283.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Regression
 {

--- a/LanguageExt.Tests/ScheduleTest/AffTests.cs
+++ b/LanguageExt.Tests/ScheduleTest/AffTests.cs
@@ -9,7 +9,6 @@ using LanguageExt.Sys;
 using LanguageExt.Sys.Test;
 using LanguageExt.Sys.Traits;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.ScheduleTest;
 

--- a/LanguageExt.Tests/ScheduleTest/EffTests.cs
+++ b/LanguageExt.Tests/ScheduleTest/EffTests.cs
@@ -7,7 +7,6 @@ using LanguageExt.Sys;
 using LanguageExt.Sys.Test;
 using LanguageExt.Sys.Traits;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.ScheduleTest;
 

--- a/LanguageExt.Tests/ScheduleTest/ScheduleChangesTests.cs
+++ b/LanguageExt.Tests/ScheduleTest/ScheduleChangesTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.ScheduleTest;
 

--- a/LanguageExt.Tests/ScheduleTest/ScheduleTests.cs
+++ b/LanguageExt.Tests/ScheduleTest/ScheduleTests.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.ScheduleTest
 {

--- a/LanguageExt.Tests/Seq.Arr.Tests.cs
+++ b/LanguageExt.Tests/Seq.Arr.Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Seq.Cons.Tests.cs
+++ b/LanguageExt.Tests/Seq.Cons.Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Seq.Enumerable.Tests.cs
+++ b/LanguageExt.Tests/Seq.Enumerable.Tests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Seq.IList.Tests.cs
+++ b/LanguageExt.Tests/Seq.IList.Tests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Seq.Lst.Tests.cs
+++ b/LanguageExt.Tests/Seq.Lst.Tests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/Seq.Module.Tests.cs
+++ b/LanguageExt.Tests/Seq.Module.Tests.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 using static LanguageExt.Seq;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/SeqTypes/SeqListTests.cs
+++ b/LanguageExt.Tests/SeqTypes/SeqListTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.SeqTypes
 {

--- a/LanguageExt.Tests/SequenceStackSafetyTests.cs
+++ b/LanguageExt.Tests/SequenceStackSafetyTests.cs
@@ -6,8 +6,7 @@ using Xunit;
 namespace LanguageExt.Tests
 {
     using static Enumerable;
-    using static Prelude;
-    
+
     public class SequenceStackSafetyTests
     {
         [Fact(Skip = "This is fixed in the Traverse branch")]

--- a/LanguageExt.Tests/SerialisationTests.cs
+++ b/LanguageExt.Tests/SerialisationTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using static LanguageExt.Prelude;
 using Xunit;
 using Newtonsoft.Json;
 using System.Runtime.Serialization;

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -1,5 +1,4 @@
 ﻿using L = LanguageExt;
-using static LanguageExt.Prelude;
 using static LanguageExt.Map;
 using Xunit;
 using System;

--- a/LanguageExt.Tests/StackTests.cs
+++ b/LanguageExt.Tests/StackTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.List;
+﻿using static LanguageExt.List;
 using static LanguageExt.Stack;
 using Xunit;
 

--- a/LanguageExt.Tests/Subtractable.cs
+++ b/LanguageExt.Tests/Subtractable.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/SysX/Diag/ActivityTests.cs
+++ b/LanguageExt.Tests/SysX/Diag/ActivityTests.cs
@@ -6,7 +6,6 @@ using LanguageExt.SysX.Test;
 using Xunit;
 using System.Diagnostics;
 using FluentAssertions;
-using static LanguageExt.Prelude;
 using static LanguageExt.AffExtensions;
 
 namespace LanguageExt.Tests.SysX.Diag;

--- a/LanguageExt.Tests/TaskTests.cs
+++ b/LanguageExt.Tests/TaskTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TrackingHashMapTests.cs
+++ b/LanguageExt.Tests/TrackingHashMapTests.cs
@@ -1,5 +1,4 @@
-﻿using static LanguageExt.Prelude;
-using static LanguageExt.HashMap;
+﻿using static LanguageExt.HashMap;
 using Xunit;
 using System;
 using System.Linq;

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/HashSet.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/IEnumerable.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Set.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Collections/Stck.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Identity.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Option.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/Try.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/TryOption.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Arr/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ArrT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Arr.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/IEnumerable.cs
@@ -4,7 +4,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Lst.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Que.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Seq.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Set.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Collections/Stck.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Either.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Option.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/Try.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/TryOption.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Either/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Either/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/EitherAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/EitherAsync.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/OptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/OptionAsync.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TaskAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TaskAsync.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TryAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TryAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TryOptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Async/TryOptionAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/IEnumerable.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Stack.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Collections/Stack.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Either.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Option.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/Try.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/TryOption.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherAsync/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Arr.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/IEnumerable.cs
@@ -4,7 +4,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Lst.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Que.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Seq.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Set.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Collections/Stck.cs
@@ -1,7 +1,6 @@
 using LanguageExt;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Either.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Option.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/Try.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/TryOption.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/EitherUnsafe/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using Xunit;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.EitherUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Arr.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/HashSet.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Lst.cs
@@ -4,7 +4,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Que.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Seq.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Set.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Collections/Stck.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Either.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/EitherUnsafe.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Identity.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Option.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/OptionUnsafe.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/Try.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/TryOption.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/HashSet/Sync/ValidationSeq.cs
@@ -3,7 +3,6 @@ using Xunit;
 using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.HashSetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Arr.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/IEnumerable.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Lst.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Que.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Seq.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Set.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Collections/Stck.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Either.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/EitherUnsafe.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Option.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/Try.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/TryOption.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/IEnumerable/Sync/ValidationSeq.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.IEnumerableT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Arr.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/HashSet.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/IEnumerable.cs
@@ -1,6 +1,5 @@
 ﻿using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Lst.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Que.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Seq.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Set.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Collections/Stck.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Either.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Identity.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Option.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/Try.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/TryOption.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Identity/Sync/ValidationSeq.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 using LanguageExt.Common;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Identity.Sync

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/HashSet.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/IEnumerable.cs
@@ -4,8 +4,6 @@ using G = System.Collections.Generic;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {
-    using static Prelude;
-    
     public class IEnumerableLst
     {
         G.IEnumerable<T> mkEnum<T>(params T[] ts)

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Set.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Collections/Stck.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using Xunit.Abstractions;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Identity.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Option.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using Xunit.Abstractions;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using Xunit.Abstractions;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Lst/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Lst.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Arr.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/HashSet.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/IEnumerable.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Lst.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Que.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Seq.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Set.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Collections/Stck.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Either.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/EitherUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Identity.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Option.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/OptionUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Option/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Option/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/EitherAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/EitherAsync.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/OptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/OptionAsync.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TaskAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TaskAsync.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TryAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TryAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TryOptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Async/TryOptionAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/IEnumerable.cs
@@ -2,7 +2,6 @@ using Xunit;
 using System;
 using System.Linq;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Stack.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Collections/Stack.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Either.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/EitherUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Identity.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Option.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/OptionUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionAsync/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Arr.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/HashSet.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/IEnumerabler.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/IEnumerabler.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Lst.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Que.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Seq.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Set.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Collections/Stck.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Either.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/EitherUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Identity.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Option.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/OptionUnsafe.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/OptionUnsafe/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.OptionUnsafeT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/IEnumerable.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Set.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Collections/Stck.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Identity.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Option.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/Try.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/TryOption.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Que/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Que/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.QueT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/HashSet.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/IEnumerable.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Lst.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Set.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Collections/Stck.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Identity.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Option.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/OptionUnsafe.cs
@@ -1,6 +1,5 @@
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/TryOption.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Validation.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/Validation.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/ValidationWithMonoid.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SeqT/Sync/ValidationWithMonoid.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SeqT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Arr.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/HashSet.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/IEnumerable.cs
@@ -5,8 +5,6 @@ using F = LanguageExt;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {
-    using static Prelude;
-    
     public class IEnumerableSet
     {
         G.IEnumerable<T> mkEnum<T>(params T[] ts)

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Que.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Seq.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Set.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Collections/Stck.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Identity.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Option.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/Try.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/TryOption.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/SetT/Sync/ValidationSeq.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.SetT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Arr.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/HashSet.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/IEnumerable.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Que.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Seq.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Set.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Collections/Stck.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Either.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/EitherUnsafe.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Identity.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Option.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/OptionUnsafe.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/Try.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/TryOption.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Stck/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Stck.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Async/EitherAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Async/EitherAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Async/OptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Async/OptionAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Async/TaskAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Async/TaskAsync.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.Common;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TaskT.Async

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Async/TryAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Async/TryAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Async/TryOptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Async/TryOptionAsync.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Arr.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/IEnumerable.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TaskT.Collections

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Lst.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Que.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Seq.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using System;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Stack.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Collections/Stack.cs
@@ -1,6 +1,5 @@
 using System;
 using Xunit;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Either.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Option.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 

--- a/LanguageExt.Tests/Transformer/Traverse/Task/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Task/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 using Xunit;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 using System.Threading.Tasks;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TaskT.Sync

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Arr.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/HashSet.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/IEnumerabler.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/IEnumerabler.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Lst.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Que.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Seq.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Set.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Collections/Stck.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Either.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/EitherUnsafe.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Identity.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Option.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/OptionUnsafe.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/Try.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/TryOption.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Try/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Try/Sync/ValidationSeq.cs
@@ -2,7 +2,6 @@ using System;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/EitherAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/EitherAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/OptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/OptionAsync.cs
@@ -4,7 +4,6 @@ using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using LanguageExt.TypeClasses;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TaskAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TaskAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TryAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TryAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TryOptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Async/TryOptionAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Arr.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/IEnumerable.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Lst.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Que.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Seq.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Stack.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Collections/Stack.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Either.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/EitherUnsafe.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Identity.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Option.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/OptionUnsafe.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/Try.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/TryOption.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryAsync/Sync/ValidationSeq.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Arr.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/IEnumerable.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Lst.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Que.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Seq.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Set.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Collections/Stck.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Either.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/EitherUnsafe.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Identity.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Option.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/Try.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 using System;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOption/Sync/ValidationSeq.cs
@@ -2,7 +2,6 @@ using System;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/EitherAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/EitherAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/OptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/OptionAsync.cs
@@ -4,7 +4,6 @@ using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using LanguageExt.TypeClasses;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TaskAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TaskAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TryAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TryAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TryOptionAsync.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Async/TryOptionAsync.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Async
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Arr.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/IEnumerable.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Lst.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Que.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Seq.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Stack.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Collections/Stack.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using LanguageExt.ClassInstances;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Either.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/EitherUnsafe.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Identity.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Option.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/OptionUnsafe.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/Try.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/TryOption.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/TryOptionAsync/Sync/ValidationSeq.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.TryOptionAsyncT.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Arr.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/HashSet.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/IEnumerable.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Lst.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Que.cs
@@ -1,8 +1,7 @@
 ﻿    using LanguageExt.Common;
     using Xunit;
-    using static LanguageExt.Prelude;
 
-namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
+    namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {
     public class Que
     {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Seq.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Set.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Collections/Stck.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Either.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/EitherUnsafe.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Identity.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Option.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/OptionUnsafe.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/Try.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/TryOption.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/ValidationSeq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/Validation/Sync/ValidationSeq.cs
@@ -1,6 +1,5 @@
 ﻿using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.Validation.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Arr.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Arr.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/HashSet.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/HashSet.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/IEnumerable.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/IEnumerable.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Lst.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Lst.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Que.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Que.cs
@@ -1,9 +1,8 @@
 ﻿    using LanguageExt.ClassInstances;
     using LanguageExt.Common;
     using Xunit;
-    using static LanguageExt.Prelude;
 
-namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
+    namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {
     public class Que
     {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Seq.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Seq.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Set.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Set.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Stck.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Collections/Stck.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Collections
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Either.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Either.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/EitherUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/EitherUnsafe.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Identity.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Identity.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Option.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Option.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/OptionUnsafe.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/OptionUnsafe.cs
@@ -1,7 +1,6 @@
 ﻿using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Try.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/Try.cs
@@ -2,7 +2,6 @@
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/TryOption.cs
+++ b/LanguageExt.Tests/Transformer/Traverse/ValidationMonoid/Sync/TryOption.cs
@@ -2,7 +2,6 @@
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests.Transformer.Traverse.ValidationMonoid.Sync
 {

--- a/LanguageExt.Tests/TraverseTests.cs
+++ b/LanguageExt.Tests/TraverseTests.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/TryApply.cs
+++ b/LanguageExt.Tests/TryApply.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TryAsyncTEsts.cs
+++ b/LanguageExt.Tests/TryAsyncTEsts.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
 using Xunit;
 using LanguageExt.ClassInstances;
 using System.Diagnostics;

--- a/LanguageExt.Tests/TryBottom.cs
+++ b/LanguageExt.Tests/TryBottom.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TryMemo.cs
+++ b/LanguageExt.Tests/TryMemo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TryMonadTests.cs
+++ b/LanguageExt.Tests/TryMonadTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 using LanguageExt.ClassInstances;
 using System;
 using System.Net.Http;

--- a/LanguageExt.Tests/TryOption.cs
+++ b/LanguageExt.Tests/TryOption.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.Common;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TryOptionApply.cs
+++ b/LanguageExt.Tests/TryOptionApply.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TryOptionMonadTests.cs
+++ b/LanguageExt.Tests/TryOptionMonadTests.cs
@@ -1,6 +1,5 @@
 ﻿using Xunit;
 using System.Linq;
-using static LanguageExt.Prelude;
 using System.Collections.Generic;
 using System;
 

--- a/LanguageExt.Tests/TryOutTests.cs
+++ b/LanguageExt.Tests/TryOutTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TrySimpleTests.cs
+++ b/LanguageExt.Tests/TrySimpleTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TupleTests.cs
+++ b/LanguageExt.Tests/TupleTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/TypeClassBiFunctor.cs
+++ b/LanguageExt.Tests/TypeClassBiFunctor.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/TypeClassBool.cs
+++ b/LanguageExt.Tests/TypeClassBool.cs
@@ -3,7 +3,6 @@ using Xunit;
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/TypeClassFoldable.cs
+++ b/LanguageExt.Tests/TypeClassFoldable.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using System;
 

--- a/LanguageExt.Tests/TypeClassFunctor.cs
+++ b/LanguageExt.Tests/TypeClassFunctor.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 using System;
 

--- a/LanguageExt.Tests/TypeClassMonad.cs
+++ b/LanguageExt.Tests/TypeClassMonad.cs
@@ -3,7 +3,6 @@ using System;
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/TypeClassMonoid.cs
+++ b/LanguageExt.Tests/TypeClassMonoid.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using LanguageExt.TypeClasses;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using static LanguageExt.TypeClass;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/UnitsOfMeasureTests.cs
+++ b/LanguageExt.Tests/UnitsOfMeasureTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using LanguageExt.UnitsOfMeasure;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/UnsafeTests.cs
+++ b/LanguageExt.Tests/UnsafeTests.cs
@@ -1,5 +1,4 @@
 ﻿using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/UseFamilyTests.cs
+++ b/LanguageExt.Tests/UseFamilyTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/ValidationTests.cs
+++ b/LanguageExt.Tests/ValidationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using LanguageExt.ClassInstances;
-using static LanguageExt.Prelude;
 using Xunit;
 
 namespace LanguageExt.Tests

--- a/LanguageExt.Tests/VectorClockTests.cs
+++ b/LanguageExt.Tests/VectorClockTests.cs
@@ -1,6 +1,5 @@
 using Newtonsoft.Json;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/LanguageExt.Tests/VersionHashMapTests.cs
+++ b/LanguageExt.Tests/VersionHashMapTests.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using Newtonsoft.Json;
 using Xunit;
-using static LanguageExt.Prelude;
 
 namespace LanguageExt.Tests
 {

--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ If you are concerned about writing functionally and the possible performance ove
 ## Getting started
 
 To use this library, simply include `LanguageExt.Core.dll` in your project or grab it from NuGet, and add this to the top of each `.cs` file that needs it:
+
 ```C#
 using LanguageExt;
 using static LanguageExt.Prelude;
 ```
+or put it into the `GlobalUsings.cs` (introduced in C# 10).
 
 The namespace `LanguageExt` contains the core types, and `LanguageExt.Prelude` contains the functions that you bring into scope `using static LanguageExt.Prelude`.
 

--- a/Samples/EffectsExamples/Examples/CancelExample.cs
+++ b/Samples/EffectsExamples/Examples/CancelExample.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/Examples/ErrorAndGuardExample.cs
+++ b/Samples/EffectsExamples/Examples/ErrorAndGuardExample.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.Sys;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/Examples/FoldTest.cs
+++ b/Samples/EffectsExamples/Examples/FoldTest.cs
@@ -5,7 +5,6 @@ using LanguageExt.Pipes;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 using static LanguageExt.Pipes.Proxy;
 
 namespace EffectsExamples

--- a/Samples/EffectsExamples/Examples/ForkCancelExample.cs
+++ b/Samples/EffectsExamples/Examples/ForkCancelExample.cs
@@ -2,7 +2,6 @@
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/Examples/QueueExample.cs
+++ b/Samples/EffectsExamples/Examples/QueueExample.cs
@@ -4,7 +4,6 @@ using LanguageExt.Pipes;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 using static LanguageExt.Pipes.Proxy;
 
 namespace EffectsExamples

--- a/Samples/EffectsExamples/Examples/RetryExample.cs
+++ b/Samples/EffectsExamples/Examples/RetryExample.cs
@@ -3,7 +3,6 @@ using LanguageExt.Common;
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/Examples/TextFileChunkStreamExample.cs
+++ b/Samples/EffectsExamples/Examples/TextFileChunkStreamExample.cs
@@ -6,7 +6,6 @@ using LanguageExt.Sys.IO;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 using static LanguageExt.Pipes.Proxy;
 
 namespace EffectsExamples

--- a/Samples/EffectsExamples/Examples/TextFileLineStreamExample.cs
+++ b/Samples/EffectsExamples/Examples/TextFileLineStreamExample.cs
@@ -5,7 +5,6 @@ using LanguageExt.Sys.IO;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 using static LanguageExt.Pipes.Proxy;
 
 namespace EffectsExamples

--- a/Samples/EffectsExamples/Examples/TimeExample.cs
+++ b/Samples/EffectsExamples/Examples/TimeExample.cs
@@ -2,7 +2,6 @@
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/Examples/TimeoutExample.cs
+++ b/Samples/EffectsExamples/Examples/TimeoutExample.cs
@@ -3,7 +3,6 @@ using LanguageExt.Sys;
 using LanguageExt.Common;
 using LanguageExt.Sys.Traits;
 using LanguageExt.Effects.Traits;
-using static LanguageExt.Prelude;
 
 namespace EffectsExamples
 {

--- a/Samples/EffectsExamples/GlobalUsings.cs
+++ b/Samples/EffectsExamples/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static LanguageExt.Prelude;

--- a/Samples/EffectsExamples/Menu.cs
+++ b/Samples/EffectsExamples/Menu.cs
@@ -3,7 +3,6 @@ using LanguageExt;
 using LanguageExt.Common;
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
-using static LanguageExt.Prelude;
 using LanguageExt.Effects.Traits;
 
 namespace EffectsExamples

--- a/Samples/RecordsNetCore/Program.cs
+++ b/Samples/RecordsNetCore/Program.cs
@@ -1,5 +1,4 @@
 ﻿using LanguageExt;
-using static LanguageExt.Prelude;
 using System;
 
 namespace RecordsNetCore

--- a/Samples/TestBed/ApplicativeTest.cs
+++ b/Samples/TestBed/ApplicativeTest.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using LanguageExt;
 using System.Threading.Tasks;
-using static LanguageExt.Prelude;
 
 public static class ApplicativeTest
 {

--- a/Samples/TestBed/AtomHashMapPerf.cs
+++ b/Samples/TestBed/AtomHashMapPerf.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using LanguageExt;
-using static LanguageExt.Prelude;
 
 namespace TestBed
 {

--- a/Samples/TestBed/AtomHashMapTests.cs
+++ b/Samples/TestBed/AtomHashMapTests.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using LanguageExt;
-using static LanguageExt.Prelude;
 
 namespace TestBed
 {

--- a/Samples/TestBed/GlobalUsings.cs
+++ b/Samples/TestBed/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static LanguageExt.Prelude;

--- a/Samples/TestBed/Issue1234.cs
+++ b/Samples/TestBed/Issue1234.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using LanguageExt;
 using LanguageExt.Sys;
-using static LanguageExt.Prelude;
 using LanguageExt.Sys.Live;
 
 namespace TestBed;

--- a/Samples/TestBed/Issue1270.cs
+++ b/Samples/TestBed/Issue1270.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using LanguageExt;
 using LanguageExt.Common;
-using static LanguageExt.Prelude;
 
 namespace TestBed;
 

--- a/Samples/TestBed/IssueTests.cs
+++ b/Samples/TestBed/IssueTests.cs
@@ -5,7 +5,6 @@ using LanguageExt.Common;
 using LanguageExt.Effects.Traits;
 using LanguageExt.Sys;
 using LanguageExt.Sys.Traits;
-using static LanguageExt.Prelude;
 using Newtonsoft.Json;
 
 public class QueueExample<RT>

--- a/Samples/TestBed/PipesTest.cs
+++ b/Samples/TestBed/PipesTest.cs
@@ -6,7 +6,6 @@ using LanguageExt.Sys;
 using LanguageExt.Sys.IO;
 using LanguageExt.Sys.Live;
 using static LanguageExt.Pipes.Proxy;
-using static LanguageExt.Prelude;
 
 namespace TestBed;
 

--- a/Samples/TestBed/Program.cs
+++ b/Samples/TestBed/Program.cs
@@ -20,7 +20,6 @@ using LanguageExt.Common;
 using LanguageExt.Effects.Traits;
 using Newtonsoft.Json;
 using TestBed;
-using static LanguageExt.Prelude;
 using static LanguageExt.Pipes.Proxy;
 
 public interface IAsyncQueue<A>

--- a/Samples/TestBed/ScheduleTests.cs
+++ b/Samples/TestBed/ScheduleTests.cs
@@ -1,5 +1,4 @@
 ﻿using LanguageExt;
-using static LanguageExt.Prelude;
 using System;
 
 namespace TestBed;

--- a/Samples/TestBed/SequenceParallelTest.cs
+++ b/Samples/TestBed/SequenceParallelTest.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using LanguageExt;
 using LanguageExt.Sys;
-using static LanguageExt.Prelude;
 
 namespace TestBed;
 

--- a/Samples/TestBed/TestCodeGen.cs
+++ b/Samples/TestBed/TestCodeGen.cs
@@ -14,7 +14,6 @@ using LanguageExt;
 using LanguageExt.ClassInstances;
 using LanguageExt.Common;
 using LanguageExt.TypeClasses;
-using static LanguageExt.Prelude;
 
 namespace TestBed
 {


### PR DESCRIPTION
not a big one, but nice to have prelude everywhere in your project with the (not so new) `global using static` feature from C# 10.