### PR TITLE
Refactor: use Prelude.transform/cotransform helpers

### DIFF
--- a/LanguageExt.Core/Monads/Alternative Monads/EitherT/Trait/EitherT.TraitImpl.cs
+++ b/LanguageExt.Core/Monads/Alternative Monads/EitherT/Trait/EitherT.TraitImpl.cs
@@ -79,5 +79,5 @@ public partial class EitherT<L, M> :
         fa.As().BindLeft(l => Predicate(l) ? Fail(l).As() : EitherT.Left<L, M, A>(l));
 
     static K<OptionT<M>, A> Natural<EitherT<L, M>, OptionT<M>>.Transform<A>(K<EitherT<L, M>, A> fa) => 
-        new OptionT<M, A>(fa.As().runEither.Map(Natural.transform<Either<L>, Option, A>).Map(ma => ma.As()));
+        new OptionT<M, A>(fa.As().runEither.Map(Prelude.transform<Either<L>, Option, A>).Map(ma => ma.As()));
 }

--- a/LanguageExt.Core/Monads/Alternative Monads/FinT/Trait/FinT.TraitImpl.cs
+++ b/LanguageExt.Core/Monads/Alternative Monads/FinT/Trait/FinT.TraitImpl.cs
@@ -99,11 +99,11 @@ public partial class FinT<M> :
         fa.As().BindFail(l => Predicate(l) ? Fail(l).As() : FinT.Fail<M, A>(l));
 
     static K<EitherT<Error, M>, A> Natural<FinT<M>, EitherT<Error, M>>.Transform<A>(K<FinT<M>, A> fa) => 
-        new EitherT<Error, M, A>(fa.As().runFin.Map(Natural.transform<Fin, Either<Error>, A>).Map(ma => ma.As()));
+        new EitherT<Error, M, A>(fa.As().runFin.Map(Prelude.transform<Fin, Either<Error>, A>).Map(ma => ma.As()));
 
     static K<OptionT<M>, A> Natural<FinT<M>, OptionT<M>>.Transform<A>(K<FinT<M>, A> fa) => 
-        new OptionT<M, A>(fa.As().runFin.Map(Natural.transform<Fin, Option, A>).Map(ma => ma.As()));
+        new OptionT<M, A>(fa.As().runFin.Map(Prelude.transform<Fin, Option, A>).Map(ma => ma.As()));
 
     static K<TryT<M>, A> Natural<FinT<M>, TryT<M>>.Transform<A>(K<FinT<M>, A> fa) => 
-        new TryT<M, A>(fa.As().runFin.Map(Natural.transform<Fin, Try, A>).Map(ma => ma.As()));
+        new TryT<M, A>(fa.As().runFin.Map(Prelude.transform<Fin, Try, A>).Map(ma => ma.As()));
 }

--- a/LanguageExt.Core/Traits/Monads/Monad/Monad.Module.cs
+++ b/LanguageExt.Core/Traits/Monads/Monad/Monad.Module.cs
@@ -236,7 +236,7 @@ public static partial class Monad
         where M : Natural<M, Iterable>, CoNatural<M, Iterable>
     {
         var iterable = Iterable.createRange(IO.lift(e => go(e.Token)));
-        return CoNatural.transform<M, Iterable, B>(iterable);
+        return Prelude.cotransform<M, Iterable, B>(iterable);
         
         async IAsyncEnumerable<B> go([EnumeratorCancellation] CancellationToken token)
         {
@@ -247,7 +247,7 @@ public static partial class Monad
             {
                 foreach (var x in values)
                 {
-                    var iterable1 = Natural.transform<M, Iterable, Next<A, B>>(f(x)).As().AsAsyncEnumerable(token);
+                    var iterable1 = Prelude.transform<M, Iterable, Next<A, B>>(f(x)).As().AsAsyncEnumerable(token);
                     await foreach (var mb in iterable1)
                     {
                         if (mb.IsDone)

--- a/LanguageExt.Core/Traits/Natural/CoNatural.Prelude.cs
+++ b/LanguageExt.Core/Traits/Natural/CoNatural.Prelude.cs
@@ -1,0 +1,10 @@
+﻿using LanguageExt.Traits;
+
+namespace LanguageExt;
+
+public static partial class Prelude
+{
+    public static K<F, A> cotransform<F, G, A>(K<G, A> ga)
+        where F : CoNatural<F, G> =>
+        CoNatural.transform<F, G, A>(ga);
+}

--- a/LanguageExt.Core/Traits/Natural/Natural.Prelude.cs
+++ b/LanguageExt.Core/Traits/Natural/Natural.Prelude.cs
@@ -1,0 +1,10 @@
+﻿using LanguageExt.Traits;
+
+namespace LanguageExt;
+
+public static partial class Prelude
+{
+    public static K<G, A> transform<F, G, A>(K<F, A> fa)
+        where F : Natural<F, G> =>
+        Natural.transform<F, G, A>(fa);
+}


### PR DESCRIPTION
Replaced direct calls to Natural.transform and CoNatural.transform with Prelude.transform and Prelude.cotransform across the codebase. Added new Prelude static classes to centralize and simplify transformation logic, improving code clarity and maintainability.

This is because LanguageExt.Prelude fields and methods are used throght using static LanguageExt.Prelude, so transform and cotransform methods facilitates use of Natural/CoNatural traits