### PR TITLE
Fixes #1522 Arr.GetHashCode throws NullReferenceException for default instances

### DIFF
--- a/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
+++ b/LanguageExt.Core/Immutable Collections/Arr/Arr.cs
@@ -38,10 +38,10 @@ public readonly struct Arr<A> :
     /// </summary>
     public static Arr<A> Empty { get; } = new (System.Array.Empty<A>());
 
-    readonly A[] value;
+    readonly A[]? value;
     readonly int start;
     readonly int length;
-    readonly Atom<int> hashCode = Atom(0);
+    readonly Atom<int>? hashCode;
 
     A[] Value
     {
@@ -788,6 +788,9 @@ public readonly struct Arr<A> :
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override int GetHashCode()
     {
+        if (hashCode is null)
+            return CalcHashCode();
+        
         var self = this;
         return hashCode == 0
             ? hashCode.Swap(_ => self.CalcHashCode())

--- a/LanguageExt.Tests/SeqTypes/Seq.Arr.Tests.cs
+++ b/LanguageExt.Tests/SeqTypes/Seq.Arr.Tests.cs
@@ -37,6 +37,54 @@ public class SeqArrTests
     }
 
     [Fact]
+    public void TestGetHashCodeEmpty()
+    {
+        var seq = Arr.empty<int>();
+
+        // check that GetHashCode won't throw
+        _ = seq.GetHashCode();
+    }
+
+    [Fact]
+    public void TestGetHashCodeDefault()
+    {
+        Arr<int> seq = default;
+
+        // check that GetHashCode won't throw
+        _ = seq.GetHashCode();
+    }
+
+    [Fact]
+    public void TestGetHashCodeDefaultCtor()
+    {
+        var seq = new Arr<int>();
+
+        // check that GetHashCode won't throw
+        _ = seq.GetHashCode();
+    }
+    
+    [Fact]
+    public void TestGetHashCodePartOfContainer()
+    {
+        var container = new Arr<int>[1];
+
+        // check that GetHashCode won't throw
+        _ = container[0].GetHashCode();
+    }
+    
+    [Fact]
+    public void TestGetHashCodeEmptyVsDefault()
+    {
+        var emptySeq = Arr.empty<int>();
+        Arr<int> defaultSeq = default;
+
+        var emptyHash = emptySeq.GetHashCode();
+        var defaultHash = defaultSeq.GetHashCode();
+        Assert.Equal(emptyHash, defaultHash);
+    }
+
+
+    [Fact]
     public void TestOne()
     {
         var arr = Arr.create(1);


### PR DESCRIPTION
The PR fixes #1522 

- Added explicit nullable annotations for reference fields due to this possibility for default instances
- Removed `hashCode = Atom(0)` since it had no effect for the default instances and is redundant for any other ctors as they do it on their own.
- Special cased `hashCode is null` to return `CalcHashCode` (it's efficient for an empty collection case).
  - **UPD**: you might have seen an initial version where it was special-cased to return `0` - it resulted in different hash codes for `empty` and `default` which are in essence the same.
- Added tests for `GetHashCode` for `empty`, `default`, `ctor()` and as a part of a container.
- Added test to make sure that GetHashCode for `empty` and `default` results in the same value
