### PR TITLE
Fix Support for Collection Expressions

### DIFF
--- a/LanguageExt.Core/CollectionBuilderAttribute.cs
+++ b/LanguageExt.Core/CollectionBuilderAttribute.cs
@@ -1,0 +1,20 @@
+﻿namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(
+        AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface,
+        Inherited = false,
+        AllowMultiple = false)]
+    public sealed class CollectionBuilderAttribute : Attribute
+    {
+        public CollectionBuilderAttribute(
+            Type builderType,
+            string methodName)
+        {
+            BuilderType = builderType;
+            MethodName = methodName;
+        }
+
+        public Type BuilderType { get; }
+        public string MethodName { get; }
+    }
+}

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
@@ -34,6 +34,17 @@ namespace LanguageExt
         [Pure]
         public static Arr<T> create<T>(params T[] items) =>
             new Arr<T>(items);
+        
+        /// <summary>
+        /// Create an array from a initial set of items
+        /// </summary>
+        /// <param name="items">Items</param>
+        /// <returns>Lst T</returns>
+        [Pure]
+        public static Arr<T> create<T>(
+            ReadOnlySpan<T> items) =>
+            create(
+                items.ToArray());
 
         /// <summary>
         /// Create an array from an initial set of items

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
 using static LanguageExt.Prelude;
 using LanguageExt.TypeClasses;
@@ -17,6 +18,9 @@ namespace LanguageExt
     /// for large arrays.
     /// </summary>
     /// <typeparam name="A">Value type</typeparam>
+    [CollectionBuilderAttribute(
+        typeof(Arr),
+        nameof(Arr.create))] 
     [Serializable]
     public struct Arr<A> :
         IEnumerable<A>,
@@ -721,6 +725,5 @@ namespace LanguageExt
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Arr<A>(SeqEmpty _) =>
             Empty;
-
     }
 }

--- a/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/List/Lst.Module.cs
@@ -51,6 +51,17 @@ namespace LanguageExt
             new Lst<T>(items);
 
         /// <summary>
+        /// Create an array from a initial set of items
+        /// </summary>
+        /// <param name="items">Items</param>
+        /// <returns>Lst T</returns>
+        [Pure]
+        public static Lst<T> create<T>(
+            ReadOnlySpan<T> items) =>
+            create(
+                items.ToArray());
+
+        /// <summary>
         /// Create a list from an initial set of items
         /// </summary>
         /// <param name="items">Items</param>

--- a/LanguageExt.Core/Immutable Collections/List/Lst.cs
+++ b/LanguageExt.Core/Immutable Collections/List/Lst.cs
@@ -15,6 +15,9 @@ namespace LanguageExt
     /// Immutable list
     /// </summary>
     /// <typeparam name="A">Value type</typeparam>
+    [CollectionBuilder(
+        typeof(List),
+        nameof(List.create))]
     [Serializable]
     public readonly struct Lst<A> :
         IComparable<Lst<A>>,

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.Module.cs
@@ -57,6 +57,17 @@ namespace LanguageExt
             System.Array.Copy(items, nitems, items.Length);
             return FromArray(items);
         }
+        
+        /// <summary>
+        /// Create an array from a initial set of items
+        /// </summary>
+        /// <param name="items">Items</param>
+        /// <returns>Lst T</returns>
+        [Pure]
+        public static Seq<T> create<T>(
+            ReadOnlySpan<T> items) =>
+            create(
+                items.ToArray());
 
         /// <summary>
         /// Create a sequence from an initial set of items

--- a/LanguageExt.Core/Immutable Collections/Seq/Seq.cs
+++ b/LanguageExt.Core/Immutable Collections/Seq/Seq.cs
@@ -17,6 +17,9 @@ namespace LanguageExt
     /// </summary>
     /// <typeparam name="A">Type of the values in the sequence</typeparam>
 
+    [CollectionBuilder(
+        typeof(Seq),
+        nameof(Seq.create))]
     public readonly struct Seq<A> :
 #pragma warning disable CS0618 // Remove ISeq complaint
         ISeq<A>,

--- a/LanguageExt.Core/Immutable Collections/Set/Set.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Set/Set.Module.cs
@@ -33,6 +33,16 @@ namespace LanguageExt
             Set<T>.Empty;
 
         /// <summary>
