### PR TITLE
Fixes for csharp 14 build errors

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.Module.cs
@@ -107,7 +107,7 @@ public partial class Arr
     /// <returns>Reversed list</returns>
     [Pure]
     public static T[] rev<T>(T[] array) =>
-        array.Reverse().ToArray();
+        array.AsEnumerable().Reverse().ToArray();
 
     /// <summary>
     /// Reverses the array (Reverse in LINQ)

--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -602,7 +602,7 @@ public struct Arr<A> :
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Arr<A> Reverse() =>
-        new (Value.Reverse().ToArray());
+        new (Value.AsEnumerable().Reverse().ToArray());
 
     /// <summary>
     /// Impure iteration of the bound values in the structure


### PR DESCRIPTION
Attempt to fix C#14 build errors

As mentioned in #1501, there are two build errors introduced when trying to build with [C#14](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-14#implicit-span-conversions) installed.
This PR resolves these issues with an explicit call to `.AsEnumerable()`. Alternative fix could be just to do a cast to `IEnumerable<T>`.

> 2>D:\git..\LanguageExt.Core\Immutable Collections\Arr\Arr.Module.cs(110,24,110,25): error CS0023: Operator '.' cannot be applied to operand of type 'void'
> 2>D:\git..\LanguageExt.Core\Immutable Collections\Arr\Arr.cs(605,29,605,30): error CS0023: Operator '.' cannot be applied to operand of type 'void'

Tested both on C#14 as well as with an explicit `LangVersion 13.0`, this compiles fine on both.