### PR TITLE
Identify and Fix Issue with Error Monoid Implementation

### DIFF
--- a/LanguageExt.Core/Common/Error.cs
+++ b/LanguageExt.Core/Common/Error.cs
@@ -202,6 +202,8 @@ public abstract record Error : Monoid<Error>
     public Error Combine(Error error) =>
         (this, error) switch
         {
+            ({IsEmpty: true}, var e)       => e,
+            (var e, {IsEmpty: true})       => e,
             (ManyErrors e1, ManyErrors e2) => new ManyErrors(e1.Errors + e2.Errors), 
             (ManyErrors e1, var e2)        => new ManyErrors(e1.Errors.Add(e2)), 
             (var e1,        ManyErrors e2) => new ManyErrors(e1.Cons(e2.Errors)), 

--- a/LanguageExt.Tests/ErrorTests.cs
+++ b/LanguageExt.Tests/ErrorTests.cs
@@ -117,18 +117,30 @@ public class ErrorTests
         var ea = Error.New(123, "Err 1");
         var eb = Error.New(345, "Err 2");
         var ec = Error.New(678, "Err 3");
-        
+
         var json = JsonConvert.SerializeObject(ea + eb + ec, settings);
-        
+
         var es = JsonConvert.DeserializeObject<Error>(json, settings);
-        
+
         Assert.False(es.IsEmpty);
         Assert.True(es.Count == 3);
         Assert.True(es.IsExpected);
         Assert.False(eb.IsExceptional);
-        
+
         Assert.True(es == ea + eb + ec);
         Assert.True(es.Is(ea + eb + ec));
         Assert.True((ea + eb + ec).Is(es));
+    }
+
+    [Fact]
+    public void MonoidLawsTest()
+    {
+        var ea = Error.New(123, "Err 1");
+        var eb = Error.New(345, "Err 2");
+        var ec = Error.New(678, "Err 3");
+
+        Assert.True((ea + eb) + ec == ea + (eb + ec), "Associativity");
+        Assert.True(Error.Empty + ea == ea, "Left Identity");
+        Assert.True(ea + Error.Empty == ea, "Right Identity");
     }
 }


### PR DESCRIPTION
I noticed that the `Error`s `Combine` method always returns a `ManyErrors`, even if you're concatenating a single error and an `Empty` error. This violates the identity monoid laws (assuming we want to use `==`  rather than `Error.Is` to determine Error equality, which may not be true) in addition to just _feeling_ like a bug, at least to me.

Obviously, if this was intended or is fine, please disregard!