+        /// Create an array from a initial set of items
+        /// </summary>
+        /// <param name="items">Items</param>
+        /// <returns>Lst T</returns>
+        [Pure]
+        public static Set<T> create<T>(
+            ReadOnlySpan<T> items) =>
+            new Set<T>(items.ToArray());
+        
+        /// <summary>
         /// Create a new set pre-populated with the items in range
         /// </summary>
         /// <typeparam name="T">Element type</typeparam>

--- a/LanguageExt.Core/Immutable Collections/Set/Set.cs
+++ b/LanguageExt.Core/Immutable Collections/Set/Set.cs
@@ -19,6 +19,9 @@ namespace LanguageExt
     /// [wikipedia.org/wiki/AVL_tree](http://en.wikipedia.org/wiki/AVL_tree)
     /// </summary>
     /// <typeparam name="A">Set item type</typeparam>
+    [CollectionBuilder(
+        typeof(Set),
+        nameof(Set.create))]
     [Serializable]
     public readonly struct Set<A> :
         IEnumerable<A>,

--- a/LanguageExt.Tests/ArrayTests.cs
+++ b/LanguageExt.Tests/ArrayTests.cs
@@ -174,5 +174,18 @@ namespace LanguageExt.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        /// See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#create-methods
+        [Fact]
+        public void CollectionExpressions()
+        {
+            Arr<int> array = [1, 2, 3, 4, 5];
+            
+            Assert.Equal(5, array.Length);
+
+            Arr<int> array2 = [99, ..array];
+            
+            Assert.Equal(6, array2.Length);
+        }
     }
 }

--- a/LanguageExt.Tests/ListTests.cs
+++ b/LanguageExt.Tests/ListTests.cs
@@ -618,5 +618,18 @@ namespace LanguageExt.Tests
 
             Assert.Equal(expected, actual);
         }
+        
+        /// See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#create-methods
+        [Fact]
+        public void CollectionExpressions()
+        {
+            Lst<int> lst = [1, 2, 3, 4, 5];
+            
+            Assert.Equal(5, lst.Count);
+
+            Lst<int> seq2 = [99, ..lst];
+            
+            Assert.Equal(6, seq2.Count);
+        }
     }
 }

--- a/LanguageExt.Tests/SeqTests.cs
+++ b/LanguageExt.Tests/SeqTests.cs
@@ -665,5 +665,18 @@ namespace LanguageExt.Tests
                 return seconds;
             }
         }
+        
+        /// See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#create-methods
+        [Fact]
+        public void CollectionExpressions()
+        {
+            Seq<int> seq = [1, 2, 3, 4, 5];
+            
+            Assert.Equal(5, seq.Length);
+
+            Seq<int> seq2 = [99, ..seq];
+            
+            Assert.Equal(6, seq2.Length);
+        }
     }
 }

--- a/LanguageExt.Tests/SetTests.cs
+++ b/LanguageExt.Tests/SetTests.cs
@@ -485,5 +485,18 @@ namespace LanguageExt.Tests
             { Assert.True(Set<OrdInt, int>(1).Case is not var (_, _) and 1); }
             { Assert.True(Set<OrdInt, int>(1, 2).Case is (1, Seq<int> xs) && xs == Seq1(2)); }
         }
+        
+        /// See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#create-methods
+        [Fact]
+        public void CollectionExpressions()
+        {
+            Set<int> set = [1, 2, 3, 3, 4, 5];
+            
+            Assert.Equal(5, set.Count);
+
+            Set<int> set2 = [3, ..set, 99];
+            
+            Assert.Equal(6, set2.Count);
+        }
     }
 }


### PR DESCRIPTION
This change **fixes** support for collection expressions like:

```C#
Arr<int> arr = [1, 5, 17];

Lst<int> lst = [5, ..arr, 19];
```
for 

- `Arr<T>`
- `Lst<T>`
- `Seq<T>`
- `Set<T>`

I've chosen these types because the compiler thinks the collection expressions are already supported for these (it compiles), but the resulting collections are always empty.

#### Collection Initializers Unaffected
This does **not** fix collection initializers like:
```C#
var arr = new Arr<int> { 1, 5, 17 };
```

This still results in an empty arr.

## Implementation
Implemented create methods according to https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/collection-expressions#create-methods
see commit https://github.com/louthy/language-ext/commit/9fff3cc9b6ddfb91fa251b1e6a984e780e288761

