### PR TITLE
Add Generic Kleisli Composition Operator

### DIFF
--- a/LanguageExt.Core/Traits/Monads/Monad/Monad.Operators.cs
+++ b/LanguageExt.Core/Traits/Monads/Monad/Monad.Operators.cs
@@ -111,4 +111,16 @@ public static partial class MonadExtensions
         public static K<M, A> operator >> (K<M, A> lhs, K<IO, Unit> rhs) =>
             lhs >> (x => (_ => x) * rhs);
     }
+        
+    extension<M, A, B, C>(Func<A, K<M, B>> self) where M : Monad<M>
+    {
+        /// <summary>
+        /// Kleisli composition operator overload. Composes two monad-returning functions, equivalent to Haskell's `>=>` or "fish" operator
+        /// </summary>
+        /// <param name="bind1">The first function to compose</param>
+        /// <param name="bind2">The second function to compose</param>
+        /// <returns></returns>
+        public static Func<A, K<M, C>> operator >> (Func<A, K<M, B>> bind1, Func<B, K<M, C>> bind2) =>
+            a => bind1(a) >> bind2;
+    }
 }


### PR DESCRIPTION
A small thing I've found useful in my local experimentation, seems worthwhile here given how generic it is.

@louthy let me know what you think; I don't have the time or inclination to create versions of this for each concrete data type (wouldn't want to put that on you either!), but I think this should be useful enough as-is