### PR TITLE
Added NotNullWhenAttribute in isEmpty method

### DIFF
--- a/LanguageExt.Core/Prelude/Prelude.cs
+++ b/LanguageExt.Core/Prelude/Prelude.cs
@@ -245,7 +245,7 @@ public static partial class Prelude
     /// <returns>True if the string is null, empty, or whitespace</returns>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool isEmpty(string? value) =>
+    public static bool isEmpty([NotNullWhen(false)] string? value) =>
         string.IsNullOrWhiteSpace(value);
 
     [Pure]


### PR DESCRIPTION
Is just that. For the C# compiler to know that the string instance is not when when using in ifs. 