### PR TITLE
Fix `behviours` -> `behaviours` typo in Core README

### DIFF
--- a/LanguageExt.Core/README.md
+++ b/LanguageExt.Core/README.md
@@ -11,7 +11,7 @@ If you're new to this library, you may need a few pointers of where to look for 
         using static LanguageExt.Prelude;
   
     This makes all functions in the `Prelude` available as though they were local.
-  * [`Traits`](Traits) are the powerhouse of this library and allow for true higher-kinded abstract behviours to be leveraged throughout.  The topic of traits is huge, so if you're looking for an introduction, take a look at [Paul Louth's Higher Kinds series on his blog](https://paullouth.com/higher-kinds-in-c-with-language-ext/).
+  * [`Traits`](Traits) are the powerhouse of this library and allow for true higher-kinded abstract behaviours to be leveraged throughout.  The topic of traits is huge, so if you're looking for an introduction, take a look at [Paul Louth's Higher Kinds series on his blog](https://paullouth.com/higher-kinds-in-c-with-language-ext/).
   * [`Monads`](Monads) contains the common monads like `Option<A>` and `Either<L, R>`, as well as state-managing monads like `Reader`, `Writer`, and `State`.  It also is home to many monad-transformers (types with a `T` suffix, like `OptionT`).  Transformers allow 'stacking' of monadic effects into 'super monads'.
   * [`Immutable Collections`](Immutable%20Collections) contains the high-performance functional collection types this library is famous for.
   * [`Effects`](Effects) is where the pure IO functionality of language-ext resides.  It is also where you'll find 


### PR DESCRIPTION
Line 14 of `LanguageExt.Core/README.md` has `behviours` (missing letter) in the Traits section.