There's also tests for this, see https://github.com/louthy/language-ext/commit/45059367ef5e895a86eabddcb3918d08da85bd2e

### Performance Considerations for `Set<T>`
The `ReadOnlySpan<T>` passed to the create methods does not implement `IEnumerable<T>` and thus cannot be passed to existing constructors of `Set<T>`.
I've compared two options:
- `ReadOnlySpan<T>.ToArray()`
- `foreach` loop over `ReadOnlySpan<T>` which performs `Set.TryAdd`

Benchmarking showed that the loop is faster for 0 or 1 elements. After that, `ToArray()` is significantly faster.

|                Method | N |      Mean |    Error |    StdDev | Rank |
|---------------------- |-- |----------:|---------:|----------:|-----:|
|        CreateLoopSpan | 0 |  12.50 ns | 0.278 ns |  0.760 ns |    1 |
| CreateCopySpanToArray | 0 |  37.68 ns | 0.866 ns |  2.512 ns |    2 |
|        CreateLoopSpan | 1 |  57.02 ns | 1.170 ns |  3.042 ns |    3 |
| CreateCopySpanToArray | 1 |  65.10 ns | 1.321 ns |  3.570 ns |    4 |
|        CreateLoopSpan | 2 | 232.58 ns | 4.624 ns |  9.445 ns |    6 |
| CreateCopySpanToArray | 2 | 163.08 ns | 3.289 ns |  8.664 ns |    5 |
|        CreateLoopSpan | 3 | 400.38 ns | 8.034 ns | 21.993 ns |    8 |
| CreateCopySpanToArray | 3 | 256.85 ns | 5.145 ns | 13.734 ns |    7 |


|                Method |  N |         Mean |      Error |       StdDev | Rank |
|---------------------- |--- |-------------:|-----------:|-------------:|-----:|
|        CreateLoopSpan |  0 |     12.69 ns |   0.279 ns |     0.618 ns |    1 |
| CreateCopySpanToArray |  0 |     37.90 ns |   0.751 ns |     1.741 ns |    2 |
|        CreateLoopSpan |  3 |    371.38 ns |   7.354 ns |    15.023 ns |    4 |
| CreateCopySpanToArray |  3 |    267.78 ns |   5.362 ns |    15.210 ns |    3 |
|        CreateLoopSpan |  7 |  1,880.21 ns |  36.439 ns |    77.655 ns |    6 |
| CreateCopySpanToArray |  7 |  1,048.89 ns |  20.921 ns |    51.319 ns |    5 |
|        CreateLoopSpan | 50 | 32,824.62 ns | 651.136 ns | 1,522.010 ns |    8 |
| CreateCopySpanToArray | 50 | 17,175.47 ns | 343.452 ns |   880.400 ns |    7 |

|                Method |      N |          Mean |        Error |        StdDev | Rank |
|---------------------- |------- |--------------:|-------------:|--------------:|-----:|
|        CreateLoopSpan |    100 |      89.48 us |     1.758 us |      2.347 us |    2 |
| CreateCopySpanToArray |    100 |      42.16 us |     0.836 us |      2.004 us |    1 |
|        CreateLoopSpan |   1000 |   1,529.97 us |    30.239 us |     58.260 us |    4 |
| CreateCopySpanToArray |   1000 |     768.68 us |    14.868 us |     18.260 us |    3 |
|        CreateLoopSpan |  10000 |  23,371.89 us |   461.683 us |    867.153 us |    6 |
| CreateCopySpanToArray |  10000 |  11,363.98 us |   209.157 us |    436.588 us |    5 |
|        CreateLoopSpan | 100000 | 391,907.57 us | 7,751.993 us | 10,348.688 us |    8 |
| CreateCopySpanToArray | 100000 | 168,161.03 us | 3,542.300 us | 10,276.854 us |    7 |

#### Implementation for `ReadOnlySpan<T>.ToArray()`
```c#
public static Set<T> create<T>(
    ReadOnlySpan<T> items) =>
    new Set<T>(items.ToArray());
```

#### Implementation with `foreach` loop
```C#
public static Set<T> create<T>(
    ReadOnlySpan<T> items)
{
    var set = empty<T>();
    foreach (var item in items)
    {
        set = set.TryAdd(item);
    }

    return set;
}
```

#### Implementation of Benchmark
See https://github.com/louthy/language-ext/pull/1323#issuecomment-2092119